### PR TITLE
Fixed default styling of `selectField`

### DIFF
--- a/components/src/jsMain/kotlin/dev/fritz2/components/select.kt
+++ b/components/src/jsMain/kotlin/dev/fritz2/components/select.kt
@@ -38,7 +38,7 @@ class SelectFieldComponent<T> : InputFormProperties by InputFormMixin(), Severit
         val staticCss = staticStyle(
             "selectFieldContainer",
             """
-                  width: 50%;
+                  width: 100%;
                   height: fit-content;
                   position: relative;
                   outline:none;


### PR DESCRIPTION
Setting default with to 100% instead of 50%. 
I have also tested in kitchensink and it looks good.