### PR TITLE
Refactor internal component structure

### DIFF
--- a/components/src/jsMain/kotlin/dev/fritz2/components/alert.kt
+++ b/components/src/jsMain/kotlin/dev/fritz2/components/alert.kt
@@ -7,6 +7,7 @@ import dev.fritz2.components.validation.Severity
 import dev.fritz2.dom.html.RenderContext
 import dev.fritz2.styling.StyleClass
 import dev.fritz2.styling.params.BasicParams
+import dev.fritz2.styling.params.BoxParams
 import dev.fritz2.styling.params.Style
 import dev.fritz2.styling.params.styled
 import dev.fritz2.styling.theme.*
@@ -51,7 +52,7 @@ import kotlinx.coroutines.flow.flowOf
  * ```
  */
 @ComponentMarker
-class AlertComponent {
+open class AlertComponent : Component<Unit> {
 
     companion object {
         private const val accentDecorationThickness = "4px"
@@ -109,16 +110,16 @@ class AlertComponent {
 
     fun content(value: String) = content(flowOf(value))
 
-    fun show(
-        renderContext: RenderContext,
-        styling: BasicParams.() -> Unit = {},
-        baseClass: StyleClass? = null,
-        id: String? = null,
-        prefix: String = "alert",
+    override fun render(
+        context: RenderContext,
+        styling: BoxParams.() -> Unit,
+        baseClass: StyleClass?,
+        id: String?,
+        prefix: String,
     ) {
         val styles = variantStyles
 
-        renderContext.apply {
+        context.apply {
             (::div.styled(baseClass = baseClass, id = id, prefix = prefix) {
                 styling()
                 display { flex }
@@ -178,6 +179,7 @@ class AlertComponent {
     }
 }
 
+
 /**
  * Creates an alert and renders it right away.
  *
@@ -193,77 +195,10 @@ fun RenderContext.alert(
     id: String? = null,
     prefix: String = "alert",
     build: AlertComponent.() -> Unit,
-) = AlertComponent().apply(build).show(this, styling, baseClass, id, prefix)
-
-/**
- * Creates and alert and returns a handler that displays it in a toast message when invoked.
- * Use [showAlertToast] to display the toast message right away.
- * The toast's theme properties are automatically set but can manually be overridden by passing [toastBuild].
- *
- * @param styling a lambda expression for declaring the styling of the toast using fritz2's styling DSL
- * @param baseClass optional CSS class that should be applied to the toast element
- * @param id the ID of the toast element
- * @param prefix the prefix for the generated CSS class of the toast element resulting in the form ``$prefix-$hash``
- * @param toastBuild a lambda expression for setting up the toast containing the alert
- * @param build a lambda expression for setting up the alert component
- */
-fun RenderContext.alertToast(
-    styling: BasicParams.() -> Unit = {},
-    baseClass: StyleClass? = null,
-    id: String? = null,
-    prefix: String = "alert",
-    toastBuild: ToastComponent.() -> Unit = { },
-    build: AlertComponent.() -> Unit,
-): SimpleHandler<Unit> {
-
-    val pendingToastStore = object : RootStore<Unit>(Unit) {
-        val show = handle {
-            showAlertToast(styling, baseClass, id, prefix, toastBuild, build)
-        }
-    }
-    return pendingToastStore.show
-}
-
-/**
- * Creates and alert and displays it as a toast message.
- * The toast's theme properties are automatically set but can manually be overridden by passing [toastBuild].
- *
- * @param styling a lambda expression for declaring the styling of the toast using fritz2's styling DSL
- * @param baseClass optional CSS class that should be applied to the toast element
- * @param id the ID of the toast element
- * @param prefix the prefix for the generated CSS class of the toast element resulting in the form ``$prefix-$hash``
- * @param toastBuild a lambda expression for setting up the toast containing the alert
- * @param build a lambda expression for setting up the alert component
- */
-fun RenderContext.showAlertToast(
-    styling: BasicParams.() -> Unit = {},
-    baseClass: StyleClass? = null,
-    id: String? = null,
-    prefix: String = "alert",
-    toastBuild: ToastComponent.() -> Unit = { },
-    build: AlertComponent.() -> Unit,
 ) {
-    val alert = AlertComponent().apply(build)
-
-    showToast {
-        toastBuild()
-        content {
-            alert.show(
-                this,
-                styling = {
-                    styling()
-                    paddings { right { giant } }
-                },
-                baseClass,
-                id,
-                prefix
-            )
-        }
-        closeButtonStyle {
-            alert.variantStyles.text()
-        }
-    }
+    AlertComponent().apply(build).render(this, styling, baseClass, id, prefix)
 }
+
 
 /**
  * Convenience extension to display a [ComponentValidationMessage] as an alert.

--- a/components/src/jsMain/kotlin/dev/fritz2/components/appFrame.kt
+++ b/components/src/jsMain/kotlin/dev/fritz2/components/appFrame.kt
@@ -8,6 +8,7 @@ import dev.fritz2.dom.html.TextElement
 import dev.fritz2.styling.StyleClass
 import dev.fritz2.styling.name
 import dev.fritz2.styling.params.BasicParams
+import dev.fritz2.styling.params.BoxParams
 import dev.fritz2.styling.params.Style
 import dev.fritz2.styling.params.styled
 import dev.fritz2.styling.staticStyle
@@ -35,7 +36,7 @@ import kotlinx.coroutines.ExperimentalCoroutinesApi
  * not meant to be called directly unless you plan to implement your own appFrame.
  */
 @ExperimentalCoroutinesApi
-open class AppFrameComponent() {
+open class AppFrameComponent : Component<Unit> {
     companion object {
         init {
             staticStyle(
@@ -119,12 +120,12 @@ open class AppFrameComponent() {
     val tabs = ComponentProperty<(Div.() -> Unit)?>(null)
 
 
-    fun render(
+    override fun render(
         context: RenderContext,
-        styling: BasicParams.() -> Unit = {},
-        baseClass: StyleClass? = null,
-        id: String? = null,
-        prefix: String = "app"
+        styling: BoxParams.() -> Unit,
+        baseClass: StyleClass?,
+        id: String?,
+        prefix: String
     ) {
         context.apply {
             box({

--- a/components/src/jsMain/kotlin/dev/fritz2/components/button.kt
+++ b/components/src/jsMain/kotlin/dev/fritz2/components/button.kt
@@ -55,6 +55,7 @@ import org.w3c.dom.events.MouseEvent
  */
 @ComponentMarker
 open class PushButtonComponent :
+    Component<Unit>,
     EventProperties<HTMLButtonElement> by EventMixin(),
     ElementProperties<Button> by ElementMixin(),
     FormProperties by FormMixin() {
@@ -141,16 +142,16 @@ open class PushButtonComponent :
 
     private fun buildColor(value: ColorProperty): Style<BasicParams> = { css("--main-color: $value;") }
 
-    var color: Style<BasicParams> = buildColor(Theme().colors.primary)
+    private var colorField: Style<BasicParams> = buildColor(Theme().colors.primary)
 
     fun color(value: Colors.() -> ColorProperty) {
-        color = buildColor(Theme().colors.value())
+        colorField = buildColor(Theme().colors.value())
     }
 
     val variant = ComponentProperty<PushButtonVariants.() -> Style<BasicParams>> { Theme().button.variants.solid }
     val size = ComponentProperty<FormSizes.() -> Style<BasicParams>> { Theme().button.sizes.normal }
 
-    var text: (RenderContext.(hide: Boolean) -> Unit)? = null
+    private var text: (RenderContext.(hide: Boolean) -> Unit)? = null
 
     fun text(value: String) {
         text = { hide -> span(if (hide) hidden.name else null) { +value } }
@@ -160,7 +161,7 @@ open class PushButtonComponent :
         text = { hide -> span(if (hide) hidden.name else null) { value.asText() } }
     }
 
-    var loadingText: (RenderContext.() -> Unit)? = null
+    private var loadingText: (RenderContext.() -> Unit)? = null
 
     fun loadingText(value: String) {
         loadingText = { span { +value } }
@@ -170,13 +171,13 @@ open class PushButtonComponent :
         loadingText = { span { value.asText() } }
     }
 
-    var loading: Flow<Boolean>? = null
+    private var loading: Flow<Boolean>? = null
 
     fun loading(value: Flow<Boolean>) {
         loading = value
     }
 
-    var icon: ((RenderContext, Style<BasicParams>) -> Unit)? = null
+    private var icon: ((RenderContext, Style<BasicParams>) -> Unit)? = null
 
     fun icon(
         styling: BasicParams.() -> Unit = {},
@@ -202,7 +203,38 @@ open class PushButtonComponent :
 
     val iconPlacement = ComponentProperty<IconPlacementContext.() -> IconPlacement> { IconPlacement.Left }
 
-    fun renderIcon(renderContext: Button, iconStyle: Style<BasicParams>, spinnerStyle: Style<BasicParams>) {
+    override fun render(
+        context: RenderContext,
+        styling: BoxParams.() -> Unit,
+        baseClass: StyleClass?,
+        id: String?,
+        prefix: String
+    ) {
+        context.apply {
+            (::button.styled(styling, baseClass + staticCss, id, prefix) {
+                colorField()
+                variant.value.invoke(Theme().button.variants)()
+                size.value.invoke(Theme().button.sizes)()
+            }) {
+                disabled(disabled.values)
+                if (text == null) {
+                    renderIcon(this, centerIconStyle, centerSpinnerStyle)
+                } else {
+                    if (icon != null && iconPlacement.value(iconPlacementContext) == IconPlacement.Left) {
+                        renderIcon(this, leftIconStyle, leftSpinnerStyle)
+                    }
+                    renderText(this)
+                    if (icon != null && iconPlacement.value(iconPlacementContext) == IconPlacement.Right) {
+                        renderIcon(this, rightIconStyle, rightSpinnerStyle)
+                    }
+                }
+                events.value.invoke(this)
+                element.value.invoke(this)
+            }
+        }
+    }
+
+    private fun renderIcon(renderContext: Button, iconStyle: Style<BasicParams>, spinnerStyle: Style<BasicParams>) {
         if (loading == null) {
             icon?.invoke(renderContext, iconStyle)
         } else {
@@ -218,7 +250,7 @@ open class PushButtonComponent :
         }
     }
 
-    fun renderLabel(renderContext: Button) {
+    private fun renderText(renderContext: Button) {
         if (loading == null || icon != null) {
             text?.invoke(renderContext, false)
         } else {
@@ -270,28 +302,7 @@ fun RenderContext.pushButton(
     prefix: String = "push-button",
     build: PushButtonComponent.() -> Unit = {}
 ) {
-    val component = PushButtonComponent().apply(build)
-
-    (::button.styled(styling, baseClass + PushButtonComponent.staticCss, id, prefix) {
-        component.color()
-        component.variant.value.invoke(Theme().button.variants)()
-        component.size.value.invoke(Theme().button.sizes)()
-    }) {
-        disabled(component.disabled.values)
-        if (component.text == null) {
-            component.renderIcon(this, component.centerIconStyle, component.centerSpinnerStyle)
-        } else {
-            if (component.icon != null && component.iconPlacement.value(PushButtonComponent.iconPlacementContext) == PushButtonComponent.IconPlacement.Left) {
-                component.renderIcon(this, component.leftIconStyle, component.leftSpinnerStyle)
-            }
-            component.renderLabel(this)
-            if (component.icon != null && component.iconPlacement.value(PushButtonComponent.iconPlacementContext) == PushButtonComponent.IconPlacement.Right) {
-                component.renderIcon(this, component.rightIconStyle, component.rightSpinnerStyle)
-            }
-        }
-        component.events.value.invoke(this)
-        component.element.value.invoke(this)
-    }
+    PushButtonComponent().apply(build).render(this, styling, baseClass, id, prefix)
 }
 
 /**

--- a/components/src/jsMain/kotlin/dev/fritz2/components/checkbox.kt
+++ b/components/src/jsMain/kotlin/dev/fritz2/components/checkbox.kt
@@ -9,6 +9,7 @@ import dev.fritz2.dom.states
 import dev.fritz2.styling.StyleClass
 import dev.fritz2.styling.className
 import dev.fritz2.styling.params.BasicParams
+import dev.fritz2.styling.params.BoxParams
 import dev.fritz2.styling.params.Style
 import dev.fritz2.styling.params.styled
 import dev.fritz2.styling.staticStyle
@@ -55,7 +56,8 @@ import org.w3c.dom.HTMLInputElement
  * ```
  */
 @ComponentMarker
