### PR TITLE
Add single mount point for boolean attributes

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,26 +1,26 @@
 name: build
 
 on:
-  push:
+  pull_request:
     branches:
-      - '**'
+      - master
 
 jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
-    - name: Set up JDK 12
-      uses: actions/setup-java@v1
-      with:
-        java-version: 12
-    - name: Build and run Unit Tests
-      run: ./gradlew allTests
-    - name: Archive test-results
-      if: always()
-      uses: actions/upload-artifact@v1.0.0
-      with:
-        name: Test-Results
-        path: core/build/reports/tests/allTests
-    - name: Build with Gradle
-      run: ./gradlew build
+      - uses: actions/checkout@v2
+      - name: Set up JDK 12
+        uses: actions/setup-java@v1
+        with:
+          java-version: 12
+      - name: Build and run Unit Tests
+        run: ./gradlew allTests
+      - name: Archive test-results
+        if: always()
+        uses: actions/upload-artifact@v1.0.0
+        with:
+          name: Test-Results
+          path: core/build/reports/tests/allTests
+      - name: Build with Gradle
+        run: ./gradlew build

--- a/core/src/jsMain/kotlin/dev/fritz2/dom/attributes.kt
+++ b/core/src/jsMain/kotlin/dev/fritz2/dom/attributes.kt
@@ -35,7 +35,7 @@ internal object ValueAttributeDelegate {
  */
 internal object CheckedAttributeDelegate {
     operator fun <X : Element> getValue(thisRef: Tag<X>, property: KProperty<*>): Flow<Boolean> =
-            throw NotImplementedError()
+        throw NotImplementedError()
 
     operator fun <X : Element> setValue(thisRef: Tag<X>, property: KProperty<*>, values: Flow<Boolean>) {
         CheckedAttributeMountPoint(values, thisRef.domNode)
@@ -72,20 +72,15 @@ interface WithAttributes<out T : Element> : WithDomNode<T> {
     fun Flow<String>.bindAttr(name: String) = AttributeMountPoint(name, this, domNode)
 
     /**
-     * bind a boolean [Flow] to a boolean attribute / flag. Use [removeWhenFalse] to control whether the attribute
-     * will be removed when the flow emits `false`. Use the [value] function to specify the actual value of the
-     * attribute.
+     * bind a boolean [Flow] to a boolean attribute / flag. When the flow emits `true` the attribute will be added.
+     * When the flow emits `false` the attribute will be removed.
      *
      * @param name of the attribute
-     * @param removeWhenFalse whether to remove the attribute when the flow emits `false`
-     * @param value function to map the boolean values to arbitrary string values
+     * @param value value for the attribute (defaults to "")
      * @receiver the [Flow] to bind
      */
-    fun Flow<Boolean>.bindAttr(
-        name: String,
-        removeWhenFalse: Boolean = true,
-        value: (Boolean) -> String = { "" }
-    ) = BooleanAttributeMountPoint(name, this, domNode, removeWhenFalse, value)
+    fun Flow<Boolean>.bindAttr(name: String, value: String = ""): BooleanAttributeMountPoint =
+        BooleanAttributeMountPoint(name, this, domNode, value)
 
     /**
      * bind a [Flow] of [List]s to an attribute. The attribute will be updated in the DOM whenever a new value appears on this [Flow].

--- a/core/src/jsMain/kotlin/dev/fritz2/dom/attributes.kt
+++ b/core/src/jsMain/kotlin/dev/fritz2/dom/attributes.kt
@@ -72,6 +72,22 @@ interface WithAttributes<out T : Element> : WithDomNode<T> {
     fun Flow<String>.bindAttr(name: String) = AttributeMountPoint(name, this, domNode)
 
     /**
+     * bind a boolean [Flow] to a boolean attribute / flag. Use [removeWhenFalse] to control whether the attribute
+     * will be removed when the flow emits `false`. Use the [value] function to specify the actual value of the
+     * attribute.
+     *
+     * @param name of the attribute
+     * @param removeWhenFalse whether to remove the attribute when the flow emits `false`
+     * @param value function to map the boolean values to arbitrary string values
+     * @receiver the [Flow] to bind
+     */
+    fun Flow<Boolean>.bindAttr(
+        name: String,
+        removeWhenFalse: Boolean = true,
+        value: (Boolean) -> String = { "" }
+    ) = BooleanAttributeMountPoint(name, this, domNode, removeWhenFalse, value)
+
+    /**
      * bind a [Flow] of [List]s to an attribute. The attribute will be updated in the DOM whenever a new value appears on this [Flow].
      * The elements of the list will be concatenated by empty space.
      *

--- a/core/src/jsMain/kotlin/dev/fritz2/dom/mount.kt
+++ b/core/src/jsMain/kotlin/dev/fritz2/dom/mount.kt
@@ -116,19 +116,13 @@ class BooleanAttributeMountPoint(
     private val name: String,
     upstream: Flow<Boolean>,
     private val target: Element?,
-    private val removeWhenFalse: Boolean,
-    private val value: (Boolean) -> String
+    private val trueValue: String
 ) : SingleMountPoint<Boolean>(upstream) {
     override fun set(value: Boolean, last: Boolean?) {
-        val stringValue = this.value.invoke(value)
         if (value) {
-            target?.setAttribute(name, stringValue)
+            target?.setAttribute(name, trueValue)
         } else {
-            if (removeWhenFalse) {
-                target?.removeAttribute(name)
-            } else {
-                target?.setAttribute(name, stringValue)
-            }
+            target?.removeAttribute(name)
         }
     }
 }

--- a/core/src/jsMain/kotlin/dev/fritz2/dom/mount.kt
+++ b/core/src/jsMain/kotlin/dev/fritz2/dom/mount.kt
@@ -105,9 +105,31 @@ class AttributeMountPoint(val name: String, upstream: Flow<String>, val target: 
      * @param value last value (to be replaced)
      */
     override fun set(value: String, last: String?) {
-        //FIXME: Should only be true for Boolean-Attributes...
-        if (value == "false") target?.removeAttribute(name)
-        else target?.setAttribute(name, value)
+        target?.setAttribute(name, value)
+    }
+}
+
+/**
+ * [BooleanAttributeMountPoint] is a special [SingleMountPoint] for the boolean attributes.
+ */
+class BooleanAttributeMountPoint(
+    private val name: String,
+    upstream: Flow<Boolean>,
+    private val target: Element?,
+    private val removeWhenFalse: Boolean,
+    private val value: (Boolean) -> String
+) : SingleMountPoint<Boolean>(upstream) {
+    override fun set(value: Boolean, last: Boolean?) {
+        val stringValue = this.value.invoke(value)
+        if (value) {
+            target?.setAttribute(name, stringValue)
+        } else {
+            if (removeWhenFalse) {
+                target?.removeAttribute(name)
+            } else {
+                target?.setAttribute(name, stringValue)
+            }
+        }
     }
 }
 

--- a/core/src/jsTest/kotlin/dev/fritz2/dom/attributes.kt
+++ b/core/src/jsTest/kotlin/dev/fritz2/dom/attributes.kt
@@ -11,6 +11,8 @@ import org.w3c.dom.HTMLDivElement
 import kotlin.browser.document
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
 
 
 class AttributeTests {
@@ -35,6 +37,18 @@ class AttributeTests {
                 const(value1).bindAttr("data-$name1")
                 attr(name2, values2)
                 const(values3).bindAttr(name3)
+
+                const(true).bindAttr("test4")
+                const(false).bindAttr("test5")
+
+                const(true).bindAttr("test6") { "foo" }
+                const(false).bindAttr("test7") { "value-does-not-matter" }
+
+                const(true).bindAttr("test8", false) { it.toString() }
+                const(false).bindAttr("test9", false) { it.toString() }
+
+                const(true).bindAttr("test10", false) { "foo" }
+                const(false).bindAttr("test11", false) { "bar" }
             }
         }.mount(targetId)
 
@@ -54,5 +68,21 @@ class AttributeTests {
         assertEquals(values2.joinToString(separator = " "), element.getAttribute(name2))
         assertEquals(values3.joinToString(separator = " "), element.getAttribute(name3))
 
+        assertEquals(value0, element.getAttribute(name0))
+        assertEquals(value1, element.getAttribute(name1))
+
+        assertTrue(element.hasAttribute("test4"))
+        assertEquals("", element.getAttribute("test4"))
+        assertFalse(element.hasAttribute("test5"))
+
+        assertTrue(element.hasAttribute("test6"))
+        assertEquals("foo", element.getAttribute("test6"))
+        assertFalse(element.hasAttribute("test7"))
+
+        assertEquals("true", element.getAttribute("test8"))
+        assertEquals("false", element.getAttribute("test9"))
+
+        assertEquals("foo", element.getAttribute("test10"))
+        assertEquals("bar", element.getAttribute("test11"))
     }
 }

--- a/core/src/jsTest/kotlin/dev/fritz2/dom/attributes.kt
+++ b/core/src/jsTest/kotlin/dev/fritz2/dom/attributes.kt
@@ -40,15 +40,7 @@ class AttributeTests {
 
                 const(true).bindAttr("test4")
                 const(false).bindAttr("test5")
-
-                const(true).bindAttr("test6") { "foo" }
-                const(false).bindAttr("test7") { "value-does-not-matter" }
-
-                const(true).bindAttr("test8", false) { it.toString() }
-                const(false).bindAttr("test9", false) { it.toString() }
-
-                const(true).bindAttr("test10", false) { "foo" }
-                const(false).bindAttr("test11", false) { "bar" }
+                const(true).bindAttr("test6", "foo")
             }
         }.mount(targetId)
 
@@ -73,16 +65,10 @@ class AttributeTests {
 
         assertTrue(element.hasAttribute("test4"))
         assertEquals("", element.getAttribute("test4"))
+
         assertFalse(element.hasAttribute("test5"))
 
         assertTrue(element.hasAttribute("test6"))
         assertEquals("foo", element.getAttribute("test6"))
-        assertFalse(element.hasAttribute("test7"))
-
-        assertEquals("true", element.getAttribute("test8"))
-        assertEquals("false", element.getAttribute("test9"))
-
-        assertEquals("foo", element.getAttribute("test10"))
-        assertEquals("bar", element.getAttribute("test11"))
     }
 }


