### PR TITLE
Harmonize parameter name in components with stores

### DIFF
--- a/components/src/jsMain/kotlin/dev/fritz2/components/checkbox.kt
+++ b/components/src/jsMain/kotlin/dev/fritz2/components/checkbox.kt
@@ -54,7 +54,7 @@ import org.w3c.dom.HTMLInputElement
  * }
  * ```
  */
-open class CheckboxComponent(protected val store: Store<Boolean>?) :
+open class CheckboxComponent(protected val value: Store<Boolean>?) :
     Component<Label>,
     EventProperties<HTMLInputElement> by EventMixin(),
     ElementProperties<Input> by ElementMixin(),
@@ -135,9 +135,9 @@ open class CheckboxComponent(protected val store: Store<Boolean>?) :
                 disabled(this@CheckboxComponent.disabled.values)
                 readOnly(this@CheckboxComponent.readonly.values)
                 type("checkbox")
-                checked(this@CheckboxComponent.store?.data ?: this@CheckboxComponent.checked.values)
+                checked(this@CheckboxComponent.value?.data ?: this@CheckboxComponent.checked.values)
                 className(this@CheckboxComponent.severityClassOf(Theme().checkbox.severity).name)
-                this@CheckboxComponent.store?.let { changes.states() handledBy it.update }
+                this@CheckboxComponent.value?.let { changes.states() handledBy it.update }
                 this@CheckboxComponent.events.value.invoke(this)
                 this@CheckboxComponent.element.value.invoke(this)
             }
@@ -196,7 +196,7 @@ open class CheckboxComponent(protected val store: Store<Boolean>?) :
  * @see CheckboxComponent
  *
  * @param styling a lambda expression for declaring the styling as fritz2's styling DSL
- * @param store a boolean store to handle the state and its changes automatically
+ * @param value a boolean store to handle the state and its changes automatically
  * @param baseClass optional CSS class that should be applied to the element
  * @param id the ID of the element
  * @param prefix the prefix for the generated CSS class resulting in the form ``$prefix-$hash``
@@ -204,9 +204,9 @@ open class CheckboxComponent(protected val store: Store<Boolean>?) :
  */
 fun RenderContext.checkbox(
     styling: BasicParams.() -> Unit = {},
-    store: Store<Boolean>? = null,
+    value: Store<Boolean>? = null,
     baseClass: StyleClass = StyleClass.None,
     id: String? = null,
     prefix: String = "checkboxComponent",
     build: CheckboxComponent.() -> Unit = {}
-): Label = CheckboxComponent(store).apply(build).render(this, styling, baseClass, id, prefix)
+): Label = CheckboxComponent(value).apply(build).render(this, styling, baseClass, id, prefix)

--- a/components/src/jsMain/kotlin/dev/fritz2/components/checkbox.kt
+++ b/components/src/jsMain/kotlin/dev/fritz2/components/checkbox.kt
@@ -177,7 +177,7 @@ open class CheckboxComponent(protected val value: Store<Boolean>?) :
  * Example usage
  * ```
  * val cheeseStore = storeOf(false)
