### PR TITLE
Fix unrecognized apidoc links

### DIFF
--- a/components/src/jsMain/kotlin/dev/fritz2/components/box.kt
+++ b/components/src/jsMain/kotlin/dev/fritz2/components/box.kt
@@ -11,7 +11,7 @@ import dev.fritz2.styling.params.GridParams
  * for arbitrary content.
  *
  * In fact it is more or less a shorthand for styling a ``div`` manually and so to avoid the cumbersome syntax
- * of [BasicComponent.styled]
+ * of ``BasicComponent.styled``
  *
  * Example usage:
  * ```
@@ -63,7 +63,7 @@ fun RenderContext.box(
  *      p { +"Some content in the box" }
  * }
  * ```
- * @see Flexbox for a detailed overview about how to define flexBox layouts
+ * @see [dev.fritz2.styling.params.Flexbox] for a detailed overview about how to define flexBox layouts
  *
  * @param styling a lambda expression for declaring the styling as fritz2's styling DSL
  * @param baseClass optional CSS class that should be applied to the element
@@ -107,7 +107,7 @@ fun RenderContext.flexBox(
  * }
  * ```
  *
- * @see GridLayout for a detailed overview about how to define grid layouts
+ * @see [dev.fritz2.styling.params.GridLayout] for a detailed overview about how to define grid layouts
  *
  * @param styling a lambda expression for declaring the styling as fritz2's styling DSL
  * @param baseClass optional CSS class that should be applied to the element

--- a/components/src/jsMain/kotlin/dev/fritz2/components/icons.kt
+++ b/components/src/jsMain/kotlin/dev/fritz2/components/icons.kt
@@ -39,8 +39,8 @@ fun RenderContext.svg(baseClass: String?, id: String?, init: Svg.() -> Unit): Sv
  * An [IconDefinition] _must_ be provided in order to render an icon. This definition wraps the pure SVG markup together
  * with additional properties like the display-name and the viewbox.
  *
- * In order to provide a comfortable way to use the predefined icons from the [Theme], use the [IconComponent.fromTheme]
- * method.
+ * In order to provide a comfortable way to use the predefined icons from the [dev.fritz2.styling.theme.Theme],
+ * use the [IconComponent.fromTheme] method.
  */
 class IconComponent {
     companion object {
@@ -70,7 +70,7 @@ class IconComponent {
 /**
  * This component enables to render an icon. It basically wraps raw SVG images into a nicer API.
  *
- * fritz2's default theme offers some basic predefined icons, have a look at [Theme.icons].
+ * fritz2's default theme offers some basic predefined icons, have a look at [dev.fritz2.styling.theme.Theme.icons].
  *
  * Every icon must be wrapped inside an [IconDefinition], that acts as a value class for the raw SVG markup.
  *

--- a/components/src/jsMain/kotlin/dev/fritz2/components/input.kt
+++ b/components/src/jsMain/kotlin/dev/fritz2/components/input.kt
@@ -85,7 +85,8 @@ object InputFieldComponent {
  * [input element](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/Input). To manually set the value or
  * react to a change refer also to its event's.
  *
- * There are some predefined stylings avaliable via the [Theme]. Have a look at [Theme.input] or [InputFieldStyles]
+ * There are some predefined stylings avaliable via the [dev.fritz2.styling.theme.Theme]. Have a look at
+ * [dev.fritz2.styling.theme.Theme.input] or [InputFieldStyles]
  *
  * ```
  * inputField({ // just style it like any other component:
@@ -105,7 +106,7 @@ object InputFieldComponent {
  * @param baseClass optional CSS class that should be applied to the element
  * @param id the ID of the element
  * @param prefix the prefix for the generated CSS class resulting in the form ``$prefix-$hash``
- * @param build a lambda expression for setting up the component itself. Details in [InputFieldComponent]
+ * @param init a lambda expression for setting up the component itself. Details in [InputFieldComponent]
  */
 fun RenderContext.inputField(
     styling: BasicParams.() -> Unit = {},

--- a/components/src/jsMain/kotlin/dev/fritz2/components/modal.kt
+++ b/components/src/jsMain/kotlin/dev/fritz2/components/modal.kt
@@ -60,12 +60,12 @@ class DefaultOverlay(
  * The actual rendering of the overlay is done within a separate interface called [Overlay].
  * There is currently one implementation [DefaultOverlay] that offers the possibility to freely inject the styling,
  * so for most use cases it might be sufficient to just use the former.
- * If there is a need to render a _different structure_ or to bypass the [Theme.zIndices] management, a custom
- * implementation is the way to go.
+ * If there is a need to render a _different structure_ or to bypass the [dev.fritz2.styling.theme.Theme.zIndices]
+ * management, a custom implementation is the way to go.
  * The interface also enforces to pass the rendering strategy identifier via the [Overlay.method] property.
  *
  * For a detailed understanding have a look into the [ModalComponent.show] function and the
- * [ModalComponent.Companion.init] block.
+ * ``ModalComponent.Companion.init`` block.
  */
 class ModalComponent {
 
@@ -212,7 +212,8 @@ class ModalComponent {
 /**
  * This component provides some modal dialog or messagebox. Basically it just offers a ``div`` that is rendered on a
  * higher [z-index](https://developer.mozilla.org/en-US/docs/Web/CSS/z-index) than the rest of the application.
- * It uses the reserved segments provided by the [ZIndices.modal] function that are initialized by [Theme.zIndices].
+ * It uses the reserved segments provided by the [dev.fritz2.styling.theme.ZIndices.modal] function that are
+ * initialized by [dev.fritz2.styling.theme.Theme.zIndices].
  * That way the top modal will always have the highest ``z-index`` and therefore be on top of the screen.
  *
  * The content and structure within the modal are completely free to model. Further more there are predefined styles
@@ -221,7 +222,7 @@ class ModalComponent {
  * with a custom solution, as a [SimpleHandler<Unit>] is injected as parameter into the [build] expression.
  *
  * As this factory function also returns a [SimpleHandler<Unit>], it is easy to combine it directly with some other
- * component that offers some sort of [Flow], like a [clickButton].
+ * component that offers some sort of Flow, like a [clickButton].
  *
  * Have a look at some example calls
  * ```

--- a/components/src/jsMain/kotlin/dev/fritz2/components/stack.kt
+++ b/components/src/jsMain/kotlin/dev/fritz2/components/stack.kt
@@ -15,7 +15,7 @@ import dev.fritz2.styling.staticStyle
  * It enables to configure the following features:
  *  - switching the default order of rendering (top -> bottom to bottom -> top for stackUps and left -> right to
  *    right -> left for lineUps)
- *  - defining the spacing between the items. For details have a look at [Theme.space]
+ *  - defining the spacing between the items. For details have a look at [dev.fritz2.styling.theme.Theme.space]
  *  - adding arbitrary items like HTML elements or other components
  *
  *  You can combine both kind of stacking components to realize a simple layou for example:

--- a/components/src/jsMain/kotlin/dev/fritz2/components/styledElements.kt
+++ b/components/src/jsMain/kotlin/dev/fritz2/components/styledElements.kt
@@ -12,7 +12,7 @@ import dev.fritz2.styling.params.StyleParamsImpl
  * Typealias for the common function signature of [RenderContext. methods.
  * It is used for defining a generic extension method for styling basic HTML elements.
  *
- * @see BasicComponent.styled
+ * @see ``BasicComponent.styled``
  */
 typealias BasicComponent<E> = (String?, String?, E.() -> Unit) -> E
 
@@ -81,7 +81,7 @@ fun <E> BasicComponent<E>.styled(
  * This method is used for HTML elements that should apply an additional dynamic styling provided as
  * external parameter. This is needed and extremely useful for implementing _components_!
  *
- * A component should behave in a similar way as a basic HTML element. So like the basic [BasicComponent.styled]
+ * A component should behave in a similar way as a basic HTML element. So like the basic ``BasicComponent.styled``
  * version you should be able to call a component like this:
  * ```
  * myComponent({ /* styling */}) { /* content and events */}
@@ -160,7 +160,7 @@ fun <E> BasicComponent<E>.styled(
  * parameter compared to [BasicComponent]
  * It is used for defining a generic extension method for styling corresponding basic HTML elements.
  *
- * @see BasicComponent.styled
+ * @see ``BasicComponent.styled``
  */
 // TODO: will be removed with 0.8 because extra parameters like label's "for" will not be in signature any more
 typealias ExtendedComponent<E> = (String?, String?, String?, E.() -> Unit) -> E
@@ -170,7 +170,7 @@ typealias ExtendedComponent<E> = (String?, String?, String?, E.() -> Unit) -> E
  *
  * Temporary variant of a styling extension function for basic HTML elements with *extended* parameter signature.
  * @see ExtendedComponent
- * @see BasicComponent.styled
+ * @see ``BasicComponent.styled``
  */
 // TODO: will be removed with 0.8 because extra parameters like label's "for" will not be in signature any more
 fun <E> ExtendedComponent<E>.styled(
@@ -190,7 +190,7 @@ fun <E> ExtendedComponent<E>.styled(
  * Typealias for the common function signature of s styled component method.
  * It is used for defining a generic extension method for styling _components_.
  *
- * @see BasicComponent.styled
+ * @see ``BasicComponent.styled``
  */
 // TODO: Are we really gonna need this? You can apply the styling easily within the allready provided component parameter
 // so this variant isn't really needed - and nobody has been used this besides the earliest exmaples of ``myRedLink``

--- a/styling/src/jsMain/kotlin/dev.fritz2.styling/params/alignment.kt
+++ b/styling/src/jsMain/kotlin/dev.fritz2.styling/params/alignment.kt
@@ -181,7 +181,7 @@ interface Alignment : StyleParams {
      * align-content { flexStart }
      * ```
      *
-     * @param sm extension function parameter for small media devices, recommended to use
+     * @param value extension function parameter for small media devices, recommended to use
      *           predefined values from [AlignContentValues]
      */
     fun alignContent(value: AlignContentValues.() -> AlignContentProperty) =

--- a/styling/src/jsMain/kotlin/dev.fritz2.styling/params/flexbox.kt
+++ b/styling/src/jsMain/kotlin/dev.fritz2.styling/params/flexbox.kt
@@ -44,10 +44,10 @@ object WrapValues : PropertyValues {
  *
  * It does **not** create a flexbox layout though!
  *
- * This is done by a special [dev.fritz2.components.flex] fabric function that creates a component
+ * This is done by a special ``dev.fritz2.components.flexBox`` fabric function that creates a component
  * with the [display](https://developer.mozilla.org/en/docs/Web/CSS/display) property already set to ``flex``.
  *
- * So it is recommended to use the provided functions within the styles parameter of [dev.fritz2.components.flex].
+ * So it is recommended to use the provided functions within the styles parameter of ``dev.fritz2.components.flexBox``.
  *
  * This interface offers all the inherited functions of [Alignment] that corresponds to the
  * [CSS alignment module](https://www.w3.org/TR/css-align-3/).

--- a/styling/src/jsMain/kotlin/dev.fritz2.styling/params/gridLayout.kt
+++ b/styling/src/jsMain/kotlin/dev.fritz2.styling/params/gridLayout.kt
@@ -200,10 +200,10 @@ internal const val columnGapKey = "column-gap: "
  *
  * It does **not** create a grid layout though!
  *
- * This is done by a special [dev.fritz2.styling.components.grid] fabric function that creates a component
+ * This is done by a special ``dev.fritz2.components.gridBox`` fabric function that creates a component
  * with the [display](https://developer.mozilla.org/en/docs/Web/CSS/display) property already set to ``grid``.
  *
- * So it is recommended to use the provided functions within the styles parameter of [dev.fritz2.components.grid].
+ * So it is recommended to use the provided functions within the styles parameter of ``dev.fritz2.components.gridBox``.
  *
  * This interface offers all the inherited functions of [Alignment] that corresponds to the
  * [CSS alignment module](https://www.w3.org/TR/css-align-3/).
@@ -529,7 +529,7 @@ interface GridLayout : StyleParams, Alignment {
      * - tedious to type (no autocompletion)
      * - not safe for refactorings (only search + replace is possible)
      * - easy to introduce typos
-     * - easy to misspell the name in the related [dev.fritz2.components.box] component and therefore break the
+     * - easy to misspell the name in the related ``dev.fritz2.components.box`` component and therefore break the
      *   relation!
      *
      * That is why it is recommended to use some sort of _container_ for the area names!

--- a/styling/src/jsMain/kotlin/dev.fritz2.styling/params/layout.kt
+++ b/styling/src/jsMain/kotlin/dev.fritz2.styling/params/layout.kt
@@ -728,8 +728,8 @@ interface Layout : StyleParams {
      * This function sets the [display](https://developer.mozilla.org/en/docs/Web/CSS/display) property of a component
      * for all media devices.
      *
-     * If you want to create a flex- or grid-layout prefer to use the specialized [dev.fritz2.styling.components.flex]
-     * and [dev.fritz2.styling.components.grid] factory functions in order to create a box, that has this property
+     * If you want to create a flex- or grid-layout prefer to use the specialized ``dev.fritz2.styling.components.flexBox``
+     * and ``dev.fritz2.styling.components.gridBox`` factory functions in order to create a box, that has this property
      * already set.
      *
      * example calls:
@@ -749,8 +749,8 @@ interface Layout : StyleParams {
      * This function sets the [display](https://developer.mozilla.org/en/docs/Web/CSS/display) property of a component
      * for each media device independently.
      *
-     * If you want to create a flex- or grid-layout prefer to use the specialized [dev.fritz2.components.flex]
-     * and [dev.fritz2.components.grid] factory functions in order to create a box, that has this property
+     * If you want to create a flex- or grid-layout prefer to use the specialized ``dev.fritz2.components.flexBox``
+     * and ``dev.fritz2.components.gridBox`` factory functions in order to create a box, that has this property
      * already set.
      *
      * example calls:

--- a/styling/src/jsMain/kotlin/dev.fritz2.styling/theme/theme.kt
+++ b/styling/src/jsMain/kotlin/dev.fritz2.styling/theme/theme.kt
@@ -173,7 +173,9 @@ interface Theme {
 }
 
 /**
- * [StateFlow] that holds the current selected [Theme]
+ * global variable that holds the currently selected [Theme]
+ *
+ * In order to *dynamically* change the theme, have a look at ``dev.fritz2.components.themeProvider``.
  */
 @ExperimentalCoroutinesApi
 var currentTheme: Theme = DefaultTheme()


### PR DESCRIPTION
- fix some links for KDoc
- remove syntax of some links, because KDoc is not able to resolve those. Apparently this affects all links from one submodule to another. Could be reworked after an upgrade to a newer version of dokka! Links are now marked with double back ticks for detecting and repairing them later on.