### PR TITLE
Fix AppFrame height on Firefox

### DIFF
--- a/components/src/jsMain/kotlin/dev/fritz2/components/appFrame.kt
+++ b/components/src/jsMain/kotlin/dev/fritz2/components/appFrame.kt
@@ -41,7 +41,7 @@ open class AppFrameComponent() {
             staticStyle(
                 """
                 body {
-                    height: min(100vh, 100%);
+                    height: 100vh;
                     max-height: -webkit-fill-available;
                     width: 100vw;
                     display: grid;


### PR DESCRIPTION
This PR fixes the AppFrame not expanding to full vertical height on Firefox.
This behavior affects Firefox on all operating systems.