### PR TITLE
Make `staticStyle` internal

### DIFF
--- a/components/src/jsMain/kotlin/dev/fritz2/components/appFrame.kt
+++ b/components/src/jsMain/kotlin/dev/fritz2/components/appFrame.kt
@@ -5,16 +5,13 @@ import dev.fritz2.binding.storeOf
 import dev.fritz2.dom.html.Div
 import dev.fritz2.dom.html.RenderContext
 import dev.fritz2.dom.html.TextElement
-import dev.fritz2.styling.StyleClass
-import dev.fritz2.styling.name
+import dev.fritz2.styling.*
 import dev.fritz2.styling.params.BasicParams
 import dev.fritz2.styling.params.BoxParams
 import dev.fritz2.styling.params.Style
 import dev.fritz2.styling.params.styled
-import dev.fritz2.styling.staticStyle
 import dev.fritz2.styling.theme.Property
 import dev.fritz2.styling.theme.Theme
-import dev.fritz2.styling.whenever
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 
 /**
@@ -39,6 +36,9 @@ import kotlinx.coroutines.ExperimentalCoroutinesApi
 open class AppFrameComponent : Component<Unit> {
     companion object {
         init {
+            // Needs to reference header heigth from Theme even though sttic style needs to be used to style the body.
+            // Header heigth might not update when the Theme is changed.
+            // FIXME: Find more elegant solution to style body
             staticStyle(
                 """
                 body {
@@ -63,14 +63,14 @@ open class AppFrameComponent : Component<Unit> {
     private val sidebarStatus = storeOf(false)
     private val toggleSidebar = sidebarStatus.handle { !it }
 
-    private val openSideBar = staticStyle(
+    private val openSideBar = style(
         "open-sidebar", """
             @media (max-width: ${Theme().breakPoints.md}) {
                 transform: translateX(0) !important;
          }""".trimIndent()
     )
 
-    private val showBackdrop = staticStyle(
+    private val showBackdrop = style(
         "show-backdrop", """
             @media (max-width: ${Theme().breakPoints.md}) {
                 left : 0 !important;

--- a/components/src/jsMain/kotlin/dev/fritz2/components/nav.kt
+++ b/components/src/jsMain/kotlin/dev/fritz2/components/nav.kt
@@ -1,14 +1,11 @@
 import dev.fritz2.components.*
 import dev.fritz2.dom.Listener
 import dev.fritz2.dom.html.RenderContext
-import dev.fritz2.styling.StyleClass
-import dev.fritz2.styling.name
+import dev.fritz2.styling.*
 import dev.fritz2.styling.params.BasicParams
 import dev.fritz2.styling.params.BoxParams
 import dev.fritz2.styling.params.styled
-import dev.fritz2.styling.staticStyle
 import dev.fritz2.styling.theme.Theme
-import dev.fritz2.styling.whenever
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flowOf
@@ -27,10 +24,8 @@ import org.w3c.dom.events.MouseEvent
  */
 @ExperimentalCoroutinesApi
 open class NavLinkComponent : Component<Listener<MouseEvent>> {
-    companion object {
-        val activeStyle = staticStyle("navlink-active") {
-            Theme().appFrame.activeNavLink()
-        }
+    private val activeStyle = style("navlink-active") {
+        Theme().appFrame.activeNavLink()
     }
 
     val icon = ComponentProperty<IconComponent.() -> Unit> { fromTheme { bookmark } }
@@ -53,7 +48,9 @@ open class NavLinkComponent : Component<Listener<MouseEvent>> {
             }, baseClass, id, prefix) {
                 spacing { small }
                 items {
-                    this@NavLinkComponent.active.value?.let { className(activeStyle.whenever(it).name) }
+                    this@NavLinkComponent.active.value?.let {
+                        className(this@NavLinkComponent.activeStyle.whenever(it).name)
+                    }
                     icon(build = this@NavLinkComponent.icon.value)
                     a { this@NavLinkComponent.text.values.asText() }
                 }

--- a/components/src/jsMain/kotlin/dev/fritz2/components/radio.kt
+++ b/components/src/jsMain/kotlin/dev/fritz2/components/radio.kt
@@ -13,6 +13,7 @@ import dev.fritz2.styling.params.BoxParams
 import dev.fritz2.styling.params.Style
 import dev.fritz2.styling.params.styled
 import dev.fritz2.styling.staticStyle
+import dev.fritz2.styling.style
 import dev.fritz2.styling.theme.FormSizes
 import dev.fritz2.styling.theme.Theme
 import kotlinx.coroutines.flow.Flow
@@ -61,10 +62,8 @@ open class RadioComponent(protected val store: Store<Boolean>? = null) :
     InputFormProperties by InputFormMixin(),
     SeverityProperties by SeverityMixin() {
 
-    companion object {
-        val radioInputStaticCss = staticStyle(
-            "radioInput",
-            """
+    private val radioInputStaticCss = style(
+        """
             position: absolute;
             height: 1px; 
             width: 1px;
@@ -88,9 +87,9 @@ open class RadioComponent(protected val store: Store<Boolean>? = null) :
                 boxShadow: none;
                 color: ${Theme().colors.disabled};
             }
-            """
-        )
-    }
+        """.trimIndent(),
+        prefix = "radioInput"
+    )
 
     val size = ComponentProperty<FormSizes.() -> Style<BasicParams>> { Theme().radio.sizes.normal }
 
@@ -145,7 +144,7 @@ open class RadioComponent(protected val store: Store<Boolean>? = null) :
                     `for`(inputId)
                 }
                 (::input.styled(
-                    baseClass = radioInputStaticCss,
+                    baseClass = this@RadioComponent.radioInputStaticCss,
                     prefix = prefix,
                     id = inputId
                 ) {

--- a/styling/src/jsMain/kotlin/dev.fritz2.styling/style.kt
+++ b/styling/src/jsMain/kotlin/dev.fritz2.styling/style.kt
@@ -130,10 +130,6 @@ inline class StyleClass(val name: String) {
  *
  * @param css well formed content of the css-rule to add
  */
-@Deprecated(
-    message = "Use 'style' instead.",
-    ReplaceWith("style(css)")
-)
 fun staticStyle(css: String) {
     Styling.addStaticCss(css)
 }
@@ -145,10 +141,6 @@ fun staticStyle(css: String) {
  * @param css well formed content of the css-rule to add
  * @return the name of the created class
  */
-@Deprecated(
-    message = "Use 'style' instead.",
-    ReplaceWith("style(css, name)")
-)
 fun staticStyle(name: String, css: String): StyleClass {
     Styling.addStaticCss(".$name { $css }")
     return StyleClass(name)
@@ -161,10 +153,6 @@ fun staticStyle(name: String, css: String): StyleClass {
  * @param styling styling DSL expression
  * @return the name of the created class
  */
-@Deprecated(
-    message = "Use 'style' instead.",
-    ReplaceWith("style(name, styling)")
-)
 fun staticStyle(name: String, styling: BoxParams.() -> Unit): StyleClass {
     val css = StyleParamsImpl().apply(styling).toCss()
     Styling.addStaticCss(".$name { $css }")

--- a/styling/src/jsMain/kotlin/dev.fritz2.styling/style.kt
+++ b/styling/src/jsMain/kotlin/dev.fritz2.styling/style.kt
@@ -130,6 +130,10 @@ inline class StyleClass(val name: String) {
  *
  * @param css well formed content of the css-rule to add
  */
+@Deprecated(
+    message = "Use 'style' instead.",
+    ReplaceWith("style(css)")
+)
 fun staticStyle(css: String) {
     Styling.addStaticCss(css)
 }
@@ -141,6 +145,10 @@ fun staticStyle(css: String) {
  * @param css well formed content of the css-rule to add
  * @return the name of the created class
  */
+@Deprecated(
+    message = "Use 'style' instead.",
+    ReplaceWith("style(css, name)")
+)
 fun staticStyle(name: String, css: String): StyleClass {
     Styling.addStaticCss(".$name { $css }")
     return StyleClass(name)
@@ -153,6 +161,10 @@ fun staticStyle(name: String, css: String): StyleClass {
  * @param styling styling DSL expression
  * @return the name of the created class
  */
+@Deprecated(
+    message = "Use 'style' instead.",
+    ReplaceWith("style(name, styling)")
+)
 fun staticStyle(name: String, styling: BoxParams.() -> Unit): StyleClass {
     val css = StyleParamsImpl().apply(styling).toCss()
     Styling.addStaticCss(".$name { $css }")

--- a/styling/src/jsMain/kotlin/dev.fritz2.styling/style.kt
+++ b/styling/src/jsMain/kotlin/dev.fritz2.styling/style.kt
@@ -128,6 +128,11 @@ inline class StyleClass(val name: String) {
 /**
  * adds some static css to your app's dynamic style sheet.
  *
+ * This function is mainly intended for internal use; use [style] whenever possible!
+ * Calling this function multiple times with identical styles will cause css-errors to be raised.
+ * Also make sure not to reference values from the Theme in the style passed to this function. They will not be updated
+ * when the Theme changes (hence 'static').
+ *
  * @param css well formed content of the css-rule to add
  */
 fun staticStyle(css: String) {
@@ -136,6 +141,11 @@ fun staticStyle(css: String) {
 
 /**
  * adds a static css-class to your app's dynamic style sheet.
+ *
+ * This function is mainly intended for internal use; use [style] whenever possible!
+ * Calling this function multiple times with identical styles will cause css-errors to be raised.
+ * Also make sure not to reference values from the Theme in the style passed to this function. They will not be updated
+ * when the Theme changes (hence 'static').
  *
  * @param name of the class to create
  * @param css well formed content of the css-rule to add
@@ -148,6 +158,11 @@ fun staticStyle(name: String, css: String): StyleClass {
 
 /**
  * adds a static css-class to your app's dynamic style sheet.
+ *
+ * This function is mainly intended for internal use; use [style] whenever possible!
+ * Calling this function multiple times with identical styles will cause css-errors to be raised.
+ * Also make sure not to reference values from the Theme in the style passed to this function. They will not be updated
+ * when the Theme changes (hence 'static').
  *
  * @param name of the class to create
  * @param styling styling DSL expression


### PR DESCRIPTION
This PR extends the `staticStyle` documentation to suggest using `style` whenever possible.
`staticStyle` should mainly be used internally (e.g. for component development) but can not actually be made `internal` as it needs to be accessible from the `components` package.

This PR also changes existing usages of `staticStyle` to `style` if needed.

Closes #303 .