- * checkbox(store = cheeseStore) {
+ * checkbox(value = cheeseStore) {
  *      label("with extra cheese") // set the label
  *      size { normal } // choose a predefined size
  * }

--- a/components/src/jsMain/kotlin/dev/fritz2/components/checkboxGroup.kt
+++ b/components/src/jsMain/kotlin/dev/fritz2/components/checkboxGroup.kt
@@ -47,7 +47,7 @@ import org.w3c.dom.HTMLElement
  * // simple use case showing the core functionality
  * val options = listOf("A", "B", "C")
  * val myStore = storeOf(listOf("B"))
- * checkboxGroup(items = options, store = myStore) {
+ * checkboxGroup(items = options, values = myStore) {
  * }
  *
  * // one can handle the events and preselected item also manually if needed:
@@ -169,7 +169,7 @@ open class CheckboxGroupComponent<T>(
  * // simple use case showing the core functionality
  * val options = listOf("A", "B", "C")
  * val myStore = storeOf(<List<String>>)
- * checkboxGroup(items = options, store = myStore) {
+ * checkboxGroup(items = options, values = myStore) {
  * }
  *
  * // use case showing some styling options and a store of List<Pair<Int,String>>

--- a/components/src/jsMain/kotlin/dev/fritz2/components/checkboxGroup.kt
+++ b/components/src/jsMain/kotlin/dev/fritz2/components/checkboxGroup.kt
@@ -63,7 +63,7 @@ import org.w3c.dom.HTMLElement
  * // use case showing some styling options and a store of List<Pair<Int,String>>
  *   val myPairs = listOf((1 to "ffffff"), (2 to "rrrrrr" ), (3 to "iiiiii"), (4 to "tttttt"), ( 5 to "zzzzzz"), (6 to "222222"))
  *  val myStore = storeOf(<List<Pair<Int,String>>)
- * checkboxGroup(items = myPairs, store = myStore) {
+ * checkboxGroup(items = myPairs, values = myStore) {
  *      label { it.second }
  *      size { large }
  *      checkedStyle {
@@ -74,7 +74,7 @@ import org.w3c.dom.HTMLElement
  */
 open class CheckboxGroupComponent<T>(
     protected val items: List<T>,
-    protected val store: Store<List<T>>?
+    protected val values: Store<List<T>>?
 ) : Component<Unit>,
     InputFormProperties by InputFormMixin(),
     SeverityProperties by SeverityMixin() {
@@ -123,7 +123,7 @@ open class CheckboxGroupComponent<T>(
             (::div.styled(styling, baseClass, id, prefix) {
                 this@CheckboxGroupComponent.direction.value(CheckboxGroupLayouts)()
             }) {
-                (this@CheckboxGroupComponent.store?.data
+                (this@CheckboxGroupComponent.values?.data
                     ?: this@CheckboxGroupComponent.selectedItems.values) handledBy multiSelectionStore.update
 
                 this@CheckboxGroupComponent.items.forEach { item ->
@@ -148,7 +148,7 @@ open class CheckboxGroupComponent<T>(
 
                 EventsContext(this, multiSelectionStore.toggle).apply {
                     this@CheckboxGroupComponent.events.value(this)
-                    this@CheckboxGroupComponent.store?.let { selected handledBy it.update }
+                    this@CheckboxGroupComponent.values?.let { selected handledBy it.update }
                 }
             }
         }
@@ -175,7 +175,7 @@ open class CheckboxGroupComponent<T>(
  * // use case showing some styling options and a store of List<Pair<Int,String>>
  * val myPairs = listOf((1 to "ffffff"), (2 to "rrrrrr" ), (3 to "iiiiii"), (4 to "tttttt"), ( 5 to "zzzzzz"), (6 to "222222"))
  * val myStore = storeOf(<List<Pair<Int,String>>)
- * checkboxGroup(items = myPairs, store = myStore) {
+ * checkboxGroup(items = myPairs, values = myStore) {
  *      label { it.second }
  *      size { large }
  *      checkedStyle {
@@ -188,7 +188,7 @@ open class CheckboxGroupComponent<T>(
  *
  * @param styling a lambda expression for declaring the styling as fritz2's styling DSL
  * @param items a list of all available options
- * @param store a store of List<T>
+ * @param values a store of List<T>
  * @param baseClass optional CSS class that should be applied to the element
  * @param id the ID of the element
  * @param prefix the prefix for the generated CSS class resulting in the form ``$prefix-$hash``
@@ -197,12 +197,12 @@ open class CheckboxGroupComponent<T>(
 fun <T> RenderContext.checkboxGroup(
     styling: BasicParams.() -> Unit = {},
     items: List<T>,
-    store: Store<List<T>>? = null,
+    values: Store<List<T>>? = null,
     baseClass: StyleClass = StyleClass.None,
     id: String? = null,
     prefix: String = "checkboxGroupComponent",
     build: CheckboxGroupComponent<T>.() -> Unit = {}
 ) {
-    CheckboxGroupComponent<T>(items, store).apply(build).render(this, styling, baseClass, id, prefix)
+    CheckboxGroupComponent<T>(items, values).apply(build).render(this, styling, baseClass, id, prefix)
 }
 

--- a/components/src/jsMain/kotlin/dev/fritz2/components/components.kt
+++ b/components/src/jsMain/kotlin/dev/fritz2/components/components.kt
@@ -152,7 +152,7 @@ class NullableDynamicComponentProperty<T>(var values: Flow<T?>) {
  * RenderContext.myComponent(
  *      styling: BasicParams.() -> Unit,
  *      items: List<String>,          // two additional parameters
- *      store: Store<String>? = null, // after ``styling`` and before ``baseClass``!
+ *      value: Store<String>? = null, // after ``styling`` and before ``baseClass``!
  *      baseClass: StyleClass,
  *      id: String?,
  *      prefix: String

--- a/components/src/jsMain/kotlin/dev/fritz2/components/formcontrol.kt
+++ b/components/src/jsMain/kotlin/dev/fritz2/components/formcontrol.kt
@@ -217,16 +217,16 @@ open class FormControlComponent : Component<Unit>, FormProperties by FormMixin()
 
     open fun inputField(
         styling: BasicParams.() -> Unit = {},
-        store: Store<String>? = null,
+        value: Store<String>? = null,
         baseClass: StyleClass = StyleClass.None,
         id: String? = null,
         prefix: String = ControlNames.inputField,
         build: InputFieldComponent.() -> Unit = {}
     ) {
-        val validationMessagesBuilder = ValidationResult.builderOf(this, store)
+        val validationMessagesBuilder = ValidationResult.builderOf(this, value)
         registerControl(ControlNames.inputField,
             {
-                inputField(styling, store, baseClass, id, prefix) {
+                inputField(styling, value, baseClass, id, prefix) {
                     size { this@FormControlComponent.sizeBuilder(this) }
                     severity(validationMessagesBuilder().hasSeverity)
                     build()
@@ -238,16 +238,16 @@ open class FormControlComponent : Component<Unit>, FormProperties by FormMixin()
 
     open fun switch(
         styling: BasicParams.() -> Unit = {},
-        store: Store<Boolean>? = null,
+        value: Store<Boolean>? = null,
         baseClass: StyleClass = StyleClass.None,
         id: String? = null,
         prefix: String = ControlNames.switch,
         build: SwitchComponent.() -> Unit = {}
     ) {
-        val validationMessagesBuilder = ValidationResult.builderOf(this, store)
+        val validationMessagesBuilder = ValidationResult.builderOf(this, value)
         registerControl(ControlNames.inputField,
             {
-                switch(styling, store, baseClass, id, prefix) {
+                switch(styling, value, baseClass, id, prefix) {
                     size { this@FormControlComponent.sizeBuilder(this) }
                     severity(validationMessagesBuilder().hasSeverity)
                     build()
@@ -281,17 +281,17 @@ open class FormControlComponent : Component<Unit>, FormProperties by FormMixin()
     open fun checkbox(
         styling: BasicParams.() -> Unit = {},
         baseClass: StyleClass = StyleClass.None,
-        store: Store<Boolean>? = null,
+        value: Store<Boolean>? = null,
         id: String? = null,
         prefix: String = ControlNames.checkbox,
         build: CheckboxComponent.() -> Unit = {}
     ) {
-        val validationMessagesBuilder = ValidationResult.builderOf(this, store)
+        val validationMessagesBuilder = ValidationResult.builderOf(this, value)
         registerControl(ControlNames.checkbox,
             {
                 checkbox({
                     styling()
-                }, store, baseClass, id, prefix) {
+                }, value, baseClass, id, prefix) {
                     size { this@FormControlComponent.sizeBuilder(this) }
                     severity(validationMessagesBuilder().hasSeverity)
                     build()
@@ -304,16 +304,16 @@ open class FormControlComponent : Component<Unit>, FormProperties by FormMixin()
     open fun <T> checkboxGroup(
         styling: BasicParams.() -> Unit = {},
         items: List<T>,
-        store: Store<List<T>>? = null,
+        values: Store<List<T>>? = null,
         baseClass: StyleClass = StyleClass.None,
         id: String? = null,
         prefix: String = ControlNames.checkboxGroup,
         build: CheckboxGroupComponent<T>.() -> Unit = {}
     ) {
-        val validationMessagesBuilder = ValidationResult.builderOf(this, store)
+        val validationMessagesBuilder = ValidationResult.builderOf(this, values)
         registerControl(ControlNames.checkboxGroup,
             {
-                checkboxGroup(styling, items, store, baseClass, id, prefix) {
+                checkboxGroup(styling, items, values, baseClass, id, prefix) {
                     size { this@FormControlComponent.sizeBuilder(this) }
                     severity(validationMessagesBuilder().hasSeverity)
                     build()
@@ -326,16 +326,16 @@ open class FormControlComponent : Component<Unit>, FormProperties by FormMixin()
     open fun <T> radioGroup(
         styling: BasicParams.() -> Unit = {},
         items: List<T>,
-        store: Store<T>? = null,
+        value: Store<T>? = null,
         baseClass: StyleClass = StyleClass.None,
         id: String? = null,
         prefix: String = ControlNames.radioGroup,
         build: RadioGroupComponent<T>.() -> Unit = {}
     ) {
-        val validationMessagesBuilder = ValidationResult.builderOf(this, store)
+        val validationMessagesBuilder = ValidationResult.builderOf(this, value)
         registerControl(ControlNames.radioGroup,
             {
-                radioGroup(styling, items, store, baseClass, id, prefix) {
+                radioGroup(styling, items, value, baseClass, id, prefix) {
                     size { this@FormControlComponent.sizeBuilder(this) }
                     severity(validationMessagesBuilder().hasSeverity)
                     build()
@@ -348,19 +348,19 @@ open class FormControlComponent : Component<Unit>, FormProperties by FormMixin()
     open fun <T> selectField(
         styling: BasicParams.() -> Unit = {},
         items: List<T>,
-        store: Store<T>? = null,
+        value: Store<T>? = null,
         baseClass: StyleClass = StyleClass.None,
         id: String? = null,
         prefix: String = ControlNames.selectField,
         build: SelectFieldComponent<T>.() -> Unit = {}
     ) {
-        val validationMessagesBuilder = ValidationResult.builderOf(this, store)
+        val validationMessagesBuilder = ValidationResult.builderOf(this, value)
         registerControl(ControlNames.selectField,
             {
                 selectField(
                     styling,
                     items,
-                    store,
+                    value,
                     baseClass,
                     id,
                     prefix
@@ -527,7 +527,7 @@ class ControlGroupRenderer(private val component: FormControlComponent) : Contro
  *         flowOf(errorMessage("id", "Sorry, always wrong in this case"))
  *     }
  *     // just use the appropriate control with its specific API!
- *     inputField(store = someStore) {
+ *     inputField(value = someStore) {
  *         placeholder("Some text to type")
  *     }
  * }
@@ -539,7 +539,7 @@ class ControlGroupRenderer(private val component: FormControlComponent) : Contro
  *     // leave out label and so on
  *     // ...
  *     // first control function called -> ok, will get rendered
- *     inputField(store = someStore) {
+ *     inputField(value = someStore) {
  *         placeholder("Some text to type")
  *     }
  *     // second call -> more than one control -> will not get rendered, but instead be logged as error!

--- a/components/src/jsMain/kotlin/dev/fritz2/components/input.kt
+++ b/components/src/jsMain/kotlin/dev/fritz2/components/input.kt
@@ -15,6 +15,7 @@ import dev.fritz2.styling.staticStyle
 import dev.fritz2.styling.theme.FormSizes
 import dev.fritz2.styling.theme.InputFieldVariants
 import dev.fritz2.styling.theme.Theme
+import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flowOf
 import org.w3c.dom.HTMLInputElement
 
@@ -29,7 +30,7 @@ import org.w3c.dom.HTMLInputElement
  *
  *  * For a detailed explanation and examples of usage have a look at the [inputField] function!
  */
-open class InputFieldComponent(protected val store: Store<String>?) :
+open class InputFieldComponent(protected val value: Store<String>?) :
     Component<Unit>,
     EventProperties<HTMLInputElement> by EventMixin(),
     ElementProperties<Input> by ElementMixin(),
@@ -59,7 +60,13 @@ open class InputFieldComponent(protected val store: Store<String>?) :
 
     val variant = ComponentProperty<InputFieldVariants.() -> Style<BasicParams>> { Theme().input.variants.outline }
     val size = ComponentProperty<FormSizes.() -> Style<BasicParams>> { Theme().input.sizes.normal }
-    val value = DynamicComponentProperty(flowOf(""))
+    val valueAttr = DynamicComponentProperty(flowOf(""))
+    fun value(value: Flow<String>) {
+        valueAttr(value)
+    }
+    fun value(value: String) {
+        valueAttr(value)
+    }
     val placeholder = DynamicComponentProperty(flowOf(""))
     val type = DynamicComponentProperty(flowOf(""))
     val step = DynamicComponentProperty(flowOf(""))
@@ -79,11 +86,11 @@ open class InputFieldComponent(protected val store: Store<String>?) :
                 disabled(this@InputFieldComponent.disabled.values)
                 readOnly(this@InputFieldComponent.readonly.values)
                 placeholder(this@InputFieldComponent.placeholder.values)
-                value(this@InputFieldComponent.value.values)
+                value(this@InputFieldComponent.valueAttr.values)
                 type(this@InputFieldComponent.type.values)
                 step(this@InputFieldComponent.step.values)
                 className(this@InputFieldComponent.severityClassOf(Theme().input.severity).name)
-                this@InputFieldComponent.store?.let {
+                this@InputFieldComponent.value?.let {
                     value(it.data)
                     changes.values() handledBy it.update
                 }
@@ -107,7 +114,7 @@ open class InputFieldComponent(protected val store: Store<String>?) :
  * react to a change refer also to its event's. All that can be achieved via the [ElementMixin.element] property!
  *
  * ```
- * inputField(store = dataStore /* inject a store so all user inputs are automatically reflected! */) {
+ * inputField(value = dataStore /* inject a store so all user inputs are automatically reflected! */) {
  *     placeholder("Placeholder") // render a placeholder text for empty field
  * }
  *
@@ -125,7 +132,7 @@ open class InputFieldComponent(protected val store: Store<String>?) :
  * }
  *
  * // apply predefined size and variant
- * inputField(store = dataStore) {
+ * inputField(value = dataStore) {
  *      size { small } // render a smaller input
  *      variant { filled } // fill the background with ``light`` color
  *      placeholder("Placeholder") // render a placeholder text for empty field
@@ -147,7 +154,7 @@ open class InputFieldComponent(protected val store: Store<String>?) :
  * @see InputFieldComponent
  *
  * @param styling a lambda expression for declaring the styling as fritz2's styling DSL
- * @param store optional [Store] that holds the data of the input
+ * @param value optional [Store] that holds the data of the input
  * @param baseClass optional CSS class that should be applied to the element
  * @param id the ID of the element
  * @param prefix the prefix for the generated CSS class resulting in the form ``$prefix-$hash``
@@ -155,11 +162,11 @@ open class InputFieldComponent(protected val store: Store<String>?) :
  */
 fun RenderContext.inputField(
     styling: BasicParams.() -> Unit = {},
-    store: Store<String>? = null,
+    value: Store<String>? = null,
     baseClass: StyleClass = StyleClass.None,
     id: String? = null,
     prefix: String = "inputField",
     build: InputFieldComponent.() -> Unit = {}
 ) {
-    InputFieldComponent(store).apply(build).render(this, styling, baseClass, id, prefix)
+    InputFieldComponent(value).apply(build).render(this, styling, baseClass, id, prefix)
 }

--- a/components/src/jsMain/kotlin/dev/fritz2/components/input.kt
+++ b/components/src/jsMain/kotlin/dev/fritz2/components/input.kt
@@ -139,7 +139,7 @@ open class InputFieldComponent(protected val valueStore: Store<String>?) :
  *      }
  *      radius { "1rem" }
  * },
- * store = dataStore) {
+ * value = dataStore) {
  *      size { small } // render a smaller input
  *      placeholder("Placeholder") // render a placeholder text for empty field
  * }

--- a/components/src/jsMain/kotlin/dev/fritz2/components/input.kt
+++ b/components/src/jsMain/kotlin/dev/fritz2/components/input.kt
@@ -15,7 +15,6 @@ import dev.fritz2.styling.staticStyle
 import dev.fritz2.styling.theme.FormSizes
 import dev.fritz2.styling.theme.InputFieldVariants
 import dev.fritz2.styling.theme.Theme
-import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flowOf
 import org.w3c.dom.HTMLInputElement
 
@@ -30,7 +29,7 @@ import org.w3c.dom.HTMLInputElement
  *
  *  * For a detailed explanation and examples of usage have a look at the [inputField] function!
  */
-open class InputFieldComponent(protected val value: Store<String>?) :
+open class InputFieldComponent(protected val valueStore: Store<String>?) :
     Component<Unit>,
     EventProperties<HTMLInputElement> by EventMixin(),
     ElementProperties<Input> by ElementMixin(),
@@ -60,13 +59,8 @@ open class InputFieldComponent(protected val value: Store<String>?) :
 
     val variant = ComponentProperty<InputFieldVariants.() -> Style<BasicParams>> { Theme().input.variants.outline }
     val size = ComponentProperty<FormSizes.() -> Style<BasicParams>> { Theme().input.sizes.normal }
-    val valueAttr = DynamicComponentProperty(flowOf(""))
-    fun value(value: Flow<String>) {
-        valueAttr(value)
-    }
-    fun value(value: String) {
-        valueAttr(value)
-    }
+
+    val value = DynamicComponentProperty(flowOf(""))
     val placeholder = DynamicComponentProperty(flowOf(""))
     val type = DynamicComponentProperty(flowOf(""))
     val step = DynamicComponentProperty(flowOf(""))
@@ -86,11 +80,11 @@ open class InputFieldComponent(protected val value: Store<String>?) :
                 disabled(this@InputFieldComponent.disabled.values)
                 readOnly(this@InputFieldComponent.readonly.values)
                 placeholder(this@InputFieldComponent.placeholder.values)
-                value(this@InputFieldComponent.valueAttr.values)
+                value(this@InputFieldComponent.value.values)
                 type(this@InputFieldComponent.type.values)
                 step(this@InputFieldComponent.step.values)
                 className(this@InputFieldComponent.severityClassOf(Theme().input.severity).name)
-                this@InputFieldComponent.value?.let {
+                this@InputFieldComponent.valueStore?.let {
                     value(it.data)
                     changes.values() handledBy it.update
                 }

--- a/components/src/jsMain/kotlin/dev/fritz2/components/radio.kt
+++ b/components/src/jsMain/kotlin/dev/fritz2/components/radio.kt
@@ -54,7 +54,7 @@ import org.w3c.dom.HTMLInputElement
  * }
  * ```
  */
-open class RadioComponent(protected val store: Store<Boolean>? = null) :
+open class RadioComponent(protected val value: Store<Boolean>? = null) :
     Component<Label>,
     EventProperties<HTMLInputElement> by EventMixin(),
     ElementProperties<Input> by ElementMixin(),
@@ -158,10 +158,10 @@ open class RadioComponent(protected val store: Store<Boolean>? = null) :
                     readOnly(this@RadioComponent.readonly.values)
                     type("radio")
                     name(inputName)
-                    checked(this@RadioComponent.store?.data ?: this@RadioComponent.selected.values)
+                    checked(this@RadioComponent.value?.data ?: this@RadioComponent.selected.values)
                     value("X")
                     className(this@RadioComponent.severityClassOf(Theme().radio.severity).name)
-                    this@RadioComponent.store?.let { changes.states() handledBy it.update }
+                    this@RadioComponent.value?.let { changes.states() handledBy it.update }
                     this@RadioComponent.events.value.invoke(this)
                     this@RadioComponent.element.value.invoke(this)
                 }
@@ -196,7 +196,7 @@ open class RadioComponent(protected val store: Store<Boolean>? = null) :
  * Example usage
  * ```
  * val cheeseStore = storeOf(false)
- * radio(store = cheeseStore) {
+ * radio(value = cheeseStore) {
  *      label("with extra cheese") // set the label
  *      size { normal } // choose a predefined size
  * }
@@ -215,7 +215,7 @@ open class RadioComponent(protected val store: Store<Boolean>? = null) :
  * @see RadioComponent
  *
  * @param styling a lambda expression for declaring the styling as fritz2's styling DSL
- * @param store a boolean store to handle the state and its changes automatically
+ * @param value a boolean store to handle the state and its changes automatically
  * @param baseClass optional CSS class that should be applied to the element
  * @param id the ID of the element
  * @param prefix the prefix for the generated CSS class resulting in the form ``$prefix-$hash``
@@ -223,10 +223,10 @@ open class RadioComponent(protected val store: Store<Boolean>? = null) :
  */
 fun RenderContext.radio(
     styling: BasicParams.() -> Unit = {},
-    store: Store<Boolean>? = null,
+    value: Store<Boolean>? = null,
     baseClass: StyleClass = StyleClass.None,
     id: String? = null,
     prefix: String = "radioComponent",
     build: RadioComponent.() -> Unit = {}
-): Label = RadioComponent(store).apply(build).render(this, styling, baseClass, id, prefix)
+): Label = RadioComponent(value).apply(build).render(this, styling, baseClass, id, prefix)
 

--- a/components/src/jsMain/kotlin/dev/fritz2/components/radioGroup.kt
+++ b/components/src/jsMain/kotlin/dev/fritz2/components/radioGroup.kt
@@ -43,7 +43,7 @@ import org.w3c.dom.HTMLElement
  * // simple use case showing the core functionality
  * val options = listOf("A", "B", "C")
  * val myStore = storeOf("B") // or ``null`` to select nothing
- * radioGroup(items = options, store = myStore) {
+ * radioGroup(items = options, value = myStore) {
  * }
  *
  * // one can handle the events and preselected item also manually if needed:
@@ -158,7 +158,7 @@ open class RadioGroupComponent<T>(protected val items: List<T>, protected val va
  * Example usage
  * ```
  * val options = listOf("A", "B", "C")
- * radioGroup(items = options, store = selectedItemStore) {
+ * radioGroup(items = options, value = selectedItemStore) {
  *     selectedItem(options[1]) // pre select "B", or ``null`` (default) to select nothing
  * }
  * ```

--- a/components/src/jsMain/kotlin/dev/fritz2/components/radioGroup.kt
+++ b/components/src/jsMain/kotlin/dev/fritz2/components/radioGroup.kt
@@ -58,7 +58,7 @@ import org.w3c.dom.HTMLElement
  * // use case showing some styling options and a store of List<Pair<Int,String>>
  * val myPairs = listOf((1 to "ffffff"), (2 to "rrrrrr" ), (3 to "iiiiii"), (4 to "tttttt"), ( 5 to "zzzzzz"), (6 to "222222"))
  * val myStore = storeOf(<List<Pair<Int,String>>)
- * radioGroup(items = myPairs, store = myStore) {
+ * radioGroup(items = myPairs, value = myStore) {
  *     label { it.second }
  *     size { large }
  *     selectedStyle {
@@ -67,7 +67,7 @@ import org.w3c.dom.HTMLElement
  * }
  * ```
  */
-open class RadioGroupComponent<T>(protected val items: List<T>, protected val store: Store<T>? = null) :
+open class RadioGroupComponent<T>(protected val items: List<T>, protected val value: Store<T>? = null) :
     Component<Unit>,
     InputFormProperties by InputFormMixin(),
     SeverityProperties by SeverityMixin() {
@@ -116,7 +116,7 @@ open class RadioGroupComponent<T>(protected val items: List<T>, protected val st
             (::div.styled(styling, baseClass, id, prefix) {
                 this@RadioGroupComponent.direction.value(RadioGroupLayouts)()
             }) {
-                (this@RadioGroupComponent.store?.data ?: this@RadioGroupComponent.selectedItem.values)
+                (this@RadioGroupComponent.value?.data ?: this@RadioGroupComponent.selectedItem.values)
                     .map { selectedItem ->
                         this@RadioGroupComponent.items.indexOf(selectedItem).let { if (it == -1) null else it }
                     } handledBy internalStore.update
@@ -138,7 +138,7 @@ open class RadioGroupComponent<T>(protected val items: List<T>, protected val st
                 }
                 EventsContext(this, internalStore.toggle.map { this@RadioGroupComponent.items[it] }).apply {
                     this@RadioGroupComponent.events.value(this)
-                    this@RadioGroupComponent.store?.let { selected handledBy it.update }
+                    this@RadioGroupComponent.value?.let { selected handledBy it.update }
                 }
             }
         }
@@ -167,7 +167,7 @@ open class RadioGroupComponent<T>(protected val items: List<T>, protected val st
  *
  * @param styling a lambda expression for declaring the styling as fritz2's styling DSL
  * @param items a list of all available options
- * @param store for backing up the preselected item and reflecting the selection automatically.
+ * @param value for backing up the preselected item and reflecting the selection automatically.
  * @param baseClass optional CSS class that should be applied to the element
  * @param id the ID of the element
  * @param prefix the prefix for the generated CSS class resulting in the form ``$prefix-$hash``
@@ -177,11 +177,11 @@ open class RadioGroupComponent<T>(protected val items: List<T>, protected val st
 fun <T> RenderContext.radioGroup(
     styling: BasicParams.() -> Unit = {},
     items: List<T>,
-    store: Store<T>? = null,
+    value: Store<T>? = null,
     baseClass: StyleClass = StyleClass.None,
     id: String? = null,
     prefix: String = "radioGroupComponent",
     build: RadioGroupComponent<T>.() -> Unit = {}
 ) {
-    RadioGroupComponent(items, store).apply(build).render(this, styling, baseClass, id, prefix)
+    RadioGroupComponent(items, value).apply(build).render(this, styling, baseClass, id, prefix)
 }

--- a/components/src/jsMain/kotlin/dev/fritz2/components/select.kt
+++ b/components/src/jsMain/kotlin/dev/fritz2/components/select.kt
@@ -33,7 +33,7 @@ import org.w3c.dom.HTMLElement
  *
  *  For a detailed explanation and examples of usage, have a look at the [selectField] function itself.
  */
-open class SelectFieldComponent<T>(protected val items: List<T>, protected val store: Store<T>? = null) :
+open class SelectFieldComponent<T>(protected val items: List<T>, protected val value: Store<T>? = null) :
     Component<Unit>,
     InputFormProperties by InputFormMixin(),
     SeverityProperties by SeverityMixin() {
@@ -93,7 +93,7 @@ open class SelectFieldComponent<T>(protected val items: List<T>, protected val s
         val grpId = id ?: uniqueId()
 
         context.apply {
-            (this@SelectFieldComponent.store?.data ?: this@SelectFieldComponent.selectedItem.values)
+            (this@SelectFieldComponent.value?.data ?: this@SelectFieldComponent.selectedItem.values)
                 .map { selectedItem ->
                     this@SelectFieldComponent.items.indexOf(selectedItem).let { if (it == -1) null else it }
                 } handledBy internalStore.update
@@ -140,7 +140,7 @@ open class SelectFieldComponent<T>(protected val items: List<T>, protected val s
                 }
                 EventsContext(this, internalStore.toggle.map { this@SelectFieldComponent.items[it] }).apply {
                     this@SelectFieldComponent.events.value(this)
-                    this@SelectFieldComponent.store?.let { selected handledBy it.update }
+                    this@SelectFieldComponent.value?.let { selected handledBy it.update }
                 }
             }
         }
@@ -150,14 +150,14 @@ open class SelectFieldComponent<T>(protected val items: List<T>, protected val s
 /**
  * This function generates a selectField element.
  *
- * You have to pass a store in order to handle the selected value,
+ * You have to pass a store as value in order to handle the selected value,
  * and the events will be connected automatically.
  *
  * A basic use case:
  * ```
  * val myOptions = listOf("black", "red", "yellow")
  * val selectedItem = storeOf("red") // preselect "red"
- * selectField (items = myOptions, store = selectedItem) {
+ * selectField (items = myOptions, value = selectedItem) {
  * }
  * ```
  *
@@ -165,14 +165,14 @@ open class SelectFieldComponent<T>(protected val items: List<T>, protected val s
  * ```
  * val myOptions = listOf("black", "red", "yellow")
  * val selectedItem = storeOf<String?>(null)
- * selectField (items = myOptions, store = selectedItem) {
+ * selectField (items = myOptions, value = selectedItem) {
  *      placeholder("My Placeholder") // will be shown until some item is selected!
  * }
  * ```
  *
  * Customize the appearance:
  * ```
- * selectField (items = myOptions, store = selectedItem) {
+ * selectField (items = myOptions, value = selectedItem) {
  *      icon { fromTheme { circleAdd } }
  *      size { large }
  *      variant { flushed }
@@ -183,14 +183,14 @@ open class SelectFieldComponent<T>(protected val items: List<T>, protected val s
  * ```
  * val persons = listOf(Person("John Doe", 37), Person("Jane Doe", 35))
  * val selectedItem = storeOf(persons[0])
- * selectField(items = persons, store = selectedItem) {
+ * selectField(items = persons, value = selectedItem) {
  *      label { it.name } // pass a lambda expression to create a label string of an specific type
  * }
  * ```
  *
  * @param styling a lambda expression for declaring the styling as fritz2's styling DSL
  * @param items a list of all available options
- * @param store for backing up the preselected item and reflecting the selection automatically.
+ * @param value for backing up the preselected item and reflecting the selection automatically.
  * @param baseClass optional CSS class that should be applied to the element
  * @param id the ID of the element
  * @param prefix the prefix for the generated CSS class resulting in the form ``$prefix-$hash``
@@ -200,11 +200,11 @@ open class SelectFieldComponent<T>(protected val items: List<T>, protected val s
 fun <T> RenderContext.selectField(
     styling: BasicParams.() -> Unit = {},
     items: List<T>,
-    store: Store<T>? = null,
+    value: Store<T>? = null,
     baseClass: StyleClass = StyleClass.None,
     id: String? = null,
     prefix: String = "selectField",
     build: SelectFieldComponent<T>.() -> Unit,
 ) {
-    SelectFieldComponent(items, store).apply(build).render(this, styling, baseClass, id, prefix)
+    SelectFieldComponent<T>(items, value).apply(build).render(this, styling, baseClass, id, prefix)
 }

--- a/components/src/jsMain/kotlin/dev/fritz2/components/switch.kt
+++ b/components/src/jsMain/kotlin/dev/fritz2/components/switch.kt
@@ -61,7 +61,7 @@ import org.w3c.dom.HTMLInputElement
  * }
  * ```
  */
-open class SwitchComponent(protected val store: Store<Boolean>? = null) :
+open class SwitchComponent(protected val value: Store<Boolean>? = null) :
     Component<Label>,
     EventProperties<HTMLInputElement> by EventMixin(),
     ElementProperties<Input> by ElementMixin(),
@@ -141,9 +141,9 @@ open class SwitchComponent(protected val store: Store<Boolean>? = null) :
                     disabled(this@SwitchComponent.disabled.values)
                     readOnly(this@SwitchComponent.readonly.values)
                     type("checkbox")
-                    checked(this@SwitchComponent.store?.data ?: this@SwitchComponent.checked.values)
+                    checked(this@SwitchComponent.value?.data ?: this@SwitchComponent.checked.values)
                     this@SwitchComponent.events.value.invoke(this)
-                    this@SwitchComponent.store?.let { changes.states() handledBy it.update }
+                    this@SwitchComponent.value?.let { changes.states() handledBy it.update }
                     className(this@SwitchComponent.severityClassOf(Theme().switch.severity).name)
                     this@SwitchComponent.element.value.invoke(this)
                 }
@@ -185,7 +185,7 @@ open class SwitchComponent(protected val store: Store<Boolean>? = null) :
  * ```
  * // Use a store
  * val cheeseStore = storeOf(false)
- * switch(store=cheeseStore) {
+ * switch(value=cheeseStore) {
  *      label("with extra cheese") // set the label
  *      size { normal } // choose a predefined size
  * }
@@ -204,7 +204,7 @@ open class SwitchComponent(protected val store: Store<Boolean>? = null) :
  * @see SwitchComponent
  *
  * @param styling a lambda expression for declaring the styling as fritz2's styling DSL
- * @param store a boolean store to handle the state and its changes automatically
+ * @param value a boolean store to handle the state and its changes automatically
  * @param baseClass optional CSS class that should be applied to the element
  * @param id the ID of the element
  * @param prefix the prefix for the generated CSS class resulting in the form ``$prefix-$hash``
@@ -212,9 +212,9 @@ open class SwitchComponent(protected val store: Store<Boolean>? = null) :
  */
 fun RenderContext.switch(
     styling: BasicParams.() -> Unit = {},
-    store: Store<Boolean>? = null,
+    value: Store<Boolean>? = null,
     baseClass: StyleClass = StyleClass.None,
     id: String? = null,
     prefix: String = "switchComponent",
     build: SwitchComponent.() -> Unit = {}
-): Label = SwitchComponent(store).apply(build).render(this, styling, baseClass, id, prefix)
+): Label = SwitchComponent(value).apply(build).render(this, styling, baseClass, id, prefix)

--- a/components/src/jsMain/kotlin/dev/fritz2/components/switch.kt
+++ b/components/src/jsMain/kotlin/dev/fritz2/components/switch.kt
@@ -42,7 +42,7 @@ import org.w3c.dom.HTMLInputElement
  * Example usage
  * ```
  * val cheeseStore = storeOf(false)
- * switch(store = cheeseStore) {
+ * switch(value = cheeseStore) {
  *      label("with extra cheese") // set the label
  *      size { normal } // choose a predefined size
  * }

--- a/components/src/jsMain/kotlin/dev/fritz2/components/textarea.kt
+++ b/components/src/jsMain/kotlin/dev/fritz2/components/textarea.kt
@@ -12,6 +12,7 @@ import dev.fritz2.styling.params.Style
 import dev.fritz2.styling.params.styled
 import dev.fritz2.styling.staticStyle
 import dev.fritz2.styling.theme.*
+import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flowOf
 import org.w3c.dom.HTMLTextAreaElement
 
@@ -30,7 +31,7 @@ import org.w3c.dom.HTMLTextAreaElement
  *  * For a detailed explanation and examples of usage have a look at the [textArea] function !
  *
  */
-open class TextAreaComponent(protected val store: Store<String>? = null) :
+open class TextAreaComponent(protected val value: Store<String>? = null) :
     Component<Unit>,
     EventProperties<HTMLTextAreaElement> by EventMixin(),
     ElementProperties<TextArea> by ElementMixin(),
@@ -51,7 +52,14 @@ open class TextAreaComponent(protected val store: Store<String>? = null) :
         )
     }
 
-    val value = DynamicComponentProperty(flowOf(""))
+    val valueAttr = DynamicComponentProperty(flowOf(""))
+    fun value(value: Flow<String>) {
+        valueAttr(value)
+    }
+    fun value(value: String) {
+        valueAttr(value)
+    }
+
     val variant = ComponentProperty<TextAreaVariants.() -> Style<BasicParams>> { basic }
     val placeholder = DynamicComponentProperty(flowOf(""))
     val resizeBehavior = ComponentProperty<TextAreaResize.() -> Style<BasicParams>> { Theme().textArea.resize.both }
@@ -73,9 +81,9 @@ open class TextAreaComponent(protected val store: Store<String>? = null) :
                 disabled(this@TextAreaComponent.disabled.values)
                 readOnly(this@TextAreaComponent.readonly.values)
                 placeholder(this@TextAreaComponent.placeholder.values)
-                value(this@TextAreaComponent.value.values)
+                value(this@TextAreaComponent.valueAttr.values)
                 className(this@TextAreaComponent.severityClassOf(Theme().textArea.severity).name)
-                this@TextAreaComponent.store?.let {
+                this@TextAreaComponent.value?.let {
                     value(it.data)
                     changes.values() handledBy it.update
                 }
@@ -102,7 +110,7 @@ open class TextAreaComponent(protected val store: Store<String>? = null) :
  *  - events -> access the DOM events of the underlying HTML element
  *  - element -> basic properties of the textarea html element; use with caution!
  *
- * textArea(store = dataStore) {
+ * textArea(value = dataStore) {
  *     placeholder { "My placeholder" } // render a placeholder text for empty textarea
  *     resizeBehavior { horizontal } // resize textarea horizontal
  *     size { small } // render a smaller textarea
@@ -137,7 +145,7 @@ open class TextAreaComponent(protected val store: Store<String>? = null) :
  * @see TextAreaComponent
  *
  * @param styling a lambda expression for declaring the styling as fritz2's styling DSL
- * @param store optional [Store] that holds the data of the textarea
+ * @param value optional [Store] that holds the data of the textarea
  * @param baseClass optional CSS class that should be applied to the element
  * @param id the ID of the element
  * @param prefix the prefix for the generated CSS class resulting in the form ``$prefix-$hash``
@@ -147,11 +155,11 @@ open class TextAreaComponent(protected val store: Store<String>? = null) :
 
 fun RenderContext.textArea(
     styling: BasicParams.() -> Unit = {},
-    store: Store<String>? = null,
+    value: Store<String>? = null,
     baseClass: StyleClass = StyleClass.None,
     id: String? = null,
     prefix: String = "textArea",
     build: TextAreaComponent.() -> Unit
 ) {
-    TextAreaComponent(store).apply(build).render(this, styling, baseClass, id, prefix)
+    TextAreaComponent(value).apply(build).render(this, styling, baseClass, id, prefix)
 }

--- a/components/src/jsMain/kotlin/dev/fritz2/components/textarea.kt
+++ b/components/src/jsMain/kotlin/dev/fritz2/components/textarea.kt
@@ -31,7 +31,7 @@ import org.w3c.dom.HTMLTextAreaElement
  *  * For a detailed explanation and examples of usage have a look at the [textArea] function !
  *
  */
-open class TextAreaComponent(protected val value: Store<String>? = null) :
+open class TextAreaComponent(protected val valueStore: Store<String>? = null) :
     Component<Unit>,
     EventProperties<HTMLTextAreaElement> by EventMixin(),
     ElementProperties<TextArea> by ElementMixin(),
@@ -52,14 +52,7 @@ open class TextAreaComponent(protected val value: Store<String>? = null) :
         )
     }
 
-    val valueAttr = DynamicComponentProperty(flowOf(""))
-    fun value(value: Flow<String>) {
-        valueAttr(value)
-    }
-    fun value(value: String) {
-        valueAttr(value)
-    }
-
+    val value = DynamicComponentProperty(flowOf(""))
     val variant = ComponentProperty<TextAreaVariants.() -> Style<BasicParams>> { basic }
     val placeholder = DynamicComponentProperty(flowOf(""))
     val resizeBehavior = ComponentProperty<TextAreaResize.() -> Style<BasicParams>> { Theme().textArea.resize.both }
@@ -81,9 +74,9 @@ open class TextAreaComponent(protected val value: Store<String>? = null) :
                 disabled(this@TextAreaComponent.disabled.values)
                 readOnly(this@TextAreaComponent.readonly.values)
                 placeholder(this@TextAreaComponent.placeholder.values)
-                value(this@TextAreaComponent.valueAttr.values)
+                value(this@TextAreaComponent.value.values)
                 className(this@TextAreaComponent.severityClassOf(Theme().textArea.severity).name)
-                this@TextAreaComponent.value?.let {
+                this@TextAreaComponent.valueStore?.let {
                     value(it.data)
                     changes.values() handledBy it.update
                 }


### PR DESCRIPTION
For a better readability and intelligibility the parameter **store** refactores to **value** or rather **values**.
**value** is intended for components with a ``Store<T>`` and **values** is intended for ``Store<List<T>>``.

**Until 0.9.x**
```kotlin
 inputField(store = myStore) {}
 checkboxGroup(store = myListStore, items = myItems) {}
```
**New**
```kotlin
inputField(value = myStore) {}
checkboxGroup(values = myListStore, items = myItems) {}
```

Especially the inputField and textArea get a better intelligibility .

**Until 0.9.x**
```kotlin
 inputField(store = myStore) {} // Store variant
 inputField { value(myFlow) } // Flow variant
```

**New**
```kotlin
 inputField(value= myStore) {} // Store variant
 inputField { value(myFlow) } // Flow variant
```

