### PR TITLE
Change alert-icon based on the specified alert-severity

### DIFF
--- a/components/src/jsMain/kotlin/dev/fritz2/components/alert.kt
+++ b/components/src/jsMain/kotlin/dev/fritz2/components/alert.kt
@@ -288,14 +288,6 @@ fun ComponentValidationMessage.asAlert(
                 Severity.Error -> error
             }
         }
-        icon {
-            when (receiver.severity) {
-                Severity.Info -> circleInformation
-                Severity.Success -> circleCheck
-                Severity.Warning -> circleWarning
-                Severity.Error -> circleError
-            }
-        }
         variant { discreet }
         sizes { size() }
         stacking { stacking() }

--- a/components/src/jsMain/kotlin/dev/fritz2/components/alert.kt
+++ b/components/src/jsMain/kotlin/dev/fritz2/components/alert.kt
@@ -22,8 +22,9 @@ import kotlinx.coroutines.flow.flowOf
  * - Success
  * - Warning
  * - Error
- * Specifying a severity will change the alert's color scheme based on the colors defined in the application theme.
- * If no severity is specified, 'info' will be used by default.
+ * Specifying a severity will change the alert's color scheme based on the colors defined in the application theme as
+ * well as the icon displayed. If no severity is specified, 'info' will be used by default.
+ * The alert's icon can manually be set via the 'icon'-property in which case the severity's icon will be ignored.
  *
  * Additionally, a number of different layout options are available. These are:
  * - 'subtle': A subtle style using different shades of the severity's base color defined in the application theme.
@@ -65,10 +66,11 @@ class AlertComponent {
         get() {
             val alertSeverity = severity.value.invoke(Theme().alert.severities)
             val alertVariantFactory = variant.value.invoke(Theme().alert.variants)
-            return alertVariantFactory.invoke(alertSeverity)
+            return alertVariantFactory.invoke(alertSeverity.color)
         }
 
-    val icon = ComponentProperty<Icons.() -> IconDefinition> { Theme().icons.circleInformation }
+    // the icon specified in AlertSeverity is used if no icon is specified manually
+    val icon = ComponentProperty<(Icons.() -> IconDefinition)?>(value = null)
 
     private var title: (RenderContext.() -> Unit)? = null
     private var content: (RenderContext.() -> Unit)? = null
@@ -152,7 +154,11 @@ class AlertComponent {
                             css("width: var(--al-icon-size)")
                             css("height: var(--al-icon-size)")
                         }) {
-                            fromTheme { icon.value(Theme().icons) }
+                            fromTheme {
+                                icon.value
+                                    ?.invoke(Theme().icons)
+                                    ?: severity.value(Theme().alert.severities).icon
+                            }
                         }
                     }
 

--- a/styling/src/jsMain/kotlin/dev.fritz2.styling/theme/default.kt
+++ b/styling/src/jsMain/kotlin/dev.fritz2.styling/theme/default.kt
@@ -2358,10 +2358,22 @@ open class DefaultTheme : Theme {
     override val alert: AlertStyles = object : AlertStyles {
         override val severities: AlertSeverities
             get() = object : AlertSeverities {
-                override val info: AlertSeverity = colors.info
-                override val success: AlertSeverity = colors.success
-                override val warning: AlertSeverity = colors.warning
-                override val error: AlertSeverity = colors.danger
+                override val info: AlertSeverity = object : AlertSeverity {
+                    override val color = colors.info
+                    override val icon = icons.circleInformation
+                }
+                override val success: AlertSeverity = object : AlertSeverity {
+                    override val color = colors.success
+                    override val icon = icons.circleCheck
+                }
+                override val warning: AlertSeverity = object : AlertSeverity {
+                    override val color = colors.warning
+                    override val icon = icons.circleWarning
+                }
+                override val error: AlertSeverity = object : AlertSeverity {
+                    override val color = colors.danger
+                    override val icon = icons.circleError
+                }
             }
 
         override val variants: AlertVariants = object : AlertVariants {

--- a/styling/src/jsMain/kotlin/dev.fritz2.styling/theme/definitions.kt
+++ b/styling/src/jsMain/kotlin/dev.fritz2.styling/theme/definitions.kt
@@ -602,7 +602,11 @@ interface AlertStacking {
     val compact: Style<BasicParams>
     val separated: Style<BasicParams>
 }
-typealias AlertSeverity = ColorProperty
+
+interface AlertSeverity {
+    val color: ColorProperty
+    val icon: IconDefinition
+}
 
 interface AlertSeverities {
     val info: AlertSeverity


### PR DESCRIPTION
This PR makes the `AlertComponent` change it's icon based on the specified alert-severity.
The icon can still be overridden via the `icon`-property of `AlertComponent`.

![Bildschirmfoto 2021-02-16 um 16 34 26](https://user-images.githubusercontent.com/12587543/108085000-250c9c00-7075-11eb-8387-c79a7b069e9d.png)
