### PR TITLE
harmonizeComponentsApi

### DIFF
--- a/components/src/jsMain/kotlin/dev/fritz2/components/button.kt
+++ b/components/src/jsMain/kotlin/dev/fritz2/components/button.kt
@@ -279,10 +279,8 @@ fun RenderContext.pushButton(
         component.variant.invoke(Theme().button.variants)()
         component.size.invoke(Theme().button.sizes)()
     }) {
-        component.element?.invoke(this)
-        component.element?.invoke(this)
-        disabled(component.disabled)
-//        readOnly(component.readonly)
+        component.element.value.invoke(this)
+        disabled(component.disabled.values)
         if (component.label == null) {
             component.renderIcon(this, component.centerIconStyle, component.centerSpinnerStyle)
         } else {

--- a/components/src/jsMain/kotlin/dev/fritz2/components/button.kt
+++ b/components/src/jsMain/kotlin/dev/fritz2/components/button.kt
@@ -51,7 +51,7 @@ import org.w3c.dom.events.MouseEvent
  *  ```
  */
 @ComponentMarker
-open class PushButtonComponent {
+open class PushButtonComponent : ElementProperties<Button> by Element(), FormProperties by Form() {
     companion object {
         val staticCss = staticStyle(
             "button",
@@ -279,6 +279,10 @@ fun RenderContext.pushButton(
         component.variant.invoke(Theme().button.variants)()
         component.size.invoke(Theme().button.sizes)()
     }) {
+        component.element?.invoke(this)
+        component.element?.invoke(this)
+        disabled(component.disabled)
+//        readOnly(component.readonly)
         if (component.label == null) {
             component.renderIcon(this, component.centerIconStyle, component.centerSpinnerStyle)
         } else {

--- a/components/src/jsMain/kotlin/dev/fritz2/components/checkbox.kt
+++ b/components/src/jsMain/kotlin/dev/fritz2/components/checkbox.kt
@@ -174,9 +174,9 @@ fun RenderContext.checkbox(
                 component.checkedStyle()
             }
         }) {
-            component.element?.invoke(this)
-            disabled(component.disabled)
-            readOnly(component.readonly)
+            component.element.value.invoke(this)
+            disabled(component.disabled.values)
+            readOnly(component.readonly.values)
             type("checkbox")
             checked(component.checked)
             component.events?.invoke(this)

--- a/components/src/jsMain/kotlin/dev/fritz2/components/checkbox.kt
+++ b/components/src/jsMain/kotlin/dev/fritz2/components/checkbox.kt
@@ -3,6 +3,7 @@ package dev.fritz2.components
 import dev.fritz2.components.CheckboxComponent.Companion.checkboxInputStaticCss
 import dev.fritz2.dom.WithEvents
 import dev.fritz2.dom.html.Div
+import dev.fritz2.dom.html.Input
 import dev.fritz2.dom.html.Label
 import dev.fritz2.dom.html.RenderContext
 import dev.fritz2.styling.StyleClass
@@ -49,7 +50,7 @@ import org.w3c.dom.HTMLInputElement
  * ```
  */
 @ComponentMarker
-class CheckboxComponent {
+class CheckboxComponent : ElementProperties<Input> by Element(), InputFormProperties by InputForm() {
     companion object {
        val checkboxInputStaticCss = staticStyle(
             "checkbox",
@@ -112,11 +113,6 @@ class CheckboxComponent {
     fun checked(value: () -> Flow<Boolean>) {
         checked = value()
     }
-
-    var disabled: Flow<Boolean> = flowOf(false) // @input
-    fun disabled(value: () -> Flow<Boolean>) {
-        disabled = value()
-    }
 }
 
 /**
@@ -178,9 +174,11 @@ fun RenderContext.checkbox(
                 component.checkedStyle()
             }
         }) {
+            component.element?.invoke(this)
+            disabled(component.disabled)
+            readOnly(component.readonly)
             type("checkbox")
             checked(component.checked)
-            disabled(component.disabled)
             component.events?.invoke(this)
         }
 

--- a/components/src/jsMain/kotlin/dev/fritz2/components/checkboxGroup.kt
+++ b/components/src/jsMain/kotlin/dev/fritz2/components/checkboxGroup.kt
@@ -205,7 +205,7 @@ fun <T>RenderContext.checkboxGroup(
                 checkedStyle { component.checkedStyle }
                 label(component.label(item))
                 checked { checkedFlow }
-                disabled { component.disabled }
+                disabled (component.disabled )
                 events {
                    changes.states().map{ item } handledBy toggle
                 }

--- a/components/src/jsMain/kotlin/dev/fritz2/components/components.kt
+++ b/components/src/jsMain/kotlin/dev/fritz2/components/components.kt
@@ -1,7 +1,64 @@
 package dev.fritz2.components
 
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.flow.map
+
 /**
  * A marker to separate the layers of calls in the type-safe-builder pattern.
  */
 @DslMarker
 annotation class ComponentMarker
+
+interface ElementProperties<T> {
+    var element: (T.() -> Unit)?
+
+    fun element(value: T.() -> Unit) {
+        element = value
+    }
+}
+
+// TODO: Constraint für Typ: T : Tag<E> ?
+class Element<T> : ElementProperties<T> {
+    override var element: (T.() -> Unit)? = null
+}
+
+interface FormProperties {
+    var disabled: Flow<Boolean>
+
+    fun disabled(value: Flow<Boolean>) {
+        disabled = value
+    }
+
+    fun disabled(value: Boolean) {
+        disabled(flowOf(value))
+    }
+
+    fun enabled(value: Flow<Boolean>) {
+        disabled = value.map { !it }
+    }
+
+    fun enabled(value: Boolean) {
+        enabled(flowOf(value))
+    }
+}
+
+open class Form : FormProperties {
+    override var disabled: Flow<Boolean> = flowOf(false)
+}
+
+interface InputFormProperties : FormProperties {
+
+    var readonly: Flow<Boolean>
+
+    fun readonly(value: Flow<Boolean>) {
+        readonly = value
+    }
+    fun readonly(value: Boolean) {
+        readonly(flowOf(value))
+    }
+}
+
+class InputForm : InputFormProperties, Form() {
+    override var readonly: Flow<Boolean> = flowOf(false)
+}

--- a/components/src/jsMain/kotlin/dev/fritz2/components/formcontrol.kt
+++ b/components/src/jsMain/kotlin/dev/fritz2/components/formcontrol.kt
@@ -178,7 +178,7 @@ open class FormControlComponent {
         control.set(ControlNames.inputField)
         {
             inputField(styling, store, baseClass, id, prefix) {
-                base {
+                element {
                     className(StyleClass(invalidClassName).whenever(msg))
                     init()
                 }

--- a/components/src/jsMain/kotlin/dev/fritz2/components/input.kt
+++ b/components/src/jsMain/kotlin/dev/fritz2/components/input.kt
@@ -90,57 +90,12 @@ open class InputFieldComponent : ElementProperties<Input> by Element(), InputFor
         }
     }
 
-    var variant: InputFieldVariants.() -> Style<BasicParams> = { Theme().input.variants.outline }
-
-    fun variant(value: InputFieldVariants.() -> Style<BasicParams>) {
-        variant = value
-    }
-
-    var size: InputFieldSizes.() -> Style<BasicParams> = { Theme().input.sizes.normal }
-
-    fun size(value: InputFieldSizes.() -> Style<BasicParams>) {
-        size = value
-    }
-
-    var value: Flow<String> = flowOf("")
-
-    fun value(value: Flow<String>) {
-        this.value = value
-    }
-
-    fun value(value: String) {
-        value(flowOf(value))
-    }
-
-    var placeholder: Flow<String> = flowOf("")
-
-    fun placeholder(value: Flow<String>) {
-        placeholder = value
-    }
-
-    fun placeholder(value: String) {
-        placeholder(flowOf(value))
-    }
-
-    var type: Flow<String> = flowOf("")
-
-    fun type(value: Flow<String>) {
-        type = value
-    }
-
-    fun type(value: String) {
-        type(flowOf(value))
-    }
-
-    var step: Flow<String> = flowOf("")
-
-    fun step(value: Flow<String>) {
-        step = value
-    }
-
-    fun step(value: String) {
-        step(flowOf(value))
-    }
+    var variant = ComponentProperty<InputFieldVariants.() -> Style<BasicParams>> { Theme().input.variants.outline }
+    var size = ComponentProperty<InputFieldSizes.() -> Style<BasicParams>> { Theme().input.sizes.normal }
+    var value = DynamicComponentProperty(flowOf(""))
+    var placeholder = DynamicComponentProperty(flowOf(""))
+    var type = DynamicComponentProperty(flowOf(""))
+    var step = DynamicComponentProperty(flowOf(""))
 }
 
 
@@ -206,17 +161,17 @@ fun RenderContext.inputField(
     val component = InputFieldComponent().apply(build)
 
     (::input.styled(styling, baseClass + InputFieldComponent.staticCss, id, prefix) {
-        component.size.invoke(Theme().input.sizes)()
-        component.variant.invoke(Theme().input.variants)()
+        component.size.value.invoke(Theme().input.sizes)()
+        component.variant.value.invoke(Theme().input.variants)()
         InputFieldComponent.basicInputStyles()
     }) {
-        component.element?.invoke(this)
-        disabled(component.disabled)
-        readOnly(component.readonly)
-        placeholder(component.placeholder)
-        value(component.value)
-        type(component.type)
-        step(component.step)
+        component.element.value.invoke(this)
+        disabled(component.disabled.values)
+        readOnly(component.readonly.values)
+        placeholder(component.placeholder.values)
+        value(component.value.values)
+        type(component.type.values)
+        step(component.step.values)
         store?.let {
             value(it.data)
             changes.values() handledBy it.update

--- a/components/src/jsMain/kotlin/dev/fritz2/components/input.kt
+++ b/components/src/jsMain/kotlin/dev/fritz2/components/input.kt
@@ -15,6 +15,8 @@ import dev.fritz2.styling.theme.InputFieldSizes
 import dev.fritz2.styling.theme.InputFieldStyles
 import dev.fritz2.styling.theme.InputFieldVariants
 import dev.fritz2.styling.theme.Theme
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flowOf
 
 /**
  * This class deals with the _configuration_ of an input element.
@@ -22,7 +24,7 @@ import dev.fritz2.styling.theme.Theme
  * The inputField can be configured for the following aspects:
  *  - the size of the element
  *  - some predefined styling variants
- *  - the base options of the HTML input element can be set.
+ *  - the element options of the HTML input element can be set.
  *    [Attributes](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#Attributes)
  *
  *  * For a detailed explanation and examples of usage have a look at the [inputField] function!
@@ -30,7 +32,7 @@ import dev.fritz2.styling.theme.Theme
  * @see InputFieldStyles
  */
 @ComponentMarker
-open class InputFieldComponent {
+open class InputFieldComponent : ElementProperties<Input> by Element(), InputFormProperties by InputForm() {
     companion object {
 
         val staticCss = staticStyle(
@@ -100,10 +102,44 @@ open class InputFieldComponent {
         size = value
     }
 
-    var base: (Input.() -> Unit)? = null
+    var value: Flow<String> = flowOf("")
 
-    fun base(value: Input.() -> Unit) {
-        base = value
+    fun value(value: Flow<String>) {
+        this.value = value
+    }
+
+    fun value(value: String) {
+        value(flowOf(value))
+    }
+
+    var placeholder: Flow<String> = flowOf("")
+
+    fun placeholder(value: Flow<String>) {
+        placeholder = value
+    }
+
+    fun placeholder(value: String) {
+        placeholder(flowOf(value))
+    }
+
+    var type: Flow<String> = flowOf("")
+
+    fun type(value: Flow<String>) {
+        type = value
+    }
+
+    fun type(value: String) {
+        type(flowOf(value))
+    }
+
+    var step: Flow<String> = flowOf("")
+
+    fun step(value: Flow<String>) {
+        step = value
+    }
+
+    fun step(value: String) {
+        step(flowOf(value))
     }
 }
 
@@ -117,11 +153,11 @@ open class InputFieldComponent {
  *
  * To enable or disable it or to make it readOnly just use the well known attributes of the HTML
  * [input element](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/Input). To manually set the value or
- * react to a change refer also to its event's. All that can be achieved via the [InputFieldComponent.base] property!
+ * react to a change refer also to its event's. All that can be achieved via the [InputFieldComponent.element] property!
  *
  * ```
  * inputField(store = dataStore) {
- *      base {
+ *      element {
  *          placeholder("Placeholder") // render a placeholder text for empty field
  *      }
  * }
@@ -130,7 +166,7 @@ open class InputFieldComponent {
  * inputField(store = dataStore) {
  *      size { small } // render a smaller input
  *      variant { filled } // fill the background with ``light`` color
- *      base {
+ *      element {
  *          placeholder("Placeholder") // render a placeholder text for empty field
  *      }
  * }
@@ -144,7 +180,7 @@ open class InputFieldComponent {
  * },
  * store = dataStore) {
  *      size { small } // render a smaller input
- *      base {
+ *      element {
  *          placeholder("Placeholder") // render a placeholder text for empty field
  *      }
  * }
@@ -174,7 +210,13 @@ fun RenderContext.inputField(
         component.variant.invoke(Theme().input.variants)()
         InputFieldComponent.basicInputStyles()
     }) {
-        component.base?.invoke(this)
+        component.element?.invoke(this)
+        disabled(component.disabled)
+        readOnly(component.readonly)
+        placeholder(component.placeholder)
+        value(component.value)
+        type(component.type)
+        step(component.step)
         store?.let {
             value(it.data)
             changes.values() handledBy it.update

--- a/components/src/jsMain/kotlin/dev/fritz2/components/radio.kt
+++ b/components/src/jsMain/kotlin/dev/fritz2/components/radio.kt
@@ -2,6 +2,7 @@ package dev.fritz2.components
 
 import dev.fritz2.dom.WithEvents
 import dev.fritz2.dom.html.Div
+import dev.fritz2.dom.html.Input
 import dev.fritz2.dom.html.Label
 import dev.fritz2.dom.html.RenderContext
 import dev.fritz2.styling.StyleClass
@@ -49,7 +50,7 @@ import org.w3c.dom.HTMLInputElement
  * ```
  */
 @ComponentMarker
-class RadioComponent {
+class RadioComponent : ElementProperties<Input> by Element(), InputFormProperties by InputForm() {
     companion object {
         val radioInputStaticCss = staticStyle(
             "radioInput",
@@ -113,14 +114,17 @@ class RadioComponent {
             +value
         }
     }
+
     fun label(value: Flow<String>) {
         label = {
             value.asText()
         }
     }
+
     fun label(value: (Div.() -> Unit)) {
         label = value
     }
+
     var labelStyle: Style<BasicParams> = { Theme().radio.label() }
     fun labelStyle(value: () -> Style<BasicParams>) {
         labelStyle = value()
@@ -141,15 +145,11 @@ class RadioComponent {
         selected = value()
     }
 
-    var disabled: Flow<Boolean> = flowOf(false) // @input
-    fun disabled(value: () -> Flow<Boolean>) {
-        disabled = value()
-    }
-
     var groupName: Flow<String> = flowOf("")
     fun groupName(value: () -> String) {
         groupName = flowOf(value())
     }
+
     fun groupName(value: () -> Flow<String>) {
         groupName = value()
     }
@@ -198,7 +198,7 @@ fun RenderContext.radio(
     val inputId = id?.let { "$it-input" }
     val alternativeGroupname = id?.let { "$it-groupName" }
     val inputName = component.groupName.map {
-        if(it.isEmpty()) {
+        if (it.isEmpty()) {
             alternativeGroupname ?: ""
         } else {
             it
@@ -219,11 +219,15 @@ fun RenderContext.radio(
             baseClass = RadioComponent.radioInputStaticCss,
             prefix = prefix,
             id = inputId
-        ){ Theme().radio.input()
+        ) {
+            Theme().radio.input()
             children("&[checked] + div") {
                 component.selectedStyle()
             }
         }) {
+            component.element?.invoke(this)
+            disabled(component.disabled)
+            readOnly(component.readonly)
             type("radio")
             name(inputName)
             checked(component.selected)
@@ -232,7 +236,7 @@ fun RenderContext.radio(
             component.events?.invoke(this)
         }
 
-        (::div.styled(){
+        (::div.styled() {
             Theme().radio.default()
             styling()
         }) { }

--- a/components/src/jsMain/kotlin/dev/fritz2/components/radio.kt
+++ b/components/src/jsMain/kotlin/dev/fritz2/components/radio.kt
@@ -225,13 +225,12 @@ fun RenderContext.radio(
                 component.selectedStyle()
             }
         }) {
-            component.element?.invoke(this)
-            disabled(component.disabled)
-            readOnly(component.readonly)
+            component.element.value.invoke(this)
+            disabled(component.disabled.values)
+            readOnly(component.readonly.values)
             type("radio")
             name(inputName)
             checked(component.selected)
-            disabled(component.disabled)
             value("X")
             component.events?.invoke(this)
         }

--- a/components/src/jsMain/kotlin/dev/fritz2/components/radioGroup.kt
+++ b/components/src/jsMain/kotlin/dev/fritz2/components/radioGroup.kt
@@ -76,11 +76,13 @@ class RadioGroupComponent<T> {
             }
         }
     }
+
     var items: Flow<List<T>> = flowOf(emptyList())
 
     fun items(value: List<T>) {
         items = flowOf(value)
     }
+
     fun items(value: () -> Flow<List<T>>) {
         items = value()
     }
@@ -90,8 +92,8 @@ class RadioGroupComponent<T> {
         icon = value()
     }
 
-    var label: ((item: T)  -> String) =  {it.toString()}
-    fun label (value: (item: T)  -> String) {
+    var label: ((item: T) -> String) = { it.toString() }
+    fun label(value: (item: T) -> String) {
         label = value
     }
 
@@ -100,13 +102,13 @@ class RadioGroupComponent<T> {
         disabled = value()
     }
 
-    fun disabled(value:  Boolean) {
+    fun disabled(value: Boolean) {
         disabled = flowOf(value)
     }
 
     var direction: Style<BasicParams> = RadioGroupLayouts.column
     fun direction(value: RadioGroupLayouts.() -> Style<BasicParams>) {
-        direction =  RadioGroupLayouts.value()
+        direction = RadioGroupLayouts.value()
     }
 
     var size: RadioSizes.() -> Style<BasicParams> = { Theme().radio.sizes.normal }
@@ -130,8 +132,6 @@ class RadioGroupComponent<T> {
     }
 
 }
-
-
 
 
 /**
@@ -162,7 +162,7 @@ class RadioGroupComponent<T> {
  * @param build a lambda expression for setting up the component itself. Details in [RadioGroupComponent]
  * @return a flow of the _selected_ item
  */
-fun <T>RenderContext.radioGroup(
+fun <T> RenderContext.radioGroup(
     styling: BasicParams.() -> Unit = {},
     store: Store<T>,
     baseClass: StyleClass? = null,
@@ -184,9 +184,9 @@ fun <T>RenderContext.radioGroup(
                 selectedStyle { component.selectedStyle }
                 label(component.label(item))
                 selected { checkedFlow }
-                disabled { component.disabled }
+                disabled(component.disabled)
                 events {
-                    changes.states().map{ item } handledBy store.update
+                    changes.states().map { item } handledBy store.update
                 }
             }
         }

--- a/components/src/jsMain/kotlin/dev/fritz2/components/switch.kt
+++ b/components/src/jsMain/kotlin/dev/fritz2/components/switch.kt
@@ -174,12 +174,11 @@ fun RenderContext.switch(
                 component.checkedStyle()
             }
         }) {
-            component.element?.invoke(this)
-            disabled(component.disabled)
-            readOnly(component.readonly)
+            component.element.value.invoke(this)
+            disabled(component.disabled.values)
+            readOnly(component.readonly.values)
             type("checkbox")
             checked(component.checked)
-            disabled(component.disabled)
             component.events?.invoke(this)
         }
 

--- a/components/src/jsMain/kotlin/dev/fritz2/components/switch.kt
+++ b/components/src/jsMain/kotlin/dev/fritz2/components/switch.kt
@@ -4,6 +4,7 @@ import dev.fritz2.binding.Store
 import dev.fritz2.components.SwitchComponent.Companion.switchInputStaticCss
 import dev.fritz2.dom.WithEvents
 import dev.fritz2.dom.html.Div
+import dev.fritz2.dom.html.Input
 import dev.fritz2.dom.html.Label
 import dev.fritz2.dom.html.RenderContext
 import dev.fritz2.identification.uniqueId
@@ -50,7 +51,7 @@ import org.w3c.dom.HTMLInputElement
  * ```
  */
 @ComponentMarker
-class SwitchComponent {
+class SwitchComponent : ElementProperties<Input> by Element(), InputFormProperties by InputForm() {
     companion object {
         val switchInputStaticCss = staticStyle(
             "switch",
@@ -114,11 +115,6 @@ class SwitchComponent {
     fun checked(value: () -> Flow<Boolean>) {
         checked = value()
     }
-
-    var disabled: Flow<Boolean> = flowOf(false) // @input
-    fun disabled(value: () -> Flow<Boolean>) {
-        disabled = value()
-    }
 }
 
 /**
@@ -178,6 +174,9 @@ fun RenderContext.switch(
                 component.checkedStyle()
             }
         }) {
+            component.element?.invoke(this)
+            disabled(component.disabled)
+            readOnly(component.readonly)
             type("checkbox")
             checked(component.checked)
             disabled(component.disabled)

--- a/components/src/jsMain/kotlin/dev/fritz2/components/textarea.kt
+++ b/components/src/jsMain/kotlin/dev/fritz2/components/textarea.kt
@@ -33,7 +33,7 @@ import kotlinx.coroutines.flow.flowOf
  *
  */
 @ComponentMarker
-class TextAreaComponent {
+class TextAreaComponent : ElementProperties<TextArea> by Element(), InputFormProperties by InputForm() {
 
     companion object {
         val staticCss = staticStyle(
@@ -48,15 +48,12 @@ class TextAreaComponent {
                 
                 """
         )
-
-
     }
 
     val basicInputStyles: Style<BasicParams> = {
 
         radius { normal }
         fontWeight { normal }
-
 
         border {
             width { thin }
@@ -82,10 +79,14 @@ class TextAreaComponent {
         }
     }
 
-
     var value: Flow<String>? = null
-    fun value(value: () -> Flow<String>) {
-        this.value = value()
+
+    fun value(value: Flow<String>) {
+        this.value = value
+    }
+
+    fun value(value: String) {
+        value(flowOf(value))
     }
 
     var placeholder: Flow<String>? = null
@@ -98,25 +99,6 @@ class TextAreaComponent {
         placeholder = value
     }
 
-    fun placeholder(value: () -> Flow<String>) {
-        placeholder = value()
-
-    }
-
-    var disable: Flow<Boolean> = flowOf(false)
-
-    fun disable(value: Boolean) {
-        disable = flowOf(value)
-    }
-
-    fun disable(value: Flow<Boolean>) {
-        disable = value
-    }
-
-    fun disable(value: () -> Flow<Boolean>) {
-        disable = value()
-    }
-
     var size: TextAreaSize.() -> Style<BasicParams> = { Theme().textarea.size.normal }
     fun size(value: TextAreaSize.() -> Style<BasicParams>) {
         size = value
@@ -126,14 +108,6 @@ class TextAreaComponent {
     fun resizeBehavior(value: TextAreaResize.() -> Style<BasicParams>) {
         resizeBehavior = value
     }
-
-    var base: (TextArea.() -> Unit)? = null
-
-    fun base(value: TextArea.() -> Unit) {
-        base = value
-    }
-
-
 }
 
 /**
@@ -211,14 +185,14 @@ fun RenderContext.textArea(
         component.basicInputStyles()
 
     }){
+        component.element?.invoke(this)
+        disabled(component.disabled)
+        readOnly(component.readonly)
         placeholder(component.placeholder ?: emptyFlow())
-        disabled(component.disable)
         value(component.value ?: emptyFlow())
-        component.base?.invoke(this)
         store?.let {
             value(it.data)
             changes.values() handledBy it.update
-
         }
     }
 }

--- a/components/src/jsMain/kotlin/dev/fritz2/components/textarea.kt
+++ b/components/src/jsMain/kotlin/dev/fritz2/components/textarea.kt
@@ -185,9 +185,9 @@ fun RenderContext.textArea(
         component.basicInputStyles()
 
     }){
-        component.element?.invoke(this)
-        disabled(component.disabled)
-        readOnly(component.readonly)
+        component.element.value.invoke(this)
+        disabled(component.disabled.values)
+        readOnly(component.readonly.values)
         placeholder(component.placeholder ?: emptyFlow())
         value(component.value ?: emptyFlow())
         store?.let {


### PR DESCRIPTION
- Apply [components guidlines](https://github.com/jwstegemann/fritz2/wiki/Interne-Komponentenrichtlinien) to all existing fritz2 components
- reduce implementation complexity by
  - using specific properties abstractions
  - using "traits" for common property groups