-class CheckboxComponent :
+open class CheckboxComponent(protected val store: Store<Boolean>?) :
+    Component<Label>,
     EventProperties<HTMLInputElement> by EventMixin(),
     ElementProperties<Input> by ElementMixin(),
     InputFormProperties by InputFormMixin(),
@@ -82,27 +84,87 @@ class CheckboxComponent :
     val size = ComponentProperty<FormSizes.() -> Style<BasicParams>> { Theme().checkbox.sizes.normal }
     val icon = ComponentProperty<Icons.() -> IconDefinition> { Theme().icons.check }
 
-    var label: (RenderContext.() -> Unit)? = null
+    private var labelField: (RenderContext.() -> Unit)? = null
 
     fun label(value: String) {
-        label = {
+        labelField = {
             span { +value }
         }
     }
 
     fun label(value: Flow<String>) {
-        label = {
+        labelField = {
             span { value.asText() }
         }
     }
 
     fun label(value: (RenderContext.() -> Unit)) {
-        label = value
+        labelField = value
     }
 
     val labelStyle = ComponentProperty(Theme().checkbox.label)
     val checked = DynamicComponentProperty(flowOf(false))
     var checkedStyle = ComponentProperty(Theme().checkbox.checked)
+
+    override fun render(
+        context: RenderContext,
+        styling: BoxParams.() -> Unit,
+        baseClass: StyleClass?,
+        id: String?,
+        prefix: String
+    ): Label = with(context) {
+        (::label.styled(
+            baseClass = baseClass,
+            id = id,
+            prefix = prefix
+        ) {
+            size.value.invoke(Theme().checkbox.sizes)()
+        }) {
+            val inputId = id?.let { "$it-input" }
+            inputId?.let {
+                `for`(inputId)
+            }
+            (::input.styled(
+                baseClass = checkboxInputStaticCss,
+                prefix = prefix,
+                id = inputId
+            ) {
+                Theme().checkbox.input()
+                children("&[checked] + div") {
+                    checkedStyle.value()
+                }
+            }) {
+                disabled(disabled.values)
+                readOnly(readonly.values)
+                type("checkbox")
+                checked(store?.data ?: checked.values)
+                className(severityClassOf(Theme().checkbox.severity, prefix))
+                store?.let { changes.states() handledBy it.update }
+                events.value.invoke(this)
+                element.value.invoke(this)
+            }
+
+            (::div.styled() {
+                Theme().checkbox.default()
+                styling()
+            }) {
+                icon({
+                    Theme().checkbox.icon()
+                }) {
+                    def(icon.value(Theme().icons))
+                }
+            }
+
+            labelField?.let {
+                (::div.styled {
+                    labelStyle.value()
+                }){
+                    it(this)
+                }
+            }
+        }
+
+    }
 }
 
 /**
@@ -149,57 +211,4 @@ fun RenderContext.checkbox(
     id: String? = null,
     prefix: String = "checkboxComponent",
     build: CheckboxComponent.() -> Unit = {}
-): Label {
-    val component = CheckboxComponent().apply(build)
-    val inputId = id?.let { "$it-input" }
-
-    return (::label.styled(
-        baseClass = baseClass,
-        id = id,
-        prefix = prefix
-    ) {
-        component.size.value.invoke(Theme().checkbox.sizes)()
-    }) {
-        inputId?.let {
-            `for`(inputId)
-        }
-        (::input.styled(
-            baseClass = checkboxInputStaticCss,
-            prefix = prefix,
-            id = inputId
-        ) {
-            Theme().checkbox.input()
-            children("&[checked] + div") {
-                component.checkedStyle.value()
-            }
-        }) {
-            disabled(component.disabled.values)
-            readOnly(component.readonly.values)
-            type("checkbox")
-            checked(store?.data ?: component.checked.values)
-            className(component.severityClassOf(Theme().checkbox.severity, prefix))
-            store?.let { changes.states() handledBy it.update }
-            component.events.value.invoke(this)
-            component.element.value.invoke(this)
-        }
-
-        (::div.styled() {
-            Theme().checkbox.default()
-            styling()
-        }) {
-            icon({
-                Theme().checkbox.icon()
-            }) {
-                def(component.icon.value(Theme().icons))
-            }
-        }
-
-        component.label?.let {
-            (::div.styled {
-                component.labelStyle.value()
-            }){
-                it(this)
-            }
-        }
-    }
-}
+): Label = CheckboxComponent(store).apply(build).render(this, styling, baseClass, id, prefix)

--- a/components/src/jsMain/kotlin/dev/fritz2/components/components.kt
+++ b/components/src/jsMain/kotlin/dev/fritz2/components/components.kt
@@ -1,12 +1,15 @@
 package dev.fritz2.components
 
+import org.w3c.dom.*
+import dev.fritz2.dom.Listener
 import dev.fritz2.binding.RootStore
-import dev.fritz2.binding.SimpleHandler
+import org.w3c.dom.events.MouseEvent
 import dev.fritz2.components.validation.Severity
 import dev.fritz2.dom.WithEvents
 import dev.fritz2.dom.html.RenderContext
 import dev.fritz2.styling.StyleClass
 import dev.fritz2.styling.params.BasicParams
+import dev.fritz2.styling.params.BoxParams
 import dev.fritz2.styling.params.Style
 import dev.fritz2.styling.staticStyle
 import dev.fritz2.styling.theme.SeverityStyles
@@ -15,6 +18,8 @@ import kotlinx.coroutines.flow.emptyFlow
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.map
 import org.w3c.dom.Element
+import dev.fritz2.identification.uniqueId
+import dev.fritz2.styling.className
 
 /**
  * A marker to separate the layers of calls in the type-safe-builder pattern.
@@ -22,12 +27,62 @@ import org.w3c.dom.Element
 @DslMarker
 annotation class ComponentMarker
 
+
+/**
+ * Generic container for modeling a property for a component class.
+ * Use it like this:
+ * ```
+ * open class SomeComponent {
+ *      val myProp = ComponentProperty("some text")
+ *      val myBooleanProp = ComponentProperty(false)
+ *
+ *      // should rather be some implementation in the default theme of course!
+ *      class SizesContext {
+ *          small: Style<BasicParams> = { fontSize { small } }
+ *          normal: Style<BasicParams> = { fontSize { small } }
+ *          large: Style<BasicParams> = { fontSize { small } }
+ *      }
+ *
+ *      val sizes = ComponentProperty<SizesContext.() -> Style<BasicParams>> { normal }
+ * }
+ * // within your UI declaration:
+ * someComponent {
+ *      myProp("Some specific content") // pass simple parameter
+ *      myBooleanProp(true)
+ *      sizes { large } // use expression syntax
+ * }
+ * ```
+ */
 class ComponentProperty<T>(var value: T) {
     operator fun invoke(newValue: T) {
         value = newValue
     }
 }
 
+/**
+ * Generic container for modeling a property for a component class that could be either consist on a value or on a
+ * [Flow] of a value.
+ *
+ * Use it like this:
+ * ```
+ * open class SomeComponent {
+ *      val myProp = DynamicComponentProperty("some text")
+ *      val myBooleanProp = DynamicComponentProperty(false)
+ * }
+ * // within your UI declaration and static values:
+ * someComponent {
+ *      myProp("Some specific content")
+ *      myBooleanProp(true)
+ * }
+ * // within your UI declaration and dynamic values:
+ * val contentStore = storeOf("Empty")
+ * val toggle = storeOf(false)
+ * someComponent {
+ *      myProp(contentStore.data)
+ *      myBooleanProp(toggle.data)
+ * }
+ * ```
+ */
 class DynamicComponentProperty<T>(var values: Flow<T>) {
     operator fun invoke(newValue: T) {
         values = flowOf(newValue)
@@ -38,6 +93,23 @@ class DynamicComponentProperty<T>(var values: Flow<T>) {
     }
 }
 
+/**
+ * Generic container for modeling a property for a component class that could be either consist on a nullable value
+ * or on a [Flow] of a nullable value. This specific implementation could be useful for properties where the distinction
+ * between some states and the "not yet set" state is important.
+ *
+ * Use it like this:
+ * ```
+ * open class SomeComponent<T> {
+ *      val selectedItem = NullableDynamicComponentProperty<T>(emptyFlow())
+ * }
+ * // within your UI declaration and static values:
+ * val selectedStore = storeOf<String>(null)
+ * someComponent<String> {
+ *      selectedItem(selectedStore.data) // no selection at start up!
+ * }
+ * ```
+ */
 class NullableDynamicComponentProperty<T>(var values: Flow<T?>) {
     operator fun invoke(newValue: T?) {
         values = flowOf(newValue)
@@ -48,23 +120,198 @@ class NullableDynamicComponentProperty<T>(var values: Flow<T?>) {
     }
 }
 
-interface EventProperties<T : Element> {
-    val events: ComponentProperty<WithEvents<T>.() -> Unit>
+/**
+ * Marker interface that *every* component should implement, so that the central render method appears in a unified way
+ * throughout this framework.
+ *
+ * The render method has to be implemented in order to do the actual rendering of one component.
+ * This reduces the boilerplate code within the corresponding factory function(s):
+ * ```
+ * open class MyComponent: Component {
+ *      override fun render(...) {
+ *          // some content rendering
+ *      }
+ * }
+ *
+ * RenderContext.myComponent(
+ *      // most params omitted
+ *      build: MyComponent.() -> Unit = {}
+ * ) {
+ *      MyComponent().apply(build).render(this, /* params */)
+ *      //                         ^^^^^^
+ *      //                         just start the rendering by one additional call!
+ * }
+ * ```
+ *
+ * Often a component needs *additional* parameters that are passed into the factory functions (remember that those
+ * should be located starting after the ``styling`` parameter in first position and before the ``baseClass`` parameter)
+ * Typical use cases are [Store]s or list of items, as for [RenderContext.checkboxGroup] for example.
+ * Those additional parameters should be passed via contructor injection into the component class:
+ * ```
+ * open class MyComponent(protected val items: List<String>, protected val store: Store<String>?): Component {
+ *      override fun render(...) {
+ *          // some content rendering with access to the ``items`` and the ``store``
+ *      }
+ * }
+ *
+ * RenderContext.myComponent(
+ *      styling: BasicParams.() -> Unit,
+ *      items: List<String>,          // two additional parameters
+ *      store: Store<String>? = null, // after ``styling`` and before ``baseClass``!
+ *      baseClass: StyleClass?,
+ *      id: String?,
+ *      prefix: String
+ *      build: MyComponent.() -> Unit = {}
+ * ) {
+ *      MyComponent(items, store) // inject additional parameters
+ *          .apply(build)
+ *          .render(this, styling, baseClass, id, prefix) // pass context + regular parameters
+ * }
+ * ```
+ */
+interface Component<T> {
+
+    /**
+     * Central method that should do the actual rendering of a component.
+     *
+     * Consider to declare your implementation as ``open`` in order to allow the customization of a component.
+     *
+     * @param context the receiver to render the component into
+     * @param styling a lambda expression for declaring the styling as fritz2's styling DSL
+     * @param baseClass optional CSS class that should be applied to the element
+     * @param id the ID of the element
+     * @param prefix the prefix for the generated CSS class resulting in the form ``$prefix-$hash``
+     */
+    fun render(
+        context: RenderContext,
+        styling: BoxParams.() -> Unit,
+        baseClass: StyleClass?,
+        id: String?,
+        prefix: String
+    ): T
 }
 
-class EventMixin<T : Element> : EventProperties<T> {
-    override val events: ComponentProperty<WithEvents<T>.() -> Unit> = ComponentProperty {}
-}
-
+/**
+ * An interface for exposing an HTML element. Use this vor components that more or less wrap a single basic HTML
+ * tag like ``inputField`` or ``pushButton``.
+ *
+ * The offered [element] property enables the client to access the deeper features of an element even though the
+ * component itself does not offer an appropriate functionality. A client should use this with caution,
+ * as it might massively change the default behaviour of the component!
+ *
+ * Example usage:
+ * ```
+ * // apply interface to a component class
+ * open class SomeComponent : ElementProperties<Div> by ElementMixin() {
+ *                            ^^^^^^^^^^^^^     ^^^     ^^^^^^^^^^^^^^
+ *                            implement the      |      mix in the default implementation
+ *                            interface          |
+ *                                              Expose the underlying element,
+ *                                              in this case a ``Div``!
+ * }
+ *
+ * // use the property offered by the interface
+ * someComponent {
+ *      element {
+ *          // all properties of the ``Div`` element are accessible here
+ *      }
+ * }
+ * ```
+ *
+ * Advice: Try to offer *all* useful properties for a component in a redundant way if the component usage will benefit
+ * from a feature the underlying HTML element offers! This will make it much easier for the client user to use
+ * a component and much easier to read and maintain at client side code.
+ *
+ * RFC: If the component itself offers some redundant property, the values from within the [element] property
+ * context should win and used for the redering! This is the *mandatory* behaviour!
+ */
 interface ElementProperties<T> {
+
+    /**
+     * This property enables the client to access the deeper features of an element even though the component itself
+     * does not offer an appropriate functionality. A client should use this with caution, as it might massively change
+     * the default behaviour of the component!
+     */
     val element: ComponentProperty<T.() -> Unit>
 }
 
+/**
+ * Default implementation of the [ElementProperties] interface in order to apply this as mixin for a component
+ */
 // TODO: Constraint für Typ: T : Tag<E> ?
 class ElementMixin<T> : ElementProperties<T> {
     override val element: ComponentProperty<T.() -> Unit> = ComponentProperty {}
 }
 
+/**
+ * An interface for exposing the events of a component. The type of the underlying HTML element must be specified.
+ * This way *all* events of the wrapped element get exposed to the client via the [events] property.
+ *
+ * Example usage:
+ * ```
+ * // apply interface to a component class
+ * open class SomeComponent : EventProperties<HTMLDivElement> by EventMixin() {
+ *                            ^^^^^^^^^^^^^   ^^^^^^^^^^^^^^     ^^^^^^^^^^^^
+ *                            implement the    |                 mix in the default implementation
+ *                            interface        |
+ *                                            Enables to access the underlying element,
+ *                                            in this case a ``Div`` element in order
+ *                                            to expose or wrap its events!
+ * }
+ *
+ * // use the property offered by the interface
+ * someComponent {
+ *      events {
+ *          // all events of the ``Div`` element are accessible here
+ *          clicks.value handledBy someStore.someHandler
+ *      }
+ * }
+ * ```
+ *
+ * RFC: If your component does not simply wrap some element and expose its events but instead has to offer its custom
+ * and specific events, please offer an ``events`` property by yourself, so that the access remains unified
+ * throughout this framework!
+ */
+interface EventProperties<T : Element> {
+
+    /**
+     * This property enables the client to access *all* events offered by the underlying HTML element.
+     */
+    val events: ComponentProperty<WithEvents<T>.() -> Unit>
+}
+
+/**
+ * Default implementation of the [EventProperties] interface in order to apply this as mixin for a component
+ */
+class EventMixin<T : Element> : EventProperties<T> {
+    override val events: ComponentProperty<WithEvents<T>.() -> Unit> = ComponentProperty {}
+}
+
+/**
+ * This interface add typical state properties for en- or disabling form components.
+ *
+ * As it often depends on the specific use case, the two complementary properties [disabled] and [enabled] are both
+ * offered. This is primarily for better readability at client side code.
+ *
+ * example usage:
+ * ```
+ * // apply interface to component class
+ * open class MyControl : FormProperties by FormMixin() {
+ * }
+ *
+ * // use the property offered by the interface
+ * val disable = storeOf(true)
+ * myControl {
+ *      disabled(disable.value)
+ * }
+ *
+ * // and instead of double negative expression ``val disable = storeOf(false)`` better use:
+ * val enable = storeOf(false)
+ * myControl {
+ *      enabled(enable.value)
+ * }
+ * ```
+ */
 interface FormProperties {
     val disabled: DynamicComponentProperty<Boolean>
 
@@ -77,18 +324,51 @@ interface FormProperties {
     }
 }
 
+/**
+ * Default implementation of the [FormProperties] interface in order to apply this as mixin for a component
+ */
 open class FormMixin : FormProperties {
     override val disabled = DynamicComponentProperty(flowOf(false))
 }
 
+/**
+ * This interface offers a convenience property for input form based components.
+ *
+ * By setting the [readonly] property to ``true`` the component should become readonly.
+ *
+ * Example usage:
+ * ```
+ * open class MyComponent : InputFormProperties by InputFormMixin() {
+ * }
+ *
+ * // use the property offered by the interface
+ * val readonly = storeOf(true)
+ * myControl {
+ *      readonly(readonly.value)
+ * }
+ * ```
+ */
 interface InputFormProperties : FormProperties {
     val readonly: DynamicComponentProperty<Boolean>
 }
 
+/**
+ * Default implementation of the [InputFormProperties] interface in order to apply this as mixin for a component
+ */
 class InputFormMixin : InputFormProperties, FormMixin() {
     override val readonly = DynamicComponentProperty(flowOf(false))
 }
 
+/**
+ * This interface defines convenience properties and helper functions to easily apply [Severity] based behaviour to
+ * a component.
+ *
+ * The property [severity] is offered in order to hold the current severity value.
+ *
+ * In order to reactively apply an appropriate styling based upon the current severity value of the component -
+ * changing the background color for example - the helper function [severityClassOf] helps to choose the corresponding
+ * style bades upon the [SeverityStyles] interface from the [dev.fritz2.styling.theme] package.
+ */
 interface SeverityProperties {
     val severity: NullableDynamicComponentProperty<Severity?>
 
@@ -99,10 +379,48 @@ interface SeverityProperties {
         val error: Severity = Severity.Error
     }
 
+    /**
+     * Property to manage the severity value of the component.
+     * ```
+     * myComponent {
+     *      severity { warning } // often this is passed from a [Flow] of course
+     * }
+     * ```
+     *
+     * @param value mapping expression from a [SeverityContext] to the enumeration value.
+     */
     fun severity(value: SeverityContext.() -> Severity) {
         severity(value(SeverityContext()))
     }
 
+    /**
+     * This function manages the task to map a value of the [Severity] enumeration to a corresponding style defined
+     * within the [SeverityStyles] interface. The severity itself is taken from the [severity] property, so only the
+     * styling interface's implementation has to be injected:
+     * ```
+     * open class MyComponent {
+     *      override fun render(/*...*/, prefix: String) {
+     *          someElement {
+     *              // set fitting severity for example by using a store with validation
+     *              severity(/* get severity from somewhere */)
+     *              // apply the correct style based upon the severity
+     *              className(severityClassOf(Theme().myComponent.severity, prefix))
+     *                                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+     *                                        It's a good idea to offer a
+     *                                        specific property in the
+     *                                        component's theme section
+     *                                        based upon ``SeverityStyles``
+     *          }
+     *      }
+     * }
+     * ```
+     *
+     * @param severityStyle definition for the different stylings for each state
+     * @prefix the prefix for the generated CSS class resulting in the form ``$prefix-severity-{value}``
+     *
+     * @return a flow of the current mapped style class. Can be applied to the component via [className] extension
+     *         method
+     */
     fun severityClassOf(
         severityStyle: SeverityStyles,
         prefix: String
@@ -118,14 +436,46 @@ interface SeverityProperties {
         }
 }
 
+/**
+ * Default implementation of the [SeverityProperties] interface in order to apply this as mixin for a component
+ */
 class SeverityMixin : SeverityProperties {
     override val severity = NullableDynamicComponentProperty<Severity?>(emptyFlow())
 }
 
-interface TextInputFormProperties : InputFormProperties {
-    // TODO Some further properties are equal between input type=text and textarea; could be worth to centralize!
-}
-
+/**
+ * This store can be used for components with an *internal* store that has to deal with a [List] of some type T.
+ *
+ * Use the [toggle] method to add or remove an selected item from the current selection:
+ * ```
+ * val selection = MultiSelectionStore<String>()
+ * lineUp {
+ *     items {
+ *         listOf("One", "Two", "Three", "Four", "Five").forEach { value ->
+ *             box({
+ *                 background { color { info } }
+ *             }) {
+ *                 +value
+ *                 clicks.events.map { value } handledBy selection.toggle
+ *                 //                  ^^^^^                       ^^^^^^
+ *                 //                  pass current value to the ``toggle`` handler!
+ *             }
+ *         }
+ *     }
+ * }
+ * div {
+ *     +"Selection:"
+ *     ul {
+ *         selection.data.renderEach { value ->
+ *             li { +value }
+ *         }
+ *     }
+ * }
+ * ```
+ *
+ * RFC: Never ever expose the internal store directly to the client side! Only accept values or [Flow]s and return
+ * those in order to exchange data with the client!
+ */
 class MultiSelectionStore<T> : RootStore<List<T>>(emptyList()) {
     val toggle = handleAndEmit<T, List<T>> { selectedRows, new ->
         val newSelection = if (selectedRows.contains(new))
@@ -137,6 +487,15 @@ class MultiSelectionStore<T> : RootStore<List<T>>(emptyList()) {
     }
 }
 
+/**
+ * This store can be used for components with an *internal* store that has to deal with a single element *selection*
+ * from a collection of predefined values (like for a [selectField] or [radioGroup] component)
+ *
+ * It is based upon the *index* of an item from the list represented by the [Int] type.
+ *
+ * RFC: Never ever expose the internal store directly to the client side! Only accept values or [Flow]s and return
+ * those in order to exchange data with the client!
+ */
 class SingleSelectionStore : RootStore<Int?>(null) {
     val toggle = handleAndEmit<Int, Int> { _, new ->
         emit(new)
@@ -144,46 +503,60 @@ class SingleSelectionStore : RootStore<Int?>(null) {
     }
 }
 
+/**
+ * This interface offers some convenience properties for adding a close button to a component.
+ *
+ * If offers the possibilities to:
+ * - change the styling of the default appearance
+ * - decide whether there is a close button or not
+ * - change the whole rendering by a custom implementation
+ *
+ * Example integration:
+ * ```
+ * open class MyComponent : Component<Unit>, CloseButtonProperty by CloseButtonMixin(ComponentProperty{})  {
+ * //                                        ^^^^^^^^^^^^^^^^^^^    ^^^^^^^^^^^^^^^^ ^^^^^^^^^^^^^^^^^^^
+ * //                                        implement interface    delegate to      inject empty custom
+ * //                                                               mixin            styling
+ *      override fun render(/* params omitted */) {
+ *          div {
+ *              // check if closeButton is needed and render it then
+ *              if (hasCloseButton.value) {
+ *                  closeButtonRendering.value(this) handledBy closeHandler
+ *                  //                               ^^^^^^^^^^^^^^^^^^^^^^
+ *                  //                               use return value (event)
+ *                  //                               to handle it by your closing mechanism
+ *              }
+ *          }
+ *      }
+ * }
+ * ```
+ *
+ * For some example usages, have a look at the following components:
+ * @see [ModalComponent]
+ * @see [PopoverComponent]
+ * @see [ToastComponent]
+ */
 interface CloseButtonProperty {
     val prefix: String
-    val hasCloseButton: ComponentProperty<Boolean>
-    val closeButton: ComponentProperty<(RenderContext.(SimpleHandler<Unit>) -> Unit)?>
     val closeButtonStyle: ComponentProperty<Style<BasicParams>>
-
-    fun closeButton(
-        styling: BasicParams.() -> Unit = {},
-        baseClass: StyleClass? = null,
-        id: String? = null,
-        prefix: String = this.prefix,
-        build: PushButtonComponent.() -> Unit = {}
-    )
+    val hasCloseButton: ComponentProperty<Boolean>
+    val closeButtonRendering: ComponentProperty<RenderContext.() -> Listener<MouseEvent, HTMLElement>>
 }
 
+/**
+ * Default implementation of the [CloseButtonProperty] interface in order to apply this as mixin for a component
+ */
 class CloseButtonMixin(
-    override val closeButtonStyle: ComponentProperty<Style<BasicParams>>,
-    override val prefix: String = "close-button"
+    override val prefix: String = "close-button",
+    override val closeButtonStyle: ComponentProperty<Style<BasicParams>>
 ) : CloseButtonProperty {
-
     override val hasCloseButton = ComponentProperty(true)
-
-    override val closeButton = ComponentProperty<(RenderContext.(SimpleHandler<Unit>) -> Unit)?>(null)
-
-    override fun closeButton(
-        styling: BasicParams.() -> Unit,
-        baseClass: StyleClass?,
-        id: String?,
-        prefix: String,
-        build: PushButtonComponent.() -> Unit
-    ) {
-        closeButton { closeHandle ->
-            clickButton({
-                closeButtonStyle.value()
-                styling()
-            }, baseClass, id, prefix) {
-                variant { ghost }
-                icon { fromTheme { close } }
-                build()
-            }.map { } handledBy closeHandle
+    override val closeButtonRendering = ComponentProperty<RenderContext.() -> Listener<MouseEvent, HTMLElement>> {
+        clickButton({
+            closeButtonStyle.value()
+        }, id = "close-button-${uniqueId()}", prefix = prefix) {
+            variant { ghost }
+            icon { fromTheme { close } }
         }
     }
 }

--- a/components/src/jsMain/kotlin/dev/fritz2/components/formcontrol.kt
+++ b/components/src/jsMain/kotlin/dev/fritz2/components/formcontrol.kt
@@ -9,6 +9,8 @@ import dev.fritz2.components.validation.validationMessages
 import dev.fritz2.dom.html.RenderContext
 import dev.fritz2.styling.StyleClass
 import dev.fritz2.styling.params.BasicParams
+import dev.fritz2.styling.params.BoxParams
+import dev.fritz2.styling.params.FlexParams
 import dev.fritz2.styling.params.Style
 import dev.fritz2.styling.params.styled
 import dev.fritz2.styling.theme.FormSizes
@@ -54,7 +56,7 @@ import selectField
  *
  */
 @ComponentMarker
-open class FormControlComponent : FormProperties by FormMixin() {
+open class FormControlComponent : Component<Unit>, FormProperties by FormMixin() {
     companion object {
         object ControlNames {
             const val inputField = "inputField"
@@ -374,24 +376,24 @@ open class FormControlComponent : FormProperties by FormMixin() {
         )
     }
 
-    fun render(
-        styling: BasicParams.() -> Unit = {},
-        baseClass: StyleClass? = null,
-        id: String? = null,
-        prefix: String = "formControl",
-        renderContext: RenderContext
+    override fun render(
+        context: RenderContext,
+        styling: BoxParams.() -> Unit,
+        baseClass: StyleClass?,
+        id: String?,
+        prefix: String
     ) {
         control.assignee?.second?.let {
             renderStrategies[control.assignee?.first]?.render(
                 {
                     styling()
-                }, baseClass, id, prefix, renderContext, it
+                }, baseClass, id, prefix, context, it
             )
         }
         control.assert()
     }
 
-    fun renderHelperText(renderContext: RenderContext) {
+    open fun renderHelperText(renderContext: RenderContext) {
         renderContext.apply {
             helperText.value?.let {
                 (::p.styled {
@@ -401,7 +403,7 @@ open class FormControlComponent : FormProperties by FormMixin() {
         }
     }
 
-    fun renderValidationMessages(renderContext: RenderContext) {
+    open fun renderValidationMessages(renderContext: RenderContext) {
         renderContext.apply {
             stackUp({
                 width { "100%" }
@@ -418,40 +420,12 @@ open class FormControlComponent : FormProperties by FormMixin() {
                 }
             }
         }
-
-
-        /*
-        renderContext.apply {
-            stackUp {
-                items {
-                    val stack = this
-                    this@FormControlComponent.validationMessagesBuilder?.invoke()?.messages?.render { messages ->
-                        messages.forEach {
-                            this@FormControlComponent.validationMessageRendering.value.invoke(stack, it)
-                        }
-                    }
-                }
-            }
-        }
-         */
-        /*
-        renderContext.div {
-            validationMessagesBuilder?.invoke()?.messages?.renderEach {
-                stackUp {
-                    items {
-                        this@FormControlComponent.validationMessageRendering.value(this, it)
-                    }
-                }
-            }
-        }
-
-         */
     }
 }
 
 interface ControlRenderer {
     fun render(
-        styling: BasicParams.() -> Unit = {},
+        styling: BoxParams.() -> Unit = {},
         baseClass: StyleClass? = null,
         id: String? = null,
         prefix: String = "formControl",
@@ -462,7 +436,7 @@ interface ControlRenderer {
 
 class SingleControlRenderer(private val component: FormControlComponent) : ControlRenderer {
     override fun render(
-        styling: BasicParams.() -> Unit,
+        styling: BoxParams.() -> Unit,
         baseClass: StyleClass?,
         id: String?,
         prefix: String,
@@ -474,7 +448,7 @@ class SingleControlRenderer(private val component: FormControlComponent) : Contr
                 alignItems { start }
                 width { full }
                 component.ownSize()()
-                styling()
+                styling(this as BoxParams)
             },
             baseClass = baseClass,
             id = id,
@@ -498,7 +472,7 @@ class SingleControlRenderer(private val component: FormControlComponent) : Contr
 
 class ControlGroupRenderer(private val component: FormControlComponent) : ControlRenderer {
     override fun render(
-        styling: BasicParams.() -> Unit,
+        styling: BoxParams.() -> Unit,
         baseClass: StyleClass?,
         id: String?,
         prefix: String,
@@ -598,7 +572,6 @@ fun RenderContext.formControl(
     prefix: String = "formControl",
     build: FormControlComponent.() -> Unit = {}
 ) {
-    val component = FormControlComponent().apply(build)
-    component.render(styling, baseClass, id, prefix, this)
+    FormControlComponent().apply(build).render(this, styling, baseClass, id, prefix)
 }
 

--- a/components/src/jsMain/kotlin/dev/fritz2/components/input.kt
+++ b/components/src/jsMain/kotlin/dev/fritz2/components/input.kt
@@ -8,6 +8,7 @@ import dev.fritz2.dom.values
 import dev.fritz2.styling.StyleClass
 import dev.fritz2.styling.StyleClass.Companion.plus
 import dev.fritz2.styling.className
+import dev.fritz2.styling.params.BoxParams
 import dev.fritz2.styling.params.BasicParams
 import dev.fritz2.styling.params.Style
 import dev.fritz2.styling.params.styled
@@ -28,7 +29,8 @@ import org.w3c.dom.HTMLInputElement
  *  * For a detailed explanation and examples of usage have a look at the [inputField] function!
  */
 @ComponentMarker
-open class InputFieldComponent :
+open class InputFieldComponent(protected val store: Store<String>?) :
+    Component<Unit>,
     EventProperties<HTMLInputElement> by EventMixin(),
     ElementProperties<Input> by ElementMixin(),
     InputFormProperties by InputFormMixin(),
@@ -103,6 +105,36 @@ open class InputFieldComponent :
     val placeholder = DynamicComponentProperty(flowOf(""))
     val type = DynamicComponentProperty(flowOf(""))
     val step = DynamicComponentProperty(flowOf(""))
+
+    override fun render(
+        context: RenderContext,
+        styling: BoxParams.() -> Unit,
+        baseClass: StyleClass?,
+        id: String?,
+        prefix: String
+    ) {
+        context.apply {
+            (::input.styled(styling, baseClass + staticCss, id, prefix) {
+                size.value.invoke(Theme().input.sizes)()
+                variant.value.invoke(Theme().input.variants)()
+                basicInputStyles()
+            }) {
+                disabled(disabled.values)
+                readOnly(readonly.values)
+                placeholder(placeholder.values)
+                value(value.values)
+                type(type.values)
+                step(step.values)
+                className(severityClassOf(Theme().input.severity, prefix))
+                store?.let {
+                    value(it.data)
+                    changes.values() handledBy it.update
+                }
+                events.value.invoke(this)
+                element.value.invoke(this)
+            }
+        }
+    }
 }
 
 
@@ -172,25 +204,5 @@ fun RenderContext.inputField(
     prefix: String = "inputField",
     build: InputFieldComponent.() -> Unit = {}
 ) {
-    val component = InputFieldComponent().apply(build)
-
-    (::input.styled(styling, baseClass + InputFieldComponent.staticCss, id, prefix) {
-        component.size.value.invoke(Theme().input.sizes)()
-        component.variant.value.invoke(Theme().input.variants)()
-        InputFieldComponent.basicInputStyles()
-    }) {
-        disabled(component.disabled.values)
-        readOnly(component.readonly.values)
-        placeholder(component.placeholder.values)
-        value(component.value.values)
-        type(component.type.values)
-        step(component.step.values)
-        className(component.severityClassOf(Theme().input.severity, prefix))
-        store?.let {
-            value(it.data)
-            changes.values() handledBy it.update
-        }
-        component.events.value.invoke(this)
-        component.element.value.invoke(this)
-    }
+    InputFieldComponent(store).apply(build).render(this, styling, baseClass, id, prefix)
 }

--- a/components/src/jsMain/kotlin/dev/fritz2/components/nav.kt
+++ b/components/src/jsMain/kotlin/dev/fritz2/components/nav.kt
@@ -5,6 +5,7 @@ import dev.fritz2.dom.stopImmediatePropagation
 import dev.fritz2.styling.StyleClass
 import dev.fritz2.styling.name
 import dev.fritz2.styling.params.BasicParams
+import dev.fritz2.styling.params.BoxParams
 import dev.fritz2.styling.params.styled
 import dev.fritz2.styling.staticStyle
 import dev.fritz2.styling.theme.Theme
@@ -27,7 +28,7 @@ import org.w3c.dom.events.MouseEvent
  * not meant to be called directly unless you plan to implement your own navLink.
  */
 @ExperimentalCoroutinesApi
-open class NavLinkComponent {
+open class NavLinkComponent : Component<Listener<MouseEvent, HTMLElement>> {
     companion object {
         val activeStyle = staticStyle("navlink-active") {
             Theme().appFrame.activeNavLink()
@@ -35,9 +36,39 @@ open class NavLinkComponent {
     }
 
     val icon = ComponentProperty<IconComponent.() -> Unit> { fromTheme { bookmark } }
-    val text = DynamicComponentProperty<String>(flowOf("Navigation Link"))
+    val text = DynamicComponentProperty(flowOf("Navigation Link"))
     val active = ComponentProperty<Flow<Boolean>?>(null)
+
+    override fun render(
+        context: RenderContext,
+        styling: BoxParams.() -> Unit,
+        baseClass: StyleClass?,
+        id: String?,
+        prefix: String
+    ): Listener<MouseEvent, HTMLElement> {
+        var clickEvents: Listener<MouseEvent, HTMLElement>? = null
+
+        context.apply {
+            lineUp({
+                Theme().appFrame.navLink()
+                styling(this as BoxParams)
+            }, baseClass, id, prefix) {
+                spacing { small }
+                items {
+                    active.value?.let { className(activeStyle.whenever(it).name) }
+                    icon(build = icon.value)
+                    a { text.values.asText() }
+                }
+                events {
+                    clickEvents = clicks.stopImmediatePropagation()
+                }
+            }
+        }
+
+        return clickEvents!!
+    }
 }
+
 
 /**
  * This component generates a navigation link inside the [appFrame]'s sidebar.
@@ -63,28 +94,9 @@ fun RenderContext.navLink(
     id: String? = null,
     prefix: String = "navlink",
     build: NavLinkComponent.() -> Unit = {}
-): Listener<MouseEvent, HTMLElement> {
-    val component = NavLinkComponent().apply(build)
-    var clickEvents: Listener<MouseEvent, HTMLElement>? = null
+): Listener<MouseEvent, HTMLElement> = NavLinkComponent().apply(build)
+    .render(this, styling, baseClass, id, prefix)
 
-    lineUp({
-        Theme().appFrame.navLink()
-        styling()
-    }, baseClass, id, prefix) {
-        spacing { small }
-        items {
-            component.active.value?.let { className(NavLinkComponent.activeStyle.whenever(it).name) }
-            icon(build = component.icon.value)
-            a { component.text.values.asText() }
-        }
-        events {
-            clickEvents = clicks.stopImmediatePropagation()
-        }
-
-    }
-
-    return clickEvents!!
-}
 
 /**
  * This component generates a navigation section header inside the [appFrame]'s sidebar.

--- a/components/src/jsMain/kotlin/dev/fritz2/components/radioGroup.kt
+++ b/components/src/jsMain/kotlin/dev/fritz2/components/radioGroup.kt
@@ -6,6 +6,7 @@ import dev.fritz2.dom.states
 import dev.fritz2.identification.uniqueId
 import dev.fritz2.styling.StyleClass
 import dev.fritz2.styling.params.BasicParams
+import dev.fritz2.styling.params.BoxParams
 import dev.fritz2.styling.params.Style
 import dev.fritz2.styling.params.styled
 import dev.fritz2.styling.theme.FormSizes
@@ -65,7 +66,11 @@ import kotlinx.coroutines.flow.map
  * ```
  */
 @ComponentMarker
-class RadioGroupComponent<T> : InputFormProperties by InputFormMixin(), SeverityProperties by SeverityMixin() {
+open class RadioGroupComponent<T>(protected val items: List<T>, protected val store: Store<T>? = null) :
+    Component<Unit>,
+    InputFormProperties by InputFormMixin(),
+    SeverityProperties by SeverityMixin() {
+
     companion object {
         object RadioGroupLayouts {
             val column: Style<BasicParams> = {
@@ -95,6 +100,48 @@ class RadioGroupComponent<T> : InputFormProperties by InputFormMixin(), Severity
     }
 
     val events = ComponentProperty<EventsContext<T>.() -> Unit> {}
+
+    override fun render(
+        context: RenderContext,
+        styling: BoxParams.() -> Unit,
+        baseClass: StyleClass?,
+        id: String?,
+        prefix: String
+    ) {
+        val internalStore = SingleSelectionStore()
+        val grpId = id ?: uniqueId()
+
+        context.apply {
+            (::div.styled(styling, baseClass, id, prefix) {
+                direction.value(RadioGroupLayouts)()
+            }) {
+                (store?.data ?: selectedItem.values)
+                    .map { selectedItem ->
+                        items.indexOf(selectedItem).let { if (it == -1) null else it }
+                    } handledBy internalStore.update
+
+                items.withIndex().forEach { (index, item) ->
+                    val checkedFlow = internalStore.data.map { it == index }.distinctUntilChanged()
+                    radio(styling = itemStyle.value, id = grpId + "-grp-item-" + uniqueId()) {
+                        this.size { this@RadioGroupComponent.size.value.invoke(Theme().radio.sizes) }
+                        labelStyle(labelStyle.value)
+                        selectedStyle(selectedStyle.value)
+                        label(this@RadioGroupComponent.label.value(item))
+                        selected(checkedFlow)
+                        disabled(this@RadioGroupComponent.disabled.values)
+                        severity(severity.values)
+                        events {
+                            changes.states().map { index } handledBy internalStore.toggle
+                        }
+                    }
+                }
+            }
+            EventsContext(internalStore.toggle.map { items[it] }).apply {
+                events.value(this)
+                store?.let { selected handledBy it.update }
+            }
+        }
+    }
 }
 
 
@@ -135,37 +182,5 @@ fun <T> RenderContext.radioGroup(
     prefix: String = "radioGroupComponent",
     build: RadioGroupComponent<T>.() -> Unit = {}
 ) {
-    val component = RadioGroupComponent<T>().apply(build)
-    val internalStore = SingleSelectionStore()
-
-    val grpId = id ?: uniqueId()
-    (::div.styled(styling, baseClass, id, prefix) {
-        component.direction.value(RadioGroupComponent.Companion.RadioGroupLayouts)()
-    }) {
-        (store?.data ?: component.selectedItem.values)
-            .map { selectedItem ->
-                items.indexOf(selectedItem).let { if (it == -1) null else it }
-            } handledBy internalStore.update
-
-        items.withIndex().forEach { (index, item) ->
-            val checkedFlow = internalStore.data.map { it == index }.distinctUntilChanged()
-            radio(styling = component.itemStyle.value, id = grpId + "-grp-item-" + uniqueId()) {
-                size { component.size.value.invoke(Theme().radio.sizes) }
-                labelStyle(component.labelStyle.value)
-                selectedStyle(component.selectedStyle.value)
-                label(component.label.value(item))
-                selected(checkedFlow)
-                disabled(component.disabled.values)
-                severity(component.severity.values)
-                events {
-                    changes.states().map { index } handledBy internalStore.toggle
-                }
-            }
-        }
-
-        RadioGroupComponent.EventsContext(internalStore.toggle.map { items[it] }).apply {
-            component.events.value(this)
-            store?.let { selected handledBy it.update }
-        }
-    }
+    RadioGroupComponent(items, store).apply(build).render(this, styling, baseClass, id, prefix)
 }

--- a/components/src/jsMain/kotlin/dev/fritz2/components/select.kt
+++ b/components/src/jsMain/kotlin/dev/fritz2/components/select.kt
@@ -7,6 +7,7 @@ import dev.fritz2.styling.StyleClass
 import dev.fritz2.styling.StyleClass.Companion.plus
 import dev.fritz2.styling.className
 import dev.fritz2.styling.params.BasicParams
+import dev.fritz2.styling.params.BoxParams
 import dev.fritz2.styling.params.Style
 import dev.fritz2.styling.params.styled
 import dev.fritz2.styling.staticStyle
@@ -32,7 +33,10 @@ import kotlinx.coroutines.flow.map
  *  For a detailed explanation and examples of usage, have a look at the [selectField] function itself.
  */
 @ComponentMarker
-class SelectFieldComponent<T> : InputFormProperties by InputFormMixin(), SeverityProperties by SeverityMixin() {
+open class SelectFieldComponent<T>(protected val items: List<T>, protected val store: Store<T>? = null) :
+    Component<Unit>,
+    InputFormProperties by InputFormMixin(),
+    SeverityProperties by SeverityMixin() {
 
     companion object {
         val staticCss = staticStyle(
@@ -121,6 +125,73 @@ class SelectFieldComponent<T> : InputFormProperties by InputFormMixin(), Severit
     }
 
     val events = ComponentProperty<EventsContext<T>.() -> Unit> {}
+
+    override fun render(
+        context: RenderContext,
+        styling: BoxParams.() -> Unit,
+        baseClass: StyleClass?,
+        id: String?,
+        prefix: String
+    ) {
+        val internalStore = SingleSelectionStore()
+
+        val grpId = id ?: uniqueId()
+
+        context.apply {
+            (store?.data ?: selectedItem.values)
+                .map { selectedItem ->
+                    items.indexOf(selectedItem).let { if (it == -1) null else it }
+                } handledBy internalStore.update
+
+            (::div.styled(styling, baseClass + staticCss, grpId, prefix) {}){
+
+                (::select.styled(styling, baseClass) {
+                    basicSelectStyles()
+                    variant.value.invoke(Theme().select.variants)()
+                    size.value.invoke(Theme().select.sizes)()
+                }){
+                    disabled(disabled.values)
+
+                    internalStore.data.render {
+                        if (it == null) {
+                            option {
+                                value("null")
+                                selected(true)
+                                +placeholder.value
+                            }
+                        }
+                    }
+
+                    items.withIndex().forEach { (index, item) ->
+                        val checkedFlow = internalStore.data.map { it == index }.distinctUntilChanged()
+                        option {
+                            value(index.toString())
+                            selected(checkedFlow)
+                            +label.value(item)
+                        }
+                    }
+
+                    className(severityClassOf(Theme().select.severity, prefix))
+
+                    changes.selectedValue().map { it.toInt() } handledBy internalStore.toggle
+                }
+
+                (::div.styled(prefix = "icon-wrapper") {
+                    size.value.invoke(Theme().select.sizes)()
+                    iconWrapperStyle()
+                }){
+                    icon({
+                        iconStyle()
+                    }) { def(icon.value(Theme().icons)) }
+                }
+            }
+
+            EventsContext(internalStore.toggle.map { items[it] }).apply {
+                events.value(this)
+                store?.let { selected handledBy it.update }
+            }
+        }
+    }
 }
 
 /**
@@ -182,61 +253,5 @@ fun <T> RenderContext.selectField(
     prefix: String = "selectField",
     build: SelectFieldComponent<T>.() -> Unit,
 ) {
-    val component = SelectFieldComponent<T>().apply(build)
-    val internalStore = SingleSelectionStore()
-
-    val grpId = id ?: uniqueId()
-
-    (store?.data ?: component.selectedItem.values)
-        .map { selectedItem ->
-            items.indexOf(selectedItem).let { if (it == -1) null else it }
-        } handledBy internalStore.update
-
-    (::div.styled(styling, baseClass + SelectFieldComponent.staticCss, grpId, prefix) {}){
-
-        (::select.styled(styling, baseClass) {
-            component.basicSelectStyles()
-            component.variant.value.invoke(Theme().select.variants)()
-            component.size.value.invoke(Theme().select.sizes)()
-        }){
-            disabled(component.disabled.values)
-
-            internalStore.data.render {
-                if (it == null) {
-                    option {
-                        value("null")
-                        selected(true)
-                        +component.placeholder.value
-                    }
-                }
-            }
-
-            items.withIndex().forEach { (index, item) ->
-                val checkedFlow = internalStore.data.map { it == index }.distinctUntilChanged()
-                option {
-                    value(index.toString())
-                    selected(checkedFlow)
-                    +component.label.value(item)
-                }
-            }
-
-            className(component.severityClassOf(Theme().select.severity, prefix))
-
-            changes.selectedValue().map { it.toInt() } handledBy internalStore.toggle
-        }
-
-        (::div.styled(prefix = "icon-wrapper") {
-            component.size.value.invoke(Theme().select.sizes)()
-            component.iconWrapperStyle()
-        }){
-            icon({
-                component.iconStyle()
-            }) { def(component.icon.value(Theme().icons)) }
-        }
-    }
-
-    SelectFieldComponent.EventsContext(internalStore.toggle.map { items[it] }).apply {
-        component.events.value(this)
-        store?.let { selected handledBy it.update }
-    }
+    SelectFieldComponent<T>(items, store).apply(build).render(this, styling, baseClass, id, prefix)
 }

--- a/components/src/jsMain/kotlin/dev/fritz2/components/stack.kt
+++ b/components/src/jsMain/kotlin/dev/fritz2/components/stack.kt
@@ -5,6 +5,7 @@ import dev.fritz2.dom.html.RenderContext
 import dev.fritz2.styling.StyleClass
 import dev.fritz2.styling.StyleClass.Companion.plus
 import dev.fritz2.styling.params.FlexParams
+import dev.fritz2.styling.params.BoxParams
 import dev.fritz2.styling.params.ScaledValueProperty
 import dev.fritz2.styling.params.Style
 import dev.fritz2.styling.staticStyle
@@ -64,7 +65,7 @@ import org.w3c.dom.HTMLDivElement
  *  ```
  */
 @ComponentMarker
-abstract class StackComponent : EventProperties<HTMLDivElement> by EventMixin() {
+abstract class StackComponent : Component<Div>, EventProperties<HTMLDivElement> by EventMixin() {
     companion object {
         val staticCss = staticStyle(
             "stack",
@@ -77,6 +78,20 @@ abstract class StackComponent : EventProperties<HTMLDivElement> by EventMixin() 
     val items = ComponentProperty<(RenderContext.() -> Unit)> {}
 
     abstract val stackStyles: Style<FlexParams>
+
+    override fun render(
+        context: RenderContext,
+        styling: BoxParams.() -> Unit,
+        baseClass: StyleClass?,
+        id: String?,
+        prefix: String
+    ) = context.flexBox({
+        stackStyles()
+        styling(this as BoxParams)
+    }, baseClass = baseClass + staticCss, prefix = prefix, id = id) {
+        items.value(this)
+        events.value(this)
+    }
 }
 
 
@@ -142,17 +157,8 @@ fun RenderContext.stackUp(
     id: String? = null,
     prefix: String = "stack-up",
     build: StackUpComponent.() -> Unit = {}
-): Div {
-    val component = StackUpComponent().apply(build)
+): Div = StackUpComponent().apply(build).render(this, styling, baseClass, id, prefix)
 
-    return flexBox({
-        component.stackStyles()
-        styling()
-    }, baseClass = baseClass + StackComponent.staticCss, prefix = prefix, id = id) {
-        component.items.value(this)
-        component.events.value(this)
-    }
-}
 
 /**
  * This component class just defines the core styling in order to render child items within a flexBox layout
@@ -217,14 +223,4 @@ fun RenderContext.lineUp(
     id: String? = null,
     prefix: String = "line-up",
     build: LineUpComponent.() -> Unit = {}
-): Div {
-    val component = LineUpComponent().apply(build)
-
-    return flexBox({
-        component.stackStyles()
-        styling()
-    }, baseClass = baseClass + StackComponent.staticCss, prefix = prefix, id = id) {
-        component.items.value(this)
-        component.events.value(this)
-    }
-}
+): Div = LineUpComponent().apply(build).render(this, styling, baseClass, id, prefix)

--- a/components/src/jsMain/kotlin/dev/fritz2/components/textarea.kt
+++ b/components/src/jsMain/kotlin/dev/fritz2/components/textarea.kt
@@ -8,6 +8,7 @@ import dev.fritz2.styling.StyleClass
 import dev.fritz2.styling.StyleClass.Companion.plus
 import dev.fritz2.styling.className
 import dev.fritz2.styling.params.BasicParams
+import dev.fritz2.styling.params.BoxParams
 import dev.fritz2.styling.params.Style
 import dev.fritz2.styling.params.styled
 import dev.fritz2.styling.staticStyle
@@ -33,7 +34,8 @@ import org.w3c.dom.HTMLTextAreaElement
  *
  */
 @ComponentMarker
-class TextAreaComponent :
+open class TextAreaComponent(protected val store: Store<String>? = null) :
+    Component<Unit>,
     EventProperties<HTMLTextAreaElement> by EventMixin(),
     ElementProperties<TextArea> by ElementMixin(),
     InputFormProperties by InputFormMixin(),
@@ -87,6 +89,35 @@ class TextAreaComponent :
     val placeholder = DynamicComponentProperty(flowOf(""))
     val resizeBehavior = ComponentProperty<TextAreaResize.() -> Style<BasicParams>> { Theme().textArea.resize.vertical }
     val size = ComponentProperty<FormSizes.() -> Style<BasicParams>> { Theme().textArea.sizes.normal }
+
+    override fun render(
+        context: RenderContext,
+        styling: BoxParams.() -> Unit,
+        baseClass: StyleClass?,
+        id: String?,
+        prefix: String
+    ) {
+        context.apply {
+            (::textarea.styled(styling, baseClass + staticCss, id, prefix) {
+                resizeBehavior.value.invoke(Theme().textArea.resize)()
+                size.value.invoke(Theme().textArea.sizes)()
+                basicInputStyles()
+
+            }){
+                disabled(disabled.values)
+                readOnly(readonly.values)
+                placeholder(placeholder.values)
+                value(value.values)
+                className(severityClassOf(Theme().textArea.severity, prefix))
+                store?.let {
+                    value(it.data)
+                    changes.values() handledBy it.update
+                }
+                events.value.invoke(this)
+                element.value.invoke(this)
+            }
+        }
+    }
 }
 
 /**
@@ -156,25 +187,5 @@ fun RenderContext.textArea(
     prefix: String = "textArea",
     build: TextAreaComponent.() -> Unit
 ) {
-
-    val component = TextAreaComponent().apply(build)
-
-    (::textarea.styled(styling, baseClass + TextAreaComponent.staticCss, id, prefix) {
-        component.resizeBehavior.value.invoke(Theme().textArea.resize)()
-        component.size.value.invoke(Theme().textArea.sizes)()
-        component.basicInputStyles()
-
-    }){
-        disabled(component.disabled.values)
-        readOnly(component.readonly.values)
-        placeholder(component.placeholder.values)
-        value(component.value.values)
-        className(component.severityClassOf(Theme().textArea.severity, prefix))
-        store?.let {
-            value(it.data)
-            changes.values() handledBy it.update
-        }
-        component.events.value.invoke(this)
-        component.element.value.invoke(this)
-    }
+    TextAreaComponent(store).apply(build).render(this, styling, baseClass, id, prefix)
 }

--- a/components/src/jsMain/kotlin/dev/fritz2/components/toast.kt
+++ b/components/src/jsMain/kotlin/dev/fritz2/components/toast.kt
@@ -3,18 +3,13 @@ package dev.fritz2.components
 import dev.fritz2.binding.RootStore
 import dev.fritz2.binding.SimpleHandler
 import dev.fritz2.binding.invoke
-import dev.fritz2.components.Position.bottom
-import dev.fritz2.components.Position.bottomLeft
-import dev.fritz2.components.Position.bottomRight
-import dev.fritz2.components.Position.top
-import dev.fritz2.components.Position.topLeft
-import dev.fritz2.components.Position.topRight
 import dev.fritz2.components.ToastComponent.Companion.closeAllToasts
 import dev.fritz2.components.ToastComponent.Companion.closeLastToast
 import dev.fritz2.dom.html.*
 import dev.fritz2.identification.uniqueId
 import dev.fritz2.styling.StyleClass
 import dev.fritz2.styling.params.BasicParams
+import dev.fritz2.styling.params.BoxParams
 import dev.fritz2.styling.params.ColorProperty
 import dev.fritz2.styling.params.Style
 import dev.fritz2.styling.params.styled
@@ -23,21 +18,6 @@ import dev.fritz2.styling.theme.*
 import kotlinx.coroutines.*
 import kotlinx.coroutines.flow.map
 
-
-private const val defaultToastContainerPrefix = "ul-toast-container"
-private const val defaultInnerToastPrefix = "toast-inner"
-
-object Position {
-
-    const val bottom = "bottom"
-    const val bottomLeft = "bottomLeft"
-    const val bottomRight = "bottomRight"
-    const val top = "top"
-    const val topLeft = "topLeft"
-    const val topRight = "topRight"
-
-    val positionList = listOf(bottom, bottomLeft, bottomRight, top, topLeft, topRight)
-}
 
 /**
  * This class combines the _configuration_ and the core styling of a toast.
@@ -51,12 +31,15 @@ object Position {
  * - content : actual content of the toast, e.g. some text or an icon.
  *
  * In order to avoid having to build the toast's content manually, it is recommended to use toasts in combination with
- * alerts. This can be done by providing an [AlertComponent] as the toast's content or by using one of the convenience
- * methods provided, such as [alertToast] or [showAlertToast]:
+ * alerts. This can be done by providing an [AlertComponent] as the toast's content.
  * ```
- * showAlertToast {
- *     title("Alert-Toast")
- *     content("This is a test-alert in a toast.")
+ * showToast {
+ *     content {
+ *          alert {
+ *              title("Alert-Toast")
+ *              content("This is a test-alert in a toast.")
+ *          }
+ *     }
  *     severity { success }
  *     variant { leftAccent }
  * }
@@ -84,23 +67,35 @@ object Position {
  *      text("closeAll")
  * } handledBy ToastComponent.closeAllToasts()
  * ```
- *
- * @param styling lambda expression for declaring the styling of the toast using fritz2's styling DSL
- * @param baseClass optional CSS class that should be applied to the toast element
- * @param id ID of the toast element, a unique id will be generated if no ID is specified
- * @param prefix prefix for the generated CSS class of the toast element resulting in the form ``$prefix-$hash``
  */
 @ComponentMarker
-class ToastComponent(
-    private val styling: BasicParams.() -> Unit = {},
-    private val baseClass: StyleClass? = null,
-    id: String? = null,
-    private val prefix: String = defaultInnerToastPrefix
-) {
+open class ToastComponent : Component<Unit>,
+    CloseButtonProperty by CloseButtonMixin(
+        "toast-close-button",
+        ComponentProperty(Theme().toast.closeButton.close)
+    ) {
 
-    object ToastStore : RootStore<List<ToastComponent>>(listOf(), id = "toast-store") {
+    object Placement {
 
-        val add = handle<ToastComponent> { allToasts, newToast ->
+        const val bottom = "bottom"
+        const val bottomLeft = "bottomLeft"
+        const val bottomRight = "bottomRight"
+        const val top = "top"
+        const val topLeft = "topLeft"
+        const val topRight = "topRight"
+
+        val placements = listOf(bottom, bottomLeft, bottomRight, top, topLeft, topRight)
+    }
+
+    data class ToastFragment(
+        val id: String,
+        val placement: String,
+        val render: RenderContext.() -> Li
+    )
+
+    object ToastStore : RootStore<List<ToastFragment>>(listOf(), id = "toast-store") {
+
+        val add = handle<ToastFragment> { allToasts, newToast ->
             allToasts + newToast
         }
 
@@ -163,69 +158,28 @@ class ToastComponent(
 
         private val job = Job()
         private val globalId = "f2c-modals-${randomId()}"
+        const val defaultToastContainerPrefix = "ul-toast-container"
 
         init {
             // Rendering of the toast container hosting all toast messages.
             globalRenderContext(globalId, job).apply {
-                Position.positionList.forEach {
+                Placement.placements.forEach {
                     val placementStyle = when (it) {
-                        bottom -> Theme().toast.placement.bottom
-                        bottomLeft -> Theme().toast.placement.bottomLeft
-                        bottomRight -> Theme().toast.placement.bottomRight
-                        top -> Theme().toast.placement.top
-                        topLeft -> Theme().toast.placement.topLeft
-                        topRight -> Theme().toast.placement.topRight
+                        Placement.bottom -> Theme().toast.placement.bottom
+                        Placement.bottomLeft -> Theme().toast.placement.bottomLeft
+                        Placement.bottomRight -> Theme().toast.placement.bottomRight
+                        Placement.top -> Theme().toast.placement.top
+                        Placement.topLeft -> Theme().toast.placement.topLeft
+                        Placement.topRight -> Theme().toast.placement.topRight
                         else -> Theme().toast.placement.bottom
                     }
 
-                    (::ul.styled(toastContainerStaticCss, id, defaultToastContainerPrefix) {
+                    (::ul.styled(toastContainerStaticCss, uniqueId(), defaultToastContainerPrefix) {
                         placementStyle()
                     }){
                         ToastStore.data
-                            .map { toasts -> toasts.filter { toast -> toast.position == it } }
-                            .renderEach { toast -> renderToast(toast) }
-                    }
-                }
-            }
-        }
-
-        private fun RenderContext.renderToast(toast: ToastComponent): Li {
-
-            if (toast.isCloseable)
-                toast.closeButton()
-
-            (MainScope() + job).launch {
-                delay(toast.duration)
-                ToastStore.remove(toast.id)
-            }
-
-            return (::li.styled(toast.baseClass, toast.id, toast.prefix) {
-                listStyle()
-                alignItems { center }
-            }){
-                (::div.styled {
-                    toastStyle()
-                    background { color(toast.background) }
-                    alignItems { center }
-                    toast.styling()
-                }){
-                    toast.content?.let {
-                        (::div.styled {
-                            css("flex: 1 1 0%;")
-                        }) {
-                            toast.content?.invoke(this)
-                        }
-                    }
-                    toast.closeButton?.let {
-                        (::div.styled {
-                            position {
-                                absolute {
-                                    right { small }
-                                }
-                            }
-                        }) {
-                            toast.closeButton?.invoke(this)
-                        }
+                            .map { toasts -> toasts.filter { toast -> toast.placement == it } }
+                            .renderEach { toast -> toast.render(this) }
                     }
                 }
             }
@@ -252,87 +206,63 @@ class ToastComponent(
         }
     }
 
-
-    val id: String = id ?: uniqueId()
-
-
-    private var content: (RenderContext.() -> Unit)? = null
-
-    fun content(value: RenderContext.() -> Unit) {
-        content = value
-    }
-
-    private var position: String = bottomRight
-
-    fun position(value: String) {
-        position = value
-    }
-
-    fun position(value: Position.() -> String) {
-        position = Position.value()
-    }
-
-    private var duration: Long = 5000L
-
-    @Suppress("unused")
-    fun duration(value: () -> Long) {
-        duration = value()
-    }
-
-    @Suppress("unused")
-    fun duration(value: Long) {
-        duration = value
-    }
-
-    private var background: Colors.() -> ColorProperty = { info }
-
-    fun background(value: Colors.() -> ColorProperty) {
-        background = value
-    }
-
-    private var isCloseable: Boolean = true
-
-    @Suppress("unused")
-    fun isCloseable(value: () -> Boolean) {
-        isCloseable = value()
-    }
-
-    @Suppress("unused")
-    fun isCloseable(value: Boolean) {
-        isCloseable = value
-    }
-
-    private var closeButtonStyle: Style<BasicParams> = { }
-
-    fun closeButtonStyle(value: Style<BasicParams>) {
-        closeButtonStyle = value
-    }
-
-    private var closeButton: (RenderContext.() -> Unit)? = null
-
-    private fun closeButton(
-        baseClass: StyleClass? = null,
-        prefix: String = "toast-close-button",
-        build: PushButtonComponent.() -> Unit = {},
-    ) {
-        closeButton = {
-            clickButton({
-                Theme().toast.closeButton.close()
-                closeButtonStyle()
-            }, baseClass, id, prefix) {
-                variant { ghost }
-                color { lightGray }
-                icon { fromTheme { close } }
-                build()
-            }.events.map { this@ToastComponent.id } handledBy ToastStore.remove
-        }
-    }
-
+    val content = ComponentProperty<(RenderContext.() -> Unit)?>(null)
+    val placement = ComponentProperty<Placement.() -> String> { bottomRight }
+    val duration = ComponentProperty(5000L)
+    val background = ComponentProperty<Colors.() -> ColorProperty> { info }
 
     /**
-     * Makes the toast visible.
+     * This method registers one toast at the central toast store and creates a rendering expression that will be
+     * executed by the central rendering in the companion's object [ToastComponent.Companion] init block.
+     *
+     * @param context not used here, just for be compliant with the interface [Component]
+     * @param styling lambda expression for declaring the styling of the toast using fritz2's styling DSL
+     * @param baseClass optional CSS class that should be applied to the toast element
+     * @param id ID of the toast element, a unique id will be generated if no ID is specified
+     * @param prefix prefix for the generated CSS class of the toast element resulting in the form ``$prefix-$hash``
      */
-    fun show() = ToastStore.add(this)
+    override fun render(
+        context: RenderContext,
+        styling: BoxParams.() -> Unit,
+        baseClass: StyleClass?,
+        id: String?,
+        prefix: String,
+    ) {
+        val localId: String = id ?: uniqueId()
+
+        (MainScope() + job).launch {
+            delay(duration.value)
+            ToastStore.remove(localId)
+        }
+
+        ToastStore.add(ToastFragment(
+            localId,
+            placement.value(Placement)
+        ) {
+            (::li.styled(baseClass, id, prefix) {
+                listStyle()
+                alignItems { center }
+            }){
+                (::div.styled {
+                    toastStyle()
+                    background { color(background.value) }
+                    alignItems { center }
+                    styling()
+                }){
+                    content.value?.let {
+                        (::div.styled {
+                            css("flex: 1 1 0%;")
+                        }) {
+                            it.invoke(this)
+                        }
+                    }
+                    if (hasCloseButton.value) {
+                        closeButtonRendering.value(this).map { localId } handledBy ToastStore.remove
+                    }
+                }
+            }
+        })
+    }
 }
 
 /**
@@ -366,10 +296,10 @@ fun RenderContext.showToast(
     styling: BasicParams.() -> Unit = {},
     baseClass: StyleClass? = null,
     id: String? = null,
-    prefix: String = defaultToastContainerPrefix,
+    prefix: String = ToastComponent.defaultToastContainerPrefix,
     build: ToastComponent.() -> Unit,
 ) {
-    ToastComponent(styling, baseClass, id, prefix).apply(build).show()
+    ToastComponent().apply(build).render(this, styling, baseClass, id, prefix)
 }
 
 /**
@@ -386,7 +316,7 @@ fun RenderContext.showToast(
  *    text("ADD TOAST")
  * } handledBy toast {
  *    position { topLeft }
- *    duration { 5000L }
+ *    duration(5000L)
  *    ...
  *    content {
  *        ...
@@ -408,7 +338,7 @@ fun RenderContext.toast(
     styling: BasicParams.() -> Unit = {},
     baseClass: StyleClass? = null,
     id: String? = null,
-    prefix: String = defaultToastContainerPrefix,
+    prefix: String = ToastComponent.defaultToastContainerPrefix,
     build: ToastComponent.() -> Unit
 ): SimpleHandler<Unit> {
 


### PR DESCRIPTION
- add central ``Component<T>`` interface for unifying the component's
  rendering process. This also reduces the code of the corresponding
  factory methods. Together it enhances also the extensibility of
  all components!
- refactor all components to implement this interface
- rework ``CloseButtonProperty`` and its mixin implementation in order
  to make its interface and therefore the usage much cleaner
  (no exposure of a handler anymore!)
- integrate the ``CloseButtonProperty`` changes within the using
  components:
  - modal
  - popover
  - toast
- ~~ATTENTION: ``file`` component still waiting for refactoring. Its
  factory functions have different return types, which makes the
  implementation a bit more daunting!~~
- remove obsolete convenience functions from ``alert`` component
- add api documentation for for basic functions and component's
  components