### PR TITLE
Added new global styling function as alternative

### DIFF
--- a/styling/src/jsMain/kotlin/dev.fritz2.styling/params/border.kt
+++ b/styling/src/jsMain/kotlin/dev.fritz2.styling/params/border.kt
@@ -78,7 +78,7 @@ internal const val borderBottomLeftRadiusKey = "border-bottom-left-radius: "
  * border { /* it == BorderContext.() -> Unit */
  *     width { thin }
  *     style { dashed }
- *     color { dark }
+ *     color { gray900 }
  * }
  * ```
  *
@@ -92,7 +92,7 @@ internal const val borderBottomLeftRadiusKey = "border-bottom-left-radius: "
  *     top {  it == /* BorderContext.() -> Unit */
  *         width { thin }
  *         style { dashed }
- *         color { dark }
+ *         color { gray900 }
  *     },
  *     bottom {
  *         // some properties
@@ -158,7 +158,7 @@ class BorderContext(
      * example call:
      * ```
      * border {
-     *     color { dark }
+     *     color { gray900 }
      *     // color { "lime" }
      *     // color { rgba(255, 0, 0, 100 }
      * }

--- a/styling/src/jsMain/kotlin/dev.fritz2.styling/params/color.kt
+++ b/styling/src/jsMain/kotlin/dev.fritz2.styling/params/color.kt
@@ -106,7 +106,7 @@ interface Color : StyleParams {
      * ```
      * color(
      *     sm = { primary.base }
-     *     lg = { dark }
+     *     lg = { gray900 }
      * )
      * ```
      *


### PR DESCRIPTION
Now you can use a alternative syntax for applying the Styling DSL to plain html `Tag`s:
```
render {
    (::div.styled {
        background { color { "red" } }
    }) {
        +"Hello World"
    }

    // new alternative
    styled(::div)({
        background { color { "red" } }
    }) {
        +"Hello World"
    }
}
```

Fixes #322