### PR TITLE
Visual fix of padding in small inputField

### DIFF
--- a/styling/src/jsMain/kotlin/dev.fritz2.styling/theme/default.kt
+++ b/styling/src/jsMain/kotlin/dev.fritz2.styling/theme/default.kt
@@ -1345,7 +1345,7 @@ open class DefaultTheme : Theme {
                 height { "2rem" }
                 fontSize { small }
                 paddings {
-                    horizontal { tiny }
+                    horizontal { small }
                 }
             }
 


### PR DESCRIPTION
Small visual fix in DefaultTheme by setting inputField padding to small when setting `small`
as size.