### PR TITLE
Makeing dependencies transitive

### DIFF
--- a/components/build.gradle.kts
+++ b/components/build.gradle.kts
@@ -30,7 +30,7 @@ kotlin {
 
         val commonMain by getting {
             dependencies {
-                implementation(project(":core"))
+                api(project(":core"))
             }
         }
 
@@ -44,7 +44,7 @@ kotlin {
         }
         val jsMain by getting {
             dependencies {
-                implementation(project(":styling"))
+                api(project(":styling"))
             }
         }
         val jsTest by getting {

--- a/datatable/build.gradle.kts
+++ b/datatable/build.gradle.kts
@@ -33,7 +33,7 @@ kotlin {
 
         val commonMain by getting {
             dependencies {
-                implementation(project(":core"))
+                api(project(":components"))
             }
         }
 
@@ -47,8 +47,6 @@ kotlin {
         }
         val jsMain by getting {
             dependencies {
-                implementation(project(":styling"))
-                implementation(project(":components"))
             }
         }
         val jsTest by getting {

--- a/kitchenSink/build.gradle.kts
+++ b/kitchenSink/build.gradle.kts
@@ -33,7 +33,7 @@ kotlin {
 
         val commonMain by getting {
             dependencies {
-                implementation(project(":core"))
+                implementation(project(":components"))
                 implementation("org.jetbrains.kotlinx:kotlinx-datetime:0.1.0")
             }
         }
@@ -48,8 +48,6 @@ kotlin {
         }
         val jsMain by getting {
             dependencies {
-                implementation(project(":styling"))
-                implementation(project(":components"))
                 implementation(project(":datatable"))
             }
         }

--- a/styling/build.gradle.kts
+++ b/styling/build.gradle.kts
@@ -30,7 +30,7 @@ kotlin {
 
         val commonMain by getting {
             dependencies {
-                implementation(project(":core"))
+                api(project(":core"))
             }
         }
         val commonTest by getting {


### PR DESCRIPTION
When adding compontens lib to your gradle build file you get core, styling and components also.