### PR TITLE
Fix horizontal and vertical convenience functions of BordersContext DSL

### DIFF
--- a/styling/src/jsMain/kotlin/dev.fritz2.styling/params/border.kt
+++ b/styling/src/jsMain/kotlin/dev.fritz2.styling/params/border.kt
@@ -258,7 +258,7 @@ class BordersContext(
      * @param value extension function parameter to open the [BorderContext] as scope of the functional expression
      *              in order to use its specific styling functions.
      */
-    fun horizontal(value: BorderContext.() -> Unit) {
+    fun vertical(value: BorderContext.() -> Unit) {
         right(value)
         left(value)
     }
@@ -275,7 +275,7 @@ class BordersContext(
      * @param value extension function parameter to open the [BorderContext] as scope of the functional expression
      *              in order to use its specific styling functions.
      */
-    fun vertical(value: BorderContext.() -> Unit) {
+    fun horizontal(value: BorderContext.() -> Unit) {
         top(value)
         bottom(value)
     }


### PR DESCRIPTION
This PR resolves issue #330 by swapping the implementations of `BorderContext.horizontal(...)` and `BorderContext.vertical(...)` so the borders created by them follow the semantics of the respective method names.

This means:
- `horizontal` now creates borders at the top and at the bottom of an element and
- `vertical` now creates borders to the left and right of an element

Currently it doesn't seem like there are any usages of these methods in fritz2 itself. The change should be stated in the release notes regardless since other projects might use these functions already and would need to adjust their code.