### PR DESCRIPTION
Adds a single mount point for boolean attributes (flags) which is flexible enough to fulfill the following requirements:

1. Add an attribute (with an empty value), when the flow emits `true`, remove the attribute, when the flow emits `false`:

    ```kotlin
    val flow: Flow<Boolean> = ...
    render {
        div {
            flow.bindAttr("hidden")
        }
    }
    ```

    will lead to 

    ```html
    <div hidden/>
    ```

    when `flow` emits `true` and 

    ```html
    <div/>
    ```

    when `flow` emits `false`.

1. Map the boolean value to an arbitrary string:

    ```kotlin
    val flow: Flow<Boolean> = ...
    render {
        a {
            flow.bindAttr("aria-expanded", removeWhenFalse = false) {
                it.toString()
            }
        }
    }
    ```

    will lead to 

    ```html
    <a aria-expanded="true"/>
    ```

    when `flow` emits `true` and 

    ```html
    <a aria-expanded="false"/>
    ```

    when `flow` emits `false`.

1. A combination of 1 and 2:

    ```kotlin
    val flow: Flow<Boolean> = ...
    render {
        li {
            flow.bindAttr("aria-current") { "page" }
        }
    }
    ```

    will lead to 

    ```html
    <li aria-current="page"/>
    ```

    when `flow` emits `true` and 

    ```html
    <li/>
    ```

    when `flow` emits `false`.
