### PR TITLE
Parameterless `invoke` function inside the Hander interface

### DIFF
--- a/components/src/jsMain/kotlin/dev/fritz2/components/toast.kt
+++ b/components/src/jsMain/kotlin/dev/fritz2/components/toast.kt
@@ -2,22 +2,18 @@ package dev.fritz2.components
 
 import dev.fritz2.binding.RootStore
 import dev.fritz2.binding.SimpleHandler
-import dev.fritz2.binding.invoke
 import dev.fritz2.components.ToastComponent.Companion.closeAllToasts
 import dev.fritz2.components.ToastComponent.Companion.closeLastToast
-import dev.fritz2.dom.html.*
+import dev.fritz2.dom.html.Li
+import dev.fritz2.dom.html.RenderContext
 import dev.fritz2.identification.uniqueId
 import dev.fritz2.styling.StyleClass
-import dev.fritz2.styling.params.BasicParams
-import dev.fritz2.styling.params.BoxParams
-import dev.fritz2.styling.params.ColorProperty
-import dev.fritz2.styling.params.Style
-import dev.fritz2.styling.params.styled
+import dev.fritz2.styling.params.*
 import dev.fritz2.styling.staticStyle
-import dev.fritz2.styling.theme.*
+import dev.fritz2.styling.theme.Colors
+import dev.fritz2.styling.theme.Theme
 import kotlinx.coroutines.*
 import kotlinx.coroutines.flow.map
-import kotlinx.coroutines.flow.toList
 
 
 /**

--- a/core/src/jsMain/kotlin/dev/fritz2/binding/handlers.kt
+++ b/core/src/jsMain/kotlin/dev/fritz2/binding/handlers.kt
@@ -1,10 +1,7 @@
 package dev.fritz2.binding
 
 import kotlinx.coroutines.Job
-import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.FlowCollector
-import kotlinx.coroutines.flow.MutableSharedFlow
-import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.flow.*
 
 /**
  * Base-interface of the different types of handlers
@@ -20,14 +17,13 @@ interface Handler<A> {
      * @param data parameter forwarded to the handler
      */
     operator fun invoke(data: A) = this.collect(flowOf(data), Job())
-}
 
-/**
- * Calls this handler exactly once.
- *
- * @receiver [Handler] which gets called
- */
-operator fun Handler<Unit>.invoke() = this.collect(flowOf(Unit), Job())
+    /**
+     * Calls this handler exactly once.
+     *
+     */
+    operator fun invoke() = this.collect(flowOf(Unit.unsafeCast<A>()), Job())
+}
 
 /**
  * Defines, how to handle actions in your [Store]. Each Handler accepts actions of a defined type.

--- a/core/src/jsTest/kotlin/dev/fritz2/binding/handlers.kt
+++ b/core/src/jsTest/kotlin/dev/fritz2/binding/handlers.kt
@@ -1,0 +1,28 @@
+package dev.fritz2.binding
+
+import dev.fritz2.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+import kotlin.test.fail
+
+class HandlersTests {
+
+    @Test
+    fun testSimpleHandler() = runTest {
+        val store = object : RootStore<Int>(0) {
+            override fun errorHandler(exception: Throwable, oldValue: Int): Int {
+                fail(exception.message)
+            }
+        }
+
+        store.handle { assertTrue(true); it }()
+        store.handle { assertTrue(true); it }(Unit)
+        store.handle<String> { n, s -> assertFalse(s::class == String::class); n }()
+        store.handle<String> { n, s -> assertTrue(s::class == Unit::class); n }()
+        store.handle<String> { n, s -> assertTrue(s.length == undefined); n }()
+        store.handle<String> { n, s -> assertTrue(s.substring(1) == undefined); n }()
+        store.handle<String> { n, _ -> assertTrue(true); n }("Hello")
+    }
+
+}

--- a/core/src/jsTest/kotlin/dev/fritz2/repositories/localstorage/localStorage.kt
+++ b/core/src/jsTest/kotlin/dev/fritz2/repositories/localstorage/localStorage.kt
@@ -1,12 +1,10 @@
 package dev.fritz2.repositories.localstorage
 
 import dev.fritz2.binding.RootStore
-import dev.fritz2.binding.invoke
 import dev.fritz2.dom.html.render
 import dev.fritz2.identification.uniqueId
 import dev.fritz2.lenses.IdProvider
 import dev.fritz2.lenses.buildLens
-import dev.fritz2.remote.WebSocketTests
 import dev.fritz2.repositories.ResourceNotFoundException
 import dev.fritz2.resource.Resource
 

--- a/core/src/jsTest/kotlin/dev/fritz2/repositories/rest/rest.kt
+++ b/core/src/jsTest/kotlin/dev/fritz2/repositories/rest/rest.kt
@@ -1,7 +1,6 @@
 package dev.fritz2.repositories.rest
 
 import dev.fritz2.binding.RootStore
-import dev.fritz2.binding.invoke
 import dev.fritz2.dom.html.render
 import dev.fritz2.identification.uniqueId
 import dev.fritz2.lenses.IdProvider

--- a/core/src/jsTest/kotlin/dev/fritz2/tracking/tracking.kt
+++ b/core/src/jsTest/kotlin/dev/fritz2/tracking/tracking.kt
@@ -1,7 +1,6 @@
 package dev.fritz2.tracking
 
 import dev.fritz2.binding.RootStore
-import dev.fritz2.binding.invoke
 import dev.fritz2.dom.html.render
 import dev.fritz2.identification.uniqueId
 import dev.fritz2.test.initDocument

--- a/lenses-annotation-processor/build.gradle.kts
+++ b/lenses-annotation-processor/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
 
 kotlin {
     jvm()
-    js(BOTH)
+    js(BOTH).browser()
 
     sourceSets {
         val commonMain by getting {


### PR DESCRIPTION
**Advantage**: No extra import is needed, which Intellij IDEA can't guess.
**Disadvantage**: No compiler error when using parameterless `invoke()` function for non-`Unit` handlers.

My experiments show that at runtime this not very bad, but of course it can be confusing. That is why I think we need to discuss this!?
```kotlin
store.handle { assertTrue(true); it }()
store.handle { assertTrue(true); it }(Unit)
store.handle<String> { n, s -> assertFalse(s::class == String::class); n }()
store.handle<String> { n, s -> assertTrue(s::class == Unit::class); n }()
store.handle<String> { n, s -> assertTrue(s.length == undefined); n }()
store.handle<String> { n, s -> assertTrue(s.substring(1) == undefined); n }()
store.handle<String> { n, _ -> assertTrue(true); n }("Hello")
```