### PR TITLE
Rework element property prioritization

### DIFF
--- a/components/src/jsMain/kotlin/dev/fritz2/components/button.kt
+++ b/components/src/jsMain/kotlin/dev/fritz2/components/button.kt
@@ -277,7 +277,6 @@ fun RenderContext.pushButton(
         component.variant.value.invoke(Theme().button.variants)()
         component.size.value.invoke(Theme().button.sizes)()
     }) {
-        component.element.value.invoke(this)
         disabled(component.disabled.values)
         if (component.text == null) {
             component.renderIcon(this, component.centerIconStyle, component.centerSpinnerStyle)
@@ -290,8 +289,8 @@ fun RenderContext.pushButton(
                 component.renderIcon(this, component.rightIconStyle, component.rightSpinnerStyle)
             }
         }
-
         component.events.value.invoke(this)
+        component.element.value.invoke(this)
     }
 }
 

--- a/components/src/jsMain/kotlin/dev/fritz2/components/checkbox.kt
+++ b/components/src/jsMain/kotlin/dev/fritz2/components/checkbox.kt
@@ -173,14 +173,14 @@ fun RenderContext.checkbox(
                 component.checkedStyle.value()
             }
         }) {
-            component.element.value.invoke(this)
             disabled(component.disabled.values)
             readOnly(component.readonly.values)
             type("checkbox")
             checked(store?.data ?: component.checked.values)
             className(component.severityClassOf(Theme().checkbox.severity, prefix))
-            component.events.value.invoke(this)
             store?.let { changes.states() handledBy it.update }
+            component.events.value.invoke(this)
+            component.element.value.invoke(this)
         }
 
         (::div.styled() {
@@ -189,8 +189,9 @@ fun RenderContext.checkbox(
         }) {
             icon({
                 Theme().checkbox.icon()
+            }) {
+                def(component.icon.value(Theme().icons))
             }
-            ) { def(component.icon.value(Theme().icons)) }
         }
 
         component.label?.let {

--- a/components/src/jsMain/kotlin/dev/fritz2/components/input.kt
+++ b/components/src/jsMain/kotlin/dev/fritz2/components/input.kt
@@ -26,8 +26,6 @@ import org.w3c.dom.HTMLInputElement
  *    [Attributes](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#Attributes)
  *
  *  * For a detailed explanation and examples of usage have a look at the [inputField] function!
- *
- * @see InputFieldStyles
  */
 @ComponentMarker
 open class InputFieldComponent :
@@ -117,7 +115,7 @@ open class InputFieldComponent :
  *
  * To enable or disable it or to make it readOnly just use the well known attributes of the HTML
  * [input element](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/Input). To manually set the value or
- * react to a change refer also to its event's. All that can be achieved via the [InputFieldComponent.element] property!
+ * react to a change refer also to its event's. All that can be achieved via the [ElementMixin.element] property!
  *
  * ```
  * inputField(store = dataStore /* inject a store so all user inputs are automatically reflected! */) {
@@ -181,8 +179,6 @@ fun RenderContext.inputField(
         component.variant.value.invoke(Theme().input.variants)()
         InputFieldComponent.basicInputStyles()
     }) {
-        component.element.value.invoke(this)
-        component.events.value.invoke(this)
         disabled(component.disabled.values)
         readOnly(component.readonly.values)
         placeholder(component.placeholder.values)
@@ -194,5 +190,7 @@ fun RenderContext.inputField(
             value(it.data)
             changes.values() handledBy it.update
         }
+        component.events.value.invoke(this)
+        component.element.value.invoke(this)
     }
 }

--- a/components/src/jsMain/kotlin/dev/fritz2/components/popover.kt
+++ b/components/src/jsMain/kotlin/dev/fritz2/components/popover.kt
@@ -55,7 +55,7 @@ class PopoverComponent : CloseButtonProperty by CloseButtonMixin(
 
     val toggle = ComponentProperty<(RenderContext.() -> Unit)?>(null)
 
-    var header: (RenderContext.() -> Unit)? = null
+    private var header: (RenderContext.() -> Unit)? = null
     fun header(value: (RenderContext.() -> Unit)) {
         header = {
             (::header.styled(prefix = "popover-header") {

--- a/components/src/jsMain/kotlin/dev/fritz2/components/radio.kt
+++ b/components/src/jsMain/kotlin/dev/fritz2/components/radio.kt
@@ -151,7 +151,7 @@ class RadioComponent :
  * @param baseClass optional CSS class that should be applied to the element
  * @param id the ID of the element
  * @param prefix the prefix for the generated CSS class resulting in the form ``$prefix-$hash``
- * @param build a lambda expression for setting up the component itself. Details in [CheckboxComponent]
+ * @param build a lambda expression for setting up the component itself. Details in [RadioComponent]
  */
 fun RenderContext.radio(
     styling: BasicParams.() -> Unit = {},
@@ -192,16 +192,16 @@ fun RenderContext.radio(
                 component.selectedStyle.value()
             }
         }) {
-            component.element.value.invoke(this)
             disabled(component.disabled.values)
             readOnly(component.readonly.values)
             type("radio")
             name(inputName)
             checked(store?.data ?: component.selected.values)
             value("X")
-            component.events.value.invoke(this)
             className(component.severityClassOf(Theme().radio.severity, prefix))
             store?.let { changes.states() handledBy it.update }
+            component.events.value.invoke(this)
+            component.element.value.invoke(this)
         }
 
         (::div.styled() {

--- a/components/src/jsMain/kotlin/dev/fritz2/components/switch.kt
+++ b/components/src/jsMain/kotlin/dev/fritz2/components/switch.kt
@@ -179,7 +179,6 @@ fun RenderContext.switch(
                 component.checkedStyle.value()
             }
         }) {
-            component.element.value.invoke(this)
             disabled(component.disabled.values)
             readOnly(component.readonly.values)
             type("checkbox")
@@ -187,6 +186,7 @@ fun RenderContext.switch(
             component.events.value.invoke(this)
             store?.let { changes.states() handledBy it.update }
             className(component.severityClassOf(Theme().switch.severity, prefix))
+            component.element.value.invoke(this)
         }
 
         (::div.styled() {

--- a/components/src/jsMain/kotlin/dev/fritz2/components/textarea.kt
+++ b/components/src/jsMain/kotlin/dev/fritz2/components/textarea.kt
@@ -165,8 +165,6 @@ fun RenderContext.textArea(
         component.basicInputStyles()
 
     }){
-        component.element.value.invoke(this)
-        component.events.value.invoke(this)
         disabled(component.disabled.values)
         readOnly(component.readonly.values)
         placeholder(component.placeholder.values)
@@ -176,5 +174,7 @@ fun RenderContext.textArea(
             value(it.data)
             changes.values() handledBy it.update
         }
+        component.events.value.invoke(this)
+        component.element.value.invoke(this)
     }
 }


### PR DESCRIPTION
- element property will be applied with the bigger priority than all other component exposed props. Example: ``type`` property of ``inputField`` can be set to ``password`` but within element's context to ``text``, so ``text`` _wins_.