### PR TITLE
Improve CloseButton API

### DIFF
--- a/components/src/jsMain/kotlin/dev/fritz2/components/components.kt
+++ b/components/src/jsMain/kotlin/dev/fritz2/components/components.kt
@@ -20,6 +20,9 @@ import kotlinx.coroutines.flow.map
 import org.w3c.dom.Element
 import dev.fritz2.identification.uniqueId
 import dev.fritz2.styling.className
+import dev.fritz2.styling.theme.IconDefinition
+import dev.fritz2.styling.theme.Icons
+import dev.fritz2.styling.theme.Theme
 
 /**
  * A marker to separate the layers of calls in the type-safe-builder pattern.
@@ -537,26 +540,34 @@ open class SingleSelectionStore : RootStore<Int?>(null) {
  * @see [ToastComponent]
  */
 interface CloseButtonProperty {
-    val prefix: String
+    val closeButtonPrefix: String
     val closeButtonStyle: ComponentProperty<Style<BasicParams>>
+    val closeButtonIcon: ComponentProperty<Icons.() -> IconDefinition>
     val hasCloseButton: ComponentProperty<Boolean>
     val closeButtonRendering: ComponentProperty<RenderContext.() -> Listener<MouseEvent, HTMLElement>>
 }
 
 /**
  * Default implementation of the [CloseButtonProperty] interface in order to apply this as mixin for a component
+ *
+ * @param closeButtonPrefix the prefix for the generated CSS class
+ * @param defaultStyle define the default styling of the button fitting for the implementing component needs
+ *                     (the placement within the component's space for example)
  */
 class CloseButtonMixin(
-    override val prefix: String = "close-button",
-    override val closeButtonStyle: ComponentProperty<Style<BasicParams>>
+    override val closeButtonPrefix: String = "close-button",
+    private val defaultStyle: Style<BasicParams>
 ) : CloseButtonProperty {
+    override val closeButtonStyle = ComponentProperty<Style<BasicParams>> {}
+    override val closeButtonIcon = ComponentProperty<Icons.() -> IconDefinition> { Theme().icons.close }
     override val hasCloseButton = ComponentProperty(true)
     override val closeButtonRendering = ComponentProperty<RenderContext.() -> Listener<MouseEvent, HTMLElement>> {
         clickButton({
+            defaultStyle()
             closeButtonStyle.value()
-        }, id = "close-button-${uniqueId()}", prefix = prefix) {
+        }, id = "close-button-${uniqueId()}", prefix = closeButtonPrefix) {
             variant { ghost }
-            icon { fromTheme { close } }
+            icon { def(closeButtonIcon.value(Theme().icons)) }
         }
     }
 }

--- a/components/src/jsMain/kotlin/dev/fritz2/components/modal.kt
+++ b/components/src/jsMain/kotlin/dev/fritz2/components/modal.kt
@@ -70,8 +70,9 @@ class DefaultOverlay(
  * ``ModalComponent.Companion.init`` block.
  */
 @ComponentMarker
-open class ModalComponent(protected val build: ModalComponent.(SimpleHandler<Unit>) -> Unit) : Component<SimpleHandler<Unit>>,
-    CloseButtonProperty by CloseButtonMixin("modal-close-button", ComponentProperty {
+open class ModalComponent(protected val build: ModalComponent.(SimpleHandler<Unit>) -> Unit) :
+    Component<SimpleHandler<Unit>>,
+    CloseButtonProperty by CloseButtonMixin("modal-close-button", {
         position {
             absolute {
                 right { none }

--- a/components/src/jsMain/kotlin/dev/fritz2/components/popover.kt
+++ b/components/src/jsMain/kotlin/dev/fritz2/components/popover.kt
@@ -24,7 +24,7 @@ import kotlinx.coroutines.flow.map
 open class PopoverComponent : Component<Unit>,
     CloseButtonProperty by CloseButtonMixin(
         "popover-close-button",
-        ComponentProperty(Theme().popover.closeButton)
+        Theme().popover.closeButton
     ) {
     companion object {
         val staticCss = staticStyle(

--- a/components/src/jsMain/kotlin/dev/fritz2/components/toast.kt
+++ b/components/src/jsMain/kotlin/dev/fritz2/components/toast.kt
@@ -72,7 +72,7 @@ import kotlinx.coroutines.flow.map
 open class ToastComponent : Component<Unit>,
     CloseButtonProperty by CloseButtonMixin(
         "toast-close-button",
-        ComponentProperty(Theme().toast.closeButton.close)
+        Theme().toast.closeButton.close
     ) {
 
     object Placement {


### PR DESCRIPTION
- add missing prefix to ``prefix`` property in order to avoid naming collisions
- improve custom styling by separating the default style from the custom styling and applying both
- add missing property to just change the icon