### PR TITLE
Fix some bugs in grouping form components

### DIFF
--- a/components/src/jsMain/kotlin/dev/fritz2/components/checkboxGroup.kt
+++ b/components/src/jsMain/kotlin/dev/fritz2/components/checkboxGroup.kt
@@ -127,10 +127,10 @@ open class CheckboxGroupComponent<T>(
                         icon { this@CheckboxGroupComponent.icon.value(Theme().icons) }
                         labelStyle(labelStyle.value)
                         checkedStyle(checkedStyle.value)
-                        label(label.value(item))
+                        label(this@CheckboxGroupComponent.label.value(item))
                         checked(checkedFlow)
-                        disabled(disabled.values)
-                        severity(severity.values)
+                        disabled(this@CheckboxGroupComponent.disabled.values)
+                        severity(this@CheckboxGroupComponent.severity.values)
                         events {
                             changes.states().map { item } handledBy multiSelectionStore.toggle
                         }

--- a/components/src/jsMain/kotlin/dev/fritz2/components/radioGroup.kt
+++ b/components/src/jsMain/kotlin/dev/fritz2/components/radioGroup.kt
@@ -129,7 +129,7 @@ open class RadioGroupComponent<T>(protected val items: List<T>, protected val st
                         label(this@RadioGroupComponent.label.value(item))
                         selected(checkedFlow)
                         disabled(this@RadioGroupComponent.disabled.values)
-                        severity(severity.values)
+                        severity(this@RadioGroupComponent.severity.values)
                         events {
                             changes.states().map { index } handledBy internalStore.toggle
                         }


### PR DESCRIPTION
- specify receiver for ambiguous properties (same name in group and single component)
- ``label``, ``disabled`` and ``severity`` should work now for radioGroup and checkboxGroup