### PR TITLE
support values and valuesAsNumber on input events as well

### DIFF
--- a/core/src/jsMain/kotlin/dev/fritz2/dom/listener.kt
+++ b/core/src/jsMain/kotlin/dev/fritz2/dom/listener.kt
@@ -5,6 +5,7 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
 import org.w3c.dom.*
 import org.w3c.dom.events.Event
+import org.w3c.dom.events.InputEvent
 import org.w3c.dom.events.KeyboardEvent
 import org.w3c.files.FileList
 
@@ -46,9 +47,21 @@ fun Listener<Event, HTMLInputElement>.values(): Flow<String> =
     events.map { it.target.unsafeCast<HTMLInputElement>().value }
 
 /**
+ * Gives you the new value as [String] from the targeting [Element].
+ */
+fun Listener<InputEvent, HTMLInputElement>.values(): Flow<String> =
+    events.map { it.target.unsafeCast<HTMLInputElement>().value }
+
+/**
  * Gives you the new value as [Double] from the targeting [Element].
  */
 fun Listener<Event, HTMLInputElement>.valuesAsNumber(): Flow<Double> =
+    events.map { it.target.unsafeCast<HTMLInputElement>().valueAsNumber }
+
+/**
+ * Gives you the new value as [Double] from the targeting [Element].
+ */
+fun Listener<InputEvent, HTMLInputElement>.valuesAsNumber(): Flow<Double> =
     events.map { it.target.unsafeCast<HTMLInputElement>().valueAsNumber }
 
 /**

--- a/core/src/jsTest/kotlin/dev/fritz2/dom/listener.kt
+++ b/core/src/jsTest/kotlin/dev/fritz2/dom/listener.kt
@@ -35,6 +35,7 @@ class ListenerTest {
                 input(id = inputId) {
                     value(store.data)
                     changes.values() handledBy store.update
+                    inputs.values() handledBy store.update
                 }
                 div(id = resultId) {
                     store.data.asText()
@@ -58,6 +59,11 @@ class ListenerTest {
         input.dispatchEvent(Event("change"))
         delay(100)
         assertEquals("test2", result.textContent, "wrong dom content of result-node")
+
+        input.value = "test3"
+        input.dispatchEvent(Event("input"))
+        delay(100)
+        assertEquals("test3", result.textContent, "wrong dom content of result-node")
     }
 
     @Test

--- a/core/src/jsTest/kotlin/dev/fritz2/dom/listener.kt
+++ b/core/src/jsTest/kotlin/dev/fritz2/dom/listener.kt
@@ -26,7 +26,6 @@ class ListenerTest {
         initDocument()
 
         val inputId = uniqueId()
-        val resultId = uniqueId()
 
         val store = object : RootStore<String>("start") {}
 
@@ -37,63 +36,32 @@ class ListenerTest {
                     changes.values() handledBy store.update
                     inputs.values() handledBy store.update
                 }
-                div(id = resultId) {
-                    store.data.asText()
-                }
             }
         }
 
-        // this delay seems necessary; not sure why
+        // wait for initial rendering to finish
         delay(100)
         val input = document.getElementById(inputId).unsafeCast<HTMLInputElement>()
-        val result = document.getElementById(resultId).unsafeCast<HTMLDivElement>()
 
-        assertEquals("start", result.textContent, "wrong dom content of result-node")
+        assertEquals("start", input.value, "wrong dom content of result-node")
 
         input.value = "test1"
         input.dispatchEvent(Event("change"))
-        pollUntilItSucceeds {
-            assertEquals("test1", result.textContent, "wrong dom content of result-node")
-        }
+        delay(200)
+        assertEquals("test1", input.value, "wrong dom content of result-node")
 
         input.value = "test2"
-        input.dispatchEvent(Event("change"))
-        pollUntilItSucceeds {
-            assertEquals("test2", result.textContent, "wrong dom content of result-node")
-        }
-
-        input.value = "test3"
         input.dispatchEvent(Event("input"))
-        // It seems to need this, 200 was not enough.
-        pollUntilItSucceeds {
-            assertEquals("test3", result.textContent, "wrong dom content of result-node")
-        }
-    }
-
-    suspend fun pollUntilItSucceeds(time: Long=1500, block: () -> Unit) {
-        // note this seems to fix some flakiness; probably would be good to think about
-        // a more generalized approach to polling and remove all the delays from the tests
-        // as this is flaky and slow
-        val step = 10L
-        var waited = 0L
-        while(waited<time) {
-            try {
-                block.invoke()
-                return
-            } catch (e: AssertionError) {
-                delay(step)
-                waited += step
-            }
-        }
-        block.invoke()
+        delay(200)
+        assertEquals("test2", input.value, "wrong dom content of result-node")
     }
 
     @Test
     fun testListenerForClickEvent() = runTest {
         initDocument()
 
-        val resultId = "result2"
-        val buttonId = "button2"
+        val resultId = uniqueId()
+        val buttonId = uniqueId()
 
         val store = object : RootStore<String>("start") {
             var countHandlerCalls = 0
@@ -138,8 +106,8 @@ class ListenerTest {
     fun testListenerForMultipleClickEvent() = runTest {
         initDocument()
 
-        val resultId = "result3"
-        val buttonId = "button3"
+        val resultId = uniqueId()
+        val buttonId = uniqueId()
 
         val store = object : RootStore<String>("") {
             var countHandlerCalls = 0
@@ -197,8 +165,8 @@ class ListenerTest {
     fun testListenerForKeyboardEvent() = runTest {
         initDocument()
 
-        val resultId = "result4"
-        val inputId = "button4"
+        val resultId = uniqueId()
+        val inputId = uniqueId()
 
         val store = object : RootStore<String>("") {
             var countHandlerCalls = 0


### PR DESCRIPTION
I ran into this when trying to capture the input events that the input slider fires ias you drag it. It fires a change event when you stop dragging. Likewise, useful on text input to capture values as you type.

I modified the test to test both events.  