### PR TITLE
Extends of ColorScheme approach

### DIFF
--- a/components/src/jsMain/kotlin/dev/fritz2/components/alert.kt
+++ b/components/src/jsMain/kotlin/dev/fritz2/components/alert.kt
@@ -50,22 +50,19 @@ import kotlinx.coroutines.flow.flowOf
  * ```
  */
 open class AlertComponent : Component<Unit> {
-
-    companion object {
-        private const val accentDecorationThickness = "4px"
-    }
-
     val sizes = ComponentProperty<FormSizes.() -> Style<BasicParams>> { normal }
     val stacking = ComponentProperty<AlertStacking.() -> Style<BasicParams>> { separated }
     val severity = ComponentProperty<AlertSeverities.() -> AlertSeverity> { info }
-    val variant = ComponentProperty<AlertVariants.() -> AlertVariantStyleFactory> { solid }
 
-    val variantStyles: AlertVariantStyles
-        get() {
-            val alertSeverity = severity.value.invoke(Theme().alert.severities)
-            val alertVariantFactory = variant.value.invoke(Theme().alert.variants)
-            return alertVariantFactory.invoke(alertSeverity.color)
-        }
+    object VariantContext {
+        val solid = 1
+        val subtle = 2
+        val leftAccent = 3
+        val topAccent = 4
+        val discreet = 5
+    }
+
+    val variant = ComponentProperty<VariantContext.() -> Int> { solid }
 
     // the icon specified in AlertSeverity is used if no icon is specified manually
     val icon = ComponentProperty<(Icons.() -> IconDefinition)?>(value = null)
@@ -88,9 +85,7 @@ open class AlertComponent : Component<Unit> {
         }
     }
 
-    @Suppress("unused")
     fun title(value: String) = title(flowOf(value))
-
     fun content(value: RenderContext.() -> Unit) {
         content = value
     }
@@ -114,29 +109,26 @@ open class AlertComponent : Component<Unit> {
         id: String?,
         prefix: String,
     ) {
-        val styles = variantStyles
-
         context.apply {
             (::div.styled(baseClass = baseClass, id = id, prefix = prefix) {
                 styling()
                 display { flex }
                 position { relative { } }
-                styles.background()
+                when (this@AlertComponent.variant.value(VariantContext)) {
+                    VariantContext.solid ->
+                        Theme().alert.variants
+                            .solid(this, this@AlertComponent.severity.value(Theme().alert.severities))
+                    VariantContext.subtle ->
+                        Theme().alert.variants
+                            .subtle(this, this@AlertComponent.severity.value(Theme().alert.severities))
+                    VariantContext.leftAccent ->
+                        Theme().alert.variants
+                            .leftAccent(this, this@AlertComponent.severity.value(Theme().alert.severities))
+                    VariantContext.topAccent ->
+                        Theme().alert.variants
+                            .topAccent(this, this@AlertComponent.severity.value(Theme().alert.severities))
+                }
             }) {
-                (::div.styled {
-                    width { "100%" }
-                    height { accentDecorationThickness }
-                    position { absolute { } }
-                    styles.decorationTop()
-                }) { }
-
-                (::div.styled {
-                    width { accentDecorationThickness }
-                    height { "100%" }
-                    position { absolute { } }
-                    styles.decorationLeft()
-                }) { }
-
                 (::div.styled {
                     display { flex }
                     css("flex-direction: row")
@@ -146,7 +138,6 @@ open class AlertComponent : Component<Unit> {
                 }) {
                     (::div.styled {
                         css("margin-right: var(--al-icon-margin)")
-                        styles.accent()
                     }) {
                         icon({
                             css("width: var(--al-icon-size)")
@@ -159,13 +150,11 @@ open class AlertComponent : Component<Unit> {
                             }
                         }
                     }
-
                     (::div.styled {
                         display { inlineBlock }
                         verticalAlign { middle }
                         width { "100%" }
                         lineHeight { "1.2em" }
-                        styles.text()
                     }) {
                         this@AlertComponent.title?.invoke(this)
                         this@AlertComponent.content?.invoke(this)

--- a/components/src/jsMain/kotlin/dev/fritz2/components/alert.kt
+++ b/components/src/jsMain/kotlin/dev/fritz2/components/alert.kt
@@ -54,15 +54,19 @@ open class AlertComponent : Component<Unit> {
     val stacking = ComponentProperty<AlertStacking.() -> Style<BasicParams>> { separated }
     val severity = ComponentProperty<AlertSeverities.() -> AlertSeverity> { info }
 
-    object VariantContext {
-        val solid = 1
-        val subtle = 2
-        val leftAccent = 3
-        val topAccent = 4
-        val discreet = 5
+    enum class AlertVariant {
+        SOLID, SUBTLE, LEFT_ACCENT, TOP_ACCENT, DISCREET
     }
 
-    val variant = ComponentProperty<VariantContext.() -> Int> { solid }
+    object VariantContext {
+        val solid : AlertVariant = AlertVariant.SOLID
+        val subtle = AlertVariant.SUBTLE
+        val leftAccent = AlertVariant.LEFT_ACCENT
+        val topAccent = AlertVariant.TOP_ACCENT
+        val discreet = AlertVariant.DISCREET
+    }
+
+    val variant = ComponentProperty<VariantContext.() -> AlertVariant> { solid }
 
     // the icon specified in AlertSeverity is used if no icon is specified manually
     val icon = ComponentProperty<(Icons.() -> IconDefinition)?>(value = null)

--- a/components/src/jsMain/kotlin/dev/fritz2/components/alert.kt
+++ b/components/src/jsMain/kotlin/dev/fritz2/components/alert.kt
@@ -119,18 +119,21 @@ open class AlertComponent : Component<Unit> {
                 display { flex }
                 position { relative { } }
                 when (this@AlertComponent.variant.value(VariantContext)) {
-                    VariantContext.solid ->
+                    AlertVariant.SOLID ->
                         Theme().alert.variants
                             .solid(this, this@AlertComponent.severity.value(Theme().alert.severities))
-                    VariantContext.subtle ->
+                    AlertVariant.SUBTLE ->
                         Theme().alert.variants
                             .subtle(this, this@AlertComponent.severity.value(Theme().alert.severities))
-                    VariantContext.leftAccent ->
+                    AlertVariant.LEFT_ACCENT ->
                         Theme().alert.variants
                             .leftAccent(this, this@AlertComponent.severity.value(Theme().alert.severities))
-                    VariantContext.topAccent ->
+                    AlertVariant.TOP_ACCENT ->
                         Theme().alert.variants
                             .topAccent(this, this@AlertComponent.severity.value(Theme().alert.severities))
+                    AlertVariant.DISCREET ->
+                        Theme().alert.variants
+                            .discreet(this, this@AlertComponent.severity.value(Theme().alert.severities))
                 }
             }) {
                 (::div.styled {

--- a/components/src/jsMain/kotlin/dev/fritz2/components/button.kt
+++ b/components/src/jsMain/kotlin/dev/fritz2/components/button.kt
@@ -23,7 +23,7 @@ import org.w3c.dom.events.MouseEvent
  * If not, just use those functions for stetting up a button!
  *
  * Much more important are the _configuration_ functions. You can configure the following aspects:
- *  - the background color
+ *  - the type (``colorScheme``) - default is ``primary``
  *  - the label text
  *  - the icon including its position (left or right)
  *  - a state called ``loading`` for visualizing a longer background task
@@ -139,19 +139,19 @@ open class PushButtonComponent :
         }
     }
 
-//    enum class ButtonVariant {
-//        OUTLINE, SOLID, GHOST, LINK
-//    }
+    enum class ButtonVariant {
+        OUTLINE, SOLID, GHOST, LINK
+    }
 
     object VariantContext {
-        const val outline = 1
-        const val solid = 2
-        const val ghost = 3
-        const val link = 4
+        val outline = ButtonVariant.OUTLINE
+        val solid = ButtonVariant.SOLID
+        val ghost = ButtonVariant.GHOST
+        val link = ButtonVariant.LINK
     }
 
     val type = ComponentProperty<PushButtonTypes.() -> ColorScheme> { Theme().button.types.primary }
-    val variant = ComponentProperty<VariantContext.() -> Int> { solid }
+    val variant = ComponentProperty<VariantContext.() -> ButtonVariant> { solid }
     val size = ComponentProperty<FormSizes.() -> Style<BasicParams>> { Theme().button.sizes.normal }
 
     private var text: (RenderContext.(hide: Boolean) -> Unit)? = null

--- a/components/src/jsMain/kotlin/dev/fritz2/components/button.kt
+++ b/components/src/jsMain/kotlin/dev/fritz2/components/button.kt
@@ -226,13 +226,13 @@ open class PushButtonComponent :
         context.apply {
             (::button.styled(styling, baseClass + staticCss, id, prefix) {
                when(this@PushButtonComponent.variant.value(VariantContext)) {
-                   VariantContext.solid ->
+                   ButtonVariant.SOLID ->
                        Theme().button.variants.solid(this, this@PushButtonComponent.type.value(Theme().button.types))
-                   VariantContext.link ->
+                   ButtonVariant.LINK ->
                        Theme().button.variants.link(this, this@PushButtonComponent.type.value(Theme().button.types))
-                   VariantContext.outline ->
+                   ButtonVariant.OUTLINE ->
                        Theme().button.variants.outline(this, this@PushButtonComponent.type.value(Theme().button.types))
-                   VariantContext.ghost ->
+                   ButtonVariant.GHOST ->
                        Theme().button.variants.ghost(this, this@PushButtonComponent.type.value(Theme().button.types))
                 }
                 this@PushButtonComponent.size.value.invoke(Theme().button.sizes)()

--- a/components/src/jsMain/kotlin/dev/fritz2/components/button.kt
+++ b/components/src/jsMain/kotlin/dev/fritz2/components/button.kt
@@ -1,6 +1,5 @@
 package dev.fritz2.components
 
-import dev.fritz2.components.validation.Severity
 import dev.fritz2.dom.DomListener
 import dev.fritz2.dom.Listener
 import dev.fritz2.dom.html.Button
@@ -8,7 +7,10 @@ import dev.fritz2.dom.html.RenderContext
 import dev.fritz2.styling.StyleClass
 import dev.fritz2.styling.params.*
 import dev.fritz2.styling.staticStyle
-import dev.fritz2.styling.theme.*
+import dev.fritz2.styling.theme.ColorScheme
+import dev.fritz2.styling.theme.FormSizes
+import dev.fritz2.styling.theme.PushButtonTypes
+import dev.fritz2.styling.theme.Theme
 import kotlinx.coroutines.flow.Flow
 import org.w3c.dom.HTMLButtonElement
 import org.w3c.dom.events.MouseEvent
@@ -137,19 +139,19 @@ open class PushButtonComponent :
         }
     }
 
-    enum class ButtonVariant {
-        OUTLINE, SOLID, GHOST, LINK
-    }
+//    enum class ButtonVariant {
+//        OUTLINE, SOLID, GHOST, LINK
+//    }
 
     object VariantContext {
-        val outline: ButtonVariant = ButtonVariant.OUTLINE
-        val solid: ButtonVariant = ButtonVariant.SOLID
-        val ghost: ButtonVariant = ButtonVariant.GHOST
-        val link: ButtonVariant = ButtonVariant.LINK
+        const val outline = 1
+        const val solid = 2
+        const val ghost = 3
+        const val link = 4
     }
 
     val type = ComponentProperty<PushButtonTypes.() -> ColorScheme> { Theme().button.types.primary }
-    val variant = ComponentProperty<VariantContext.() -> ButtonVariant> { solid }
+    val variant = ComponentProperty<VariantContext.() -> Int> { solid }
     val size = ComponentProperty<FormSizes.() -> Style<BasicParams>> { Theme().button.sizes.normal }
 
     private var text: (RenderContext.(hide: Boolean) -> Unit)? = null
@@ -224,10 +226,14 @@ open class PushButtonComponent :
         context.apply {
             (::button.styled(styling, baseClass + staticCss, id, prefix) {
                when(this@PushButtonComponent.variant.value(VariantContext)) {
-                   ButtonVariant.SOLID -> Theme().button.variants.solid(this, this@PushButtonComponent.type.value( Theme().button.types))
-                   ButtonVariant.LINK -> Theme().button.variants.link(this, this@PushButtonComponent.type.value( Theme().button.types))
-                   ButtonVariant.OUTLINE -> Theme().button.variants.outline(this, this@PushButtonComponent.type.value( Theme().button.types))
-                   ButtonVariant.GHOST -> Theme().button.variants.ghost(this, this@PushButtonComponent.type.value( Theme().button.types))
+                   VariantContext.solid ->
+                       Theme().button.variants.solid(this, this@PushButtonComponent.type.value(Theme().button.types))
+                   VariantContext.link ->
+                       Theme().button.variants.link(this, this@PushButtonComponent.type.value(Theme().button.types))
+                   VariantContext.outline ->
+                       Theme().button.variants.outline(this, this@PushButtonComponent.type.value(Theme().button.types))
+                   VariantContext.ghost ->
+                       Theme().button.variants.ghost(this, this@PushButtonComponent.type.value(Theme().button.types))
                 }
                 this@PushButtonComponent.size.value.invoke(Theme().button.sizes)()
             }) {

--- a/components/src/jsMain/kotlin/dev/fritz2/components/navbar.kt
+++ b/components/src/jsMain/kotlin/dev/fritz2/components/navbar.kt
@@ -71,7 +71,7 @@ open class NavbarComponent : Component<Unit> {
                         top {
                             width { "6px" }
                             style { solid }
-                            color { primary.base }
+                            color { primary.main }
                         }
 
                         bottom {

--- a/components/src/jsMain/kotlin/dev/fritz2/components/select.kt
+++ b/components/src/jsMain/kotlin/dev/fritz2/components/select.kt
@@ -64,7 +64,7 @@ open class SelectFieldComponent<T>(protected val items: List<T>, protected val s
         focus {
             focus {
                 border {
-                    color { primary.base }
+                    color { primary.main }
                 }
                 boxShadow { outline }
             }
@@ -77,7 +77,7 @@ open class SelectFieldComponent<T>(protected val items: List<T>, protected val s
 
         disabled {
             background {
-                color { neutral }
+                color { neutral.main }
             }
             color { disabled }
             hover {

--- a/components/src/jsMain/kotlin/dev/fritz2/components/textarea.kt
+++ b/components/src/jsMain/kotlin/dev/fritz2/components/textarea.kt
@@ -69,7 +69,7 @@ open class TextAreaComponent(protected val valueStore: Store<String>? = null) :
             (::textarea.styled(styling, baseClass + staticCss, id, prefix) {
                 this@TextAreaComponent.resizeBehavior.value.invoke(Theme().textArea.resize)()
                 this@TextAreaComponent.size.value.invoke(Theme().textArea.sizes)()
-                this@TextAreaComponent.variant.value.invoke(Theme().textArea.variants)
+                this@TextAreaComponent.variant.value.invoke(Theme().textArea.variants)()
             }){
                 disabled(this@TextAreaComponent.disabled.values)
                 readOnly(this@TextAreaComponent.readonly.values)

--- a/components/src/jsMain/kotlin/dev/fritz2/components/textarea.kt
+++ b/components/src/jsMain/kotlin/dev/fritz2/components/textarea.kt
@@ -69,7 +69,7 @@ open class TextAreaComponent(protected val store: Store<String>? = null) :
 
         disabled {
             background {
-                color { neutral }
+                color { neutral.main }
             }
             color { disabled }
 

--- a/components/src/jsMain/kotlin/dev/fritz2/components/toast.kt
+++ b/components/src/jsMain/kotlin/dev/fritz2/components/toast.kt
@@ -224,7 +224,7 @@ open class ToastComponent : ManagedComponent<Unit>,
     val content = ComponentProperty<(RenderContext.() -> Unit)?>(null)
     val placement = ComponentProperty<Placement.() -> String> { bottomRight }
     val duration = ComponentProperty(5000L)
-    val background = ComponentProperty<Colors.() -> ColorProperty> { info }
+    val background = ComponentProperty<Colors.() -> ColorProperty> { info.main }
 
     /**
      * This method registers one toast at the central toast store and creates a rendering expression that will be

--- a/styling/src/jsMain/kotlin/dev.fritz2.styling/theme/default.kt
+++ b/styling/src/jsMain/kotlin/dev.fritz2.styling/theme/default.kt
@@ -50,9 +50,14 @@ open class DefaultTheme : Theme {
             override val gray900 = "#171923"
 
             override val neutral = // white
-                ColorScheme(main = "#ffffff", mainContrast = gray700, highlight = gray100, highlightContrast = gray700)
+                ColorScheme(
+                    main = "#ffffff",
+                    mainContrast = gray700,
+                    highlight = gray100,
+                    highlightContrast = gray700
+                )
 
-            override val primary = // blue primary.inverted
+            override val primary =
                 ColorScheme(
                     main = "#0C5173",
                     mainContrast = gray100,
@@ -60,7 +65,7 @@ open class DefaultTheme : Theme {
                     highlightContrast = gray600
                 )
 
-            override val secondary = // yellow
+            override val secondary =
                 ColorScheme(
                     main = "#E6A300",
                     mainContrast = gray100,
@@ -68,35 +73,40 @@ open class DefaultTheme : Theme {
                     highlightContrast = gray600
                 )
 
-            override val tertiary = // grey
-                ColorScheme(main = gray600, mainContrast = gray100, highlight = gray300, highlightContrast = gray600)
+            override val tertiary =
+                ColorScheme(
+                    main = gray600,
+                    mainContrast = gray100,
+                    highlight = gray300,
+                    highlightContrast = gray600
+                )
 
             // Signal Colors
-            override val info =  // blue
+            override val info =
                 ColorScheme(
                     main = "#219EBC",
                     mainContrast = neutral.main,
                     highlight = "#d2ebf1",
                     highlightContrast = gray700
-                ) //3dbddd
+                )
 
-            override val success = // green
+            override val success =
                 ColorScheme(
                     main = "#00A848",
                     mainContrast = neutral.main,
                     highlight = "#ccedda",
                     highlightContrast = gray700
-                ) //E77457 00d95E
+                )
 
-            override val warning =   // orange
+            override val warning =
                 ColorScheme(
                     main = "#F08B3A",
                     mainContrast = neutral.main,
                     highlight = "#fce7d7",
                     highlightContrast = gray700
-                ) //f3a462
+                )
 
-            override val danger =  // red
+            override val danger =
                 ColorScheme(
                     main = "#E14F2A",
                     mainContrast = neutral.main,
@@ -1447,19 +1457,19 @@ open class DefaultTheme : Theme {
 
                 }
 
-                background { color { "white" } }
+                background { backgroundColor }
+                color { fontColor }
 
                 disabled {
                     background {
-                        color { neutral }
+                        color { neutral.highlight }
                     }
                     color { disabled }
-
                 }
 
                 focus {
                     border {
-                        color { "#3182ce" }
+                        color { focus }
                     }
                     boxShadow { outline }
                 }
@@ -1474,125 +1484,70 @@ open class DefaultTheme : Theme {
         override val severities: AlertSeverities
             get() = object : AlertSeverities {
                 override val info: AlertSeverity = object : AlertSeverity {
-                    override val color = colors.info.main
+                    override val colorScheme = colors.info
                     override val icon = icons.circleInformation
                 }
                 override val success: AlertSeverity = object : AlertSeverity {
-                    override val color = colors.success.main
+                    override val colorScheme = colors.success
                     override val icon = icons.circleCheck
                 }
                 override val warning: AlertSeverity = object : AlertSeverity {
-                    override val color = colors.warning.main
+                    override val colorScheme = colors.warning
                     override val icon = icons.circleWarning
                 }
                 override val error: AlertSeverity = object : AlertSeverity {
-                    override val color = colors.danger.main
+                    override val colorScheme = colors.danger
                     override val icon = icons.circleError
                 }
             }
 
         override val variants: AlertVariants = object : AlertVariants {
-            /*
-            TODO: Use text colors from theme
-             */
-            private val textColorDark = rgb(0, 0, 0)
-            private val textColorLight = rgb(255, 255, 255)
-
-            override val subtle: AlertVariantStyleFactory = { it ->
-                object : AlertVariantStyles {
-                    override val background: Style<BasicParams> = {
-                        background { color { alterHexColorBrightness(it, 1.5) } }
-                    }
-                    override val text: Style<BasicParams> = {
-                        color { textColorDark }
-                    }
-                    override val accent: Style<BasicParams> = {
-                        color { it }
-                    }
-                    override val decorationLeft: Style<BasicParams> = {
-                        css("visibility: hidden")
-                    }
-                    override val decorationTop: Style<BasicParams> = {
-                        css("visibility: hidden")
-                    }
+            override val subtle: BasicParams.(AlertSeverity) -> Unit = { alertSeverity ->
+                background {
+                    color { alertSeverity.colorScheme.highlight }
                 }
+                color { alertSeverity.colorScheme.highlightContrast }
             }
-            override val solid: AlertVariantStyleFactory = {
-                object : AlertVariantStyles {
-                    override val background: Style<BasicParams> = {
-                        background { color { it } }
-                    }
-                    override val text: Style<BasicParams> = {
-                        color { textColorLight }
-                    }
-                    override val accent: Style<BasicParams> = {
-                        color { textColorLight }
-                    }
-                    override val decorationLeft: Style<BasicParams> = {
-                        css("visibility: hidden")
-                    }
-                    override val decorationTop: Style<BasicParams> = {
-                        css("visibility: hidden")
-                    }
+            override val solid: BasicParams.(AlertSeverity) -> Unit = { alertSeverity ->
+                background {
+                    color { alertSeverity.colorScheme.main }
                 }
-            }
-            override val leftAccent: AlertVariantStyleFactory = {
-                object : AlertVariantStyles {
-                    override val background: Style<BasicParams> = {
-                        background { color { alterHexColorBrightness(it, 1.5) } }
-                    }
-                    override val text: Style<BasicParams> = {
-                        color { textColorDark }
-                    }
-                    override val accent: Style<BasicParams> = {
-                        color { it }
-                    }
-                    override val decorationLeft: Style<BasicParams> = {
-                        background { color { it } }
-                    }
-                    override val decorationTop: Style<BasicParams> = {
-                        css("visibility: hidden")
-                    }
-                }
-            }
-            override val topAccent: AlertVariantStyleFactory = {
-                object : AlertVariantStyles {
-                    override val background: Style<BasicParams> = {
-                        background { color { alterHexColorBrightness(it, 1.5) } }
-                    }
-                    override val text: Style<BasicParams> = {
-                        color { textColorDark }
-                    }
-                    override val accent: Style<BasicParams> = {
-                        color { it }
-                    }
-                    override val decorationLeft: Style<BasicParams> = {
-                        css("visibility: hidden")
-                    }
-                    override val decorationTop: Style<BasicParams> = {
-                        background { color { it } }
-                    }
-                }
+                color { alertSeverity.colorScheme.mainContrast }
             }
 
-            override val discreet: AlertVariantStyleFactory = {
-                object : AlertVariantStyles {
-                    override val background: Style<BasicParams> = {
-                        background { inherit }
-                    }
-                    override val text: Style<BasicParams> = {
-                        color { it }
-                    }
-                    override val accent: Style<BasicParams> = {
-                        color { it }
-                    }
-                    override val decorationLeft: Style<BasicParams> = {
-                        css("visibility: hidden")
-                    }
-                    override val decorationTop: Style<BasicParams> = {
-                        css("visibility: hidden")
+            override val leftAccent: BasicParams.(AlertSeverity) -> Unit = { alertSeverity ->
+                background {
+                    color { alertSeverity.colorScheme.highlight }
+                }
+                color { alertSeverity.colorScheme.highlightContrast }
+
+                borders {
+                    left {
+                        width { fat }
+                        color { alertSeverity.colorScheme.main }
+                        style { solid }
                     }
                 }
+            }
+            override val topAccent: BasicParams.(AlertSeverity) -> Unit = { alertSeverity ->
+                background {
+                    color { alertSeverity.colorScheme.highlight }
+                }
+                color { alertSeverity.colorScheme.highlightContrast }
+
+                borders {
+                    top {
+                        width { fat }
+                        color { alertSeverity.colorScheme.main }
+                        style { solid }
+                    }
+                }
+            }
+            override val discreet: BasicParams.(AlertSeverity) -> Unit = { _ ->
+                background {
+                    color { backgroundColor }
+                }
+                color { fontColor }
             }
         }
 
@@ -1619,7 +1574,7 @@ open class DefaultTheme : Theme {
 
         override val stacking = object : AlertStacking {
             override val compact: Style<BasicParams> = {
-                margin { "0" }
+                margin { none }
             }
             override val separated: Style<BasicParams> = {
                 margin { normal }
@@ -1716,10 +1671,12 @@ open class DefaultTheme : Theme {
                 fontSize { "1rem" }
                 height { "2.5rem" }
                 radius { normal }
+                background { backgroundColor }
+                color { fontColor }
                 focus {
                     focus {
                         border {
-                            color { primary.base }
+                            color { focus }
                         }
                         boxShadow { outline }
                     }
@@ -1732,7 +1689,7 @@ open class DefaultTheme : Theme {
 
                 disabled {
                     background {
-                        color { neutral }
+                        color { neutral.highlight }
                     }
                     color { disabled }
                     hover {
@@ -1764,7 +1721,10 @@ open class DefaultTheme : Theme {
                 }
 
                 hover {
-                    css("filter: brightness(90%);")
+                    background {
+                        color { primary.highlight }
+                    }
+                    color { primary.highlightContrast }
                 }
 
                 focus {

--- a/styling/src/jsMain/kotlin/dev.fritz2.styling/theme/default.kt
+++ b/styling/src/jsMain/kotlin/dev.fritz2.styling/theme/default.kt
@@ -49,20 +49,30 @@ open class DefaultTheme : Theme {
             override val gray800 = "#1A202C"
             override val gray900 = "#171923"
 
-            override val primary = // blue
-                ColorScheme(base = "#0C5173", baseContrast = gray100, highlight = "#CAE4EA", highlightContrast = gray600)
+            override val neutral = // white
+                ColorScheme(main = "#ffffff", mainContrast   = gray700, highlight = gray100, highlightContrast = gray700)
+
+            override val primary = // blue primary.inverted
+                ColorScheme(main = "#0C5173", mainContrast = gray100, highlight = "#CAE4EA", highlightContrast = gray600)
 
             override val secondary = // yellow
-                ColorScheme(base = "#E6A300", baseContrast = gray100, highlight = "#FFEDCB", highlightContrast = gray600)
+                ColorScheme(main = "#E6A300", mainContrast = gray100, highlight = "#FFEDCB", highlightContrast = gray600)
 
             override val tertiary = // grey
-                ColorScheme(base = gray600, baseContrast = gray100, highlight = gray300, highlightContrast = gray600)
+                ColorScheme(main = gray600, mainContrast = gray100, highlight = gray300, highlightContrast = gray600)
 
-            override val info = "#219EBC"       // blue
-            override val success = "#00A848"    // green
-            override val warning = "#F08B3A"    // orange
-            override val danger = "#E14F2A"     // red
-            override val neutral = "#ffffff"    // white
+            // Signal Colors
+            override val info =  // blue
+                 ColorScheme(main = "#219EBC", mainContrast = neutral.main, highlight = "#d2ebf1", highlightContrast = gray700) //3dbddd
+
+            override val success = // green
+                ColorScheme(main = "#00A848", mainContrast = neutral.main, highlight = "#ccedda", highlightContrast = gray700) //E77457 00d95E
+
+            override val warning =   // orange
+                ColorScheme(main = "#F08B3A", mainContrast = neutral.main, highlight = "#fce7d7", highlightContrast = gray700) //f3a462
+
+            override val danger =  // red
+                ColorScheme(main = "#E14F2A", mainContrast = neutral.main, highlight = "#f9dbd4", highlightContrast = gray700)
 
             override val disabled = gray300
             override val focus = primary.highlight
@@ -71,10 +81,10 @@ open class DefaultTheme : Theme {
     //FIXME: move to typography section
 
     override val backgroundColor
-        get() = colors.neutral
+        get() = colors.neutral.main
 
     override val fontColor
-        get() = colors.gray700
+        get() = colors.neutral.mainContrast
 
     override val fontFamilies = object : FontFamilies {
         override val normal =
@@ -174,7 +184,7 @@ open class DefaultTheme : Theme {
                 "2px",
                 color = colors.primary.highlight
             ),
-            danger = shadow("0", "0", "0", "1px", color = colors.danger)
+            danger = shadow("0", "0", "0", "1px", color = colors.danger.main)
         )
 
     override val zIndices = ZIndices(1, 100, 2, 200, 300, 2, 400, 2)
@@ -408,6 +418,9 @@ open class DefaultTheme : Theme {
             private val basic: Style<BasicParams> = {
                 radius { normal }
                 fontWeight { normal }
+                color { fontColor }
+                background { color { backgroundColor } }
+
                 border {
                     width { thin }
                     style { solid }
@@ -428,7 +441,7 @@ open class DefaultTheme : Theme {
 
                 disabled {
                     background {
-                        color { neutral }
+                        color { neutral.main }
                     }
                     color { disabled }
                     hover {
@@ -440,7 +453,7 @@ open class DefaultTheme : Theme {
 
                 focus {
                     border {
-                        color { primary.base }
+                        color { primary.main }
                     }
                     boxShadow { outline }
                 }
@@ -454,7 +467,7 @@ open class DefaultTheme : Theme {
                 background {
                     color { primary.highlight }
                 }
-                color { neutral }
+                color { neutral.main }
 
                 hover {
                     background { color { gray200 } }
@@ -496,7 +509,7 @@ open class DefaultTheme : Theme {
             override val success: Style<BasicParams> = {}
             override val warning: Style<BasicParams> = {}
             override val error: Style<BasicParams>
-                get() = basic(colors.danger, shadows.danger)
+                get() = basic(colors.danger.main, shadows.danger)
         }
     }
 
@@ -573,7 +586,7 @@ open class DefaultTheme : Theme {
             }
             width { "var(--cb-size)" }
             height { "var(--cb-size)" }
-            background { color { neutral } }
+            background { color { neutral.main } }
             border {
                 width { "1px" }
                 style { solid }
@@ -582,9 +595,9 @@ open class DefaultTheme : Theme {
             radius { "var(--cb-radius)" }
         }
         override val checked: Style<BasicParams> = {
-            background { color { primary.base } }
-            border { color { primary.base } }
-            color { neutral }
+            background { color { primary.main } }
+            border { color { primary.highlight } }
+            color { primary.mainContrast }
         }
 
         override val severity = object : SeverityStyles {
@@ -611,7 +624,7 @@ open class DefaultTheme : Theme {
             override val success: Style<BasicParams> = {}
             override val warning: Style<BasicParams> = {}
             override val error: Style<BasicParams>
-                get() = apply(colors.danger, colors.warning)
+                get() = apply(colors.danger.main, colors.danger.main)
         }
     }
 
@@ -646,7 +659,7 @@ open class DefaultTheme : Theme {
         override val input: Style<BasicParams> = {
             children("&:focus + div") {
                 border {
-                    color { primary.base }
+                    color { primary.main }
                 }
                 boxShadow { outline }
             }
@@ -672,7 +685,7 @@ open class DefaultTheme : Theme {
             css("justify-content:center;")
             width { "var(--rb-size)" }
             height { "var(--rb-size)" }
-            background { color { neutral } }
+            background { color { neutral.main } }
             border {
                 width { "2px" }
                 style { solid }
@@ -681,10 +694,10 @@ open class DefaultTheme : Theme {
             radius { "9999px" }
         }
         override val selected: Style<BasicParams> = {
-            background { color { primary.base } }
+            background { color { primary.main } }
             color { gray300 }
             border {
-                color { primary.base }
+                color { primary.main }
             }
             before {
                 css("content:\"\";")
@@ -698,7 +711,7 @@ open class DefaultTheme : Theme {
                 height { "50%" }
                 radius { "50%" }
                 background {
-                    color { neutral }
+                    color { neutral.main }
                 }
             }
         }
@@ -765,7 +778,7 @@ open class DefaultTheme : Theme {
             height { "var(--sw-height)" }
             radius { "9999px" }
             background {
-                color { neutral }
+                color { neutral.main }
             }
             css("transition: transform 250ms ease 0s;")
 
@@ -791,7 +804,7 @@ open class DefaultTheme : Theme {
             css("transition: all 120ms ease 0s;")
         }
         override val checked: Style<BasicParams> = {
-            background { color { primary.base } }
+            background { color { primary.main } }
         }
 
         override val severity: SeverityStyles
@@ -799,6 +812,15 @@ open class DefaultTheme : Theme {
     }
 
     override val button = object : PushButtonStyles {
+        override val types: PushButtonTypes = object : PushButtonTypes {
+            override val primary = colors.primary
+            override val secondary = colors.secondary
+            override val info = colors.info
+            override val success = colors.success
+            override val warning = colors.warning
+            override val danger = colors.danger
+        }
+        
         override val variants = object : PushButtonVariants {
             private val basic: Style<BasicParams> = {
                 lineHeight { smaller }
@@ -809,50 +831,56 @@ open class DefaultTheme : Theme {
                 }
             }
 
-            override val solid: Style<BasicParams> = {
+            override val solid: BasicParams.(ColorScheme) -> Unit = { colorScheme ->
                 basic()
-                background { color { "var(--main-color)" } }
-                color { neutral }
+                background { color { colorScheme.main } }
+                color   { colorScheme.mainContrast }
                 hover {
-                    css("filter: brightness(80%);")
+                    background {
+                        color { colorScheme.highlight }
+                    }
+                    color   { colorScheme.highlightContrast }
                 }
                 active {
-                    css("filter: brightness(120%);")
+                    background {
+                        color { colorScheme.highlight }
+                    }
+                    color   { colorScheme.highlightContrast }
                 }
             }
 
-            override val outline: Style<BasicParams> = {
+            override val outline:  BasicParams.(ColorScheme) -> Unit = { colorScheme ->
                 basic()
-                color { "var(--main-color)" }
+                color { colorScheme.main }
                 border {
                     width { thin }
                     style { solid }
-                    color { "var(--main-color)" }
+                    color { colorScheme.main }
                 }
                 hover {
                     background {
-                        color { gray200 }
+                        color { colorScheme.main }
                     }
-                    css("filter: brightness(80%);")
+                    color { colorScheme.mainContrast }
                 }
             }
 
-            override val ghost: Style<BasicParams> = {
+            override val ghost:  BasicParams.(ColorScheme) -> Unit = { colorScheme ->
                 basic()
-                color { "var(--main-color)" }
+                color { colorScheme.main }
             }
 
-            override val link: Style<BasicParams> = {
+            override val link:  BasicParams.(ColorScheme) -> Unit = { colorScheme ->
                 basic()
                 paddings { all { none } }
                 height { auto }
                 lineHeight { normal }
-                color { "var(--main-color)" }
+                color { colorScheme.main }
                 hover {
                     textDecoration { underline }
                 }
                 active {
-                    css("filter: brightness(120%);")
+                    color { colorScheme.highlightContrast }
                 }
             }
         }
@@ -905,7 +933,7 @@ open class DefaultTheme : Theme {
 
             private val basic: Style<BasicParams> = {
                 background {
-                    color { neutral }
+                    color { neutral.main }
                 }
                 padding { normal }
                 radius { tiny }
@@ -997,7 +1025,7 @@ open class DefaultTheme : Theme {
         override val size: PopoverSizes = object : PopoverSizes {
             private val basic: Style<BasicParams> = {
                 background {
-                    color { neutral }
+                    color { neutral.main }
                 }
                 paddings {
                     top { tiny }
@@ -1378,19 +1406,19 @@ open class DefaultTheme : Theme {
         override val severities: AlertSeverities
             get() = object : AlertSeverities {
                 override val info: AlertSeverity = object : AlertSeverity {
-                    override val color = colors.info
+                    override val color = colors.info.main
                     override val icon = icons.circleInformation
                 }
                 override val success: AlertSeverity = object : AlertSeverity {
-                    override val color = colors.success
+                    override val color = colors.success.main
                     override val icon = icons.circleCheck
                 }
                 override val warning: AlertSeverity = object : AlertSeverity {
-                    override val color = colors.warning
+                    override val color = colors.warning.main
                     override val icon = icons.circleWarning
                 }
                 override val error: AlertSeverity = object : AlertSeverity {
-                    override val color = colors.danger
+                    override val color = colors.danger.main
                     override val icon = icons.circleError
                 }
             }
@@ -1534,7 +1562,6 @@ open class DefaultTheme : Theme {
     override val toast = object : ToastStyles {
         override val placement = object : ToastPlacement {
             override val top: Style<BasicParams> = {
-
                 css("top:0px")
                 css("right:0px")
                 css("left:0px")
@@ -1569,18 +1596,20 @@ open class DefaultTheme : Theme {
         }
         override val status = object : ToastStatus {
             override val success: Style<BasicParams> = {
-
-                background { color { success } }
+                background { color { success.main } }
+                color { success.mainContrast }
             }
-
             override val error: Style<BasicParams> = {
-                background { color { danger } }
+                background { color { danger.main } }
+                color { danger.mainContrast }
             }
             override val warning: Style<BasicParams> = {
-                background { color { warning } }
+                background { color { warning.main } }
+                color { warning.mainContrast }
             }
             override val info: Style<BasicParams> = {
-                background { color { info } }
+                background { color { info.main } }
+                color { info.mainContrast }
             }
 
         }
@@ -1701,12 +1730,12 @@ open class DefaultTheme : Theme {
 
         override val brand: Style<FlexParams> = {
             //background { color { "rgb(44, 49, 54)"} }
-            background { color { primary.base } }
+            background { color { primary.main } }
             paddings {
                 all { small }
                 left { normal }
             }
-            color { gray200 }
+            color { primary.mainContrast }
             alignItems { center }
             borders {
                 bottom {
@@ -1721,8 +1750,8 @@ open class DefaultTheme : Theme {
 //                sm = "background: linear-gradient(0deg, ${Theme().colors.dark} 0%, ${Theme().colors.primary.base} 20%);",
 //                lg = "background: linear-gradient(0deg, ${Theme().colors.dark} 0%, ${Theme().colors.primary.base} 20%);"
 //            )
-            background { color { primary.base } }
-            color { gray200 }
+            background { color { primary.main } }
+            color { primary.mainContrast }
             minWidth { "22vw" }
         }
 

--- a/styling/src/jsMain/kotlin/dev.fritz2.styling/theme/default.kt
+++ b/styling/src/jsMain/kotlin/dev.fritz2.styling/theme/default.kt
@@ -1904,7 +1904,7 @@ open class DefaultTheme : Theme {
                 vertical { "0.6rem" }
                 horizontal { small }
             }
-            alignItems { AlignItemsValues.center }
+            alignItems { center }
             borders {
                 left {
                     width { "0.2rem" }

--- a/styling/src/jsMain/kotlin/dev.fritz2.styling/theme/default.kt
+++ b/styling/src/jsMain/kotlin/dev.fritz2.styling/theme/default.kt
@@ -50,29 +50,59 @@ open class DefaultTheme : Theme {
             override val gray900 = "#171923"
 
             override val neutral = // white
-                ColorScheme(main = "#ffffff", mainContrast   = gray700, highlight = gray100, highlightContrast = gray700)
+                ColorScheme(main = "#ffffff", mainContrast = gray700, highlight = gray100, highlightContrast = gray700)
 
             override val primary = // blue primary.inverted
-                ColorScheme(main = "#0C5173", mainContrast = gray100, highlight = "#CAE4EA", highlightContrast = gray600)
+                ColorScheme(
+                    main = "#0C5173",
+                    mainContrast = gray100,
+                    highlight = "#CAE4EA",
+                    highlightContrast = gray600
+                )
 
             override val secondary = // yellow
-                ColorScheme(main = "#E6A300", mainContrast = gray100, highlight = "#FFEDCB", highlightContrast = gray600)
+                ColorScheme(
+                    main = "#E6A300",
+                    mainContrast = gray100,
+                    highlight = "#FFEDCB",
+                    highlightContrast = gray600
+                )
 
             override val tertiary = // grey
                 ColorScheme(main = gray600, mainContrast = gray100, highlight = gray300, highlightContrast = gray600)
 
             // Signal Colors
             override val info =  // blue
-                 ColorScheme(main = "#219EBC", mainContrast = neutral.main, highlight = "#d2ebf1", highlightContrast = gray700) //3dbddd
+                ColorScheme(
+                    main = "#219EBC",
+                    mainContrast = neutral.main,
+                    highlight = "#d2ebf1",
+                    highlightContrast = gray700
+                ) //3dbddd
 
             override val success = // green
-                ColorScheme(main = "#00A848", mainContrast = neutral.main, highlight = "#ccedda", highlightContrast = gray700) //E77457 00d95E
+                ColorScheme(
+                    main = "#00A848",
+                    mainContrast = neutral.main,
+                    highlight = "#ccedda",
+                    highlightContrast = gray700
+                ) //E77457 00d95E
 
             override val warning =   // orange
-                ColorScheme(main = "#F08B3A", mainContrast = neutral.main, highlight = "#fce7d7", highlightContrast = gray700) //f3a462
+                ColorScheme(
+                    main = "#F08B3A",
+                    mainContrast = neutral.main,
+                    highlight = "#fce7d7",
+                    highlightContrast = gray700
+                ) //f3a462
 
             override val danger =  // red
-                ColorScheme(main = "#E14F2A", mainContrast = neutral.main, highlight = "#f9dbd4", highlightContrast = gray700)
+                ColorScheme(
+                    main = "#E14F2A",
+                    mainContrast = neutral.main,
+                    highlight = "#f9dbd4",
+                    highlightContrast = gray700
+                )
 
             override val disabled = gray300
             override val focus = primary.highlight
@@ -199,7 +229,8 @@ open class DefaultTheme : Theme {
     }
 
     // extra css for general layout by using theme props
-    override val global: String by lazy { """
+    override val global: String by lazy {
+        """
         html {
             line-height: ${lineHeights.large};
             -webkit-text-size-adjust: 100%;
@@ -813,14 +844,20 @@ open class DefaultTheme : Theme {
 
     override val button = object : PushButtonStyles {
         override val types: PushButtonTypes = object : PushButtonTypes {
-            override val primary = colors.primary
-            override val secondary = colors.secondary
-            override val info = colors.info
-            override val success = colors.success
-            override val warning = colors.warning
-            override val danger = colors.danger
+            override val primary
+                get() = colors.primary
+            override val secondary
+                get() = colors.secondary
+            override val info
+                get() = colors.info
+            override val success
+                get() = colors.success
+            override val warning
+                get() = colors.warning
+            override val danger
+                get() = colors.danger
         }
-        
+
         override val variants = object : PushButtonVariants {
             private val basic: Style<BasicParams> = {
                 lineHeight { smaller }
@@ -834,22 +871,22 @@ open class DefaultTheme : Theme {
             override val solid: BasicParams.(ColorScheme) -> Unit = { colorScheme ->
                 basic()
                 background { color { colorScheme.main } }
-                color   { colorScheme.mainContrast }
+                color { colorScheme.mainContrast }
                 hover {
                     background {
                         color { colorScheme.highlight }
                     }
-                    color   { colorScheme.highlightContrast }
+                    color { colorScheme.highlightContrast }
                 }
                 active {
                     background {
                         color { colorScheme.highlight }
                     }
-                    color   { colorScheme.highlightContrast }
+                    color { colorScheme.highlightContrast }
                 }
             }
 
-            override val outline:  BasicParams.(ColorScheme) -> Unit = { colorScheme ->
+            override val outline: BasicParams.(ColorScheme) -> Unit = { colorScheme ->
                 basic()
                 color { colorScheme.main }
                 border {
@@ -865,12 +902,12 @@ open class DefaultTheme : Theme {
                 }
             }
 
-            override val ghost:  BasicParams.(ColorScheme) -> Unit = { colorScheme ->
+            override val ghost: BasicParams.(ColorScheme) -> Unit = { colorScheme ->
                 basic()
                 color { colorScheme.main }
             }
 
-            override val link:  BasicParams.(ColorScheme) -> Unit = { colorScheme ->
+            override val link: BasicParams.(ColorScheme) -> Unit = { colorScheme ->
                 basic()
                 paddings { all { none } }
                 height { auto }

--- a/styling/src/jsMain/kotlin/dev.fritz2.styling/theme/definitions.kt
+++ b/styling/src/jsMain/kotlin/dev.fritz2.styling/theme/definitions.kt
@@ -1,6 +1,7 @@
 package dev.fritz2.styling.theme
 
 import dev.fritz2.styling.params.*
+import dev.fritz2.styling.params.BackgroundBlendModes.color
 
 /**
  * Defines a responsive [Property] that can have different values for different screen sizes.
@@ -176,17 +177,19 @@ interface FontFamilies {
 
 /**
  * Defines three colors for a color scheme.
- * First is [base] which is the default color and [baseContrast]
+ * First is [main] which is the default color and [mainContrast]
  * for showing things on top of [highlight] color.
  * Besides from that there is a color [highlight] for highlighting things
  * and a color [highlightContrast] for showing things on top of [highlight] color.
  */
 open class ColorScheme(
-    val base: ColorProperty,
-    val baseContrast: ColorProperty,
+    val main: ColorProperty,
+    val mainContrast: ColorProperty,
     val highlight: ColorProperty,
     val highlightContrast: ColorProperty
-)
+) {
+    fun inverted() : ColorScheme = ColorScheme(this.highlight, this.highlightContrast, this.main, this.mainContrast)
+}
 
 /**
  * Defines the scheme colors in a theme
@@ -195,11 +198,12 @@ interface Colors {
     val primary: ColorScheme
     val secondary: ColorScheme
     val tertiary: ColorScheme
-    val success: ColorProperty
-    val danger: ColorProperty
-    val warning: ColorProperty
-    val info: ColorProperty
-    val neutral: ColorProperty
+    val success: ColorScheme
+    val danger: ColorScheme
+    val warning: ColorScheme
+    val info: ColorScheme
+    val neutral: ColorScheme
+
     val disabled: ColorProperty
     val focus: ColorProperty
 
@@ -460,16 +464,27 @@ interface InputFieldVariants {
  * definition of the theme's pushButton
  */
 interface PushButtonStyles {
+    val types: PushButtonTypes
     val variants: PushButtonVariants
     val sizes: FormSizes
 }
 
-interface PushButtonVariants {
-    val outline: Style<BasicParams>
-    val solid: Style<BasicParams>
-    val ghost: Style<BasicParams>
-    val link: Style<BasicParams>
+interface PushButtonTypes {
+    val primary: ColorScheme
+    val secondary: ColorScheme
+    val info: ColorScheme
+    val success: ColorScheme
+    val warning: ColorScheme
+    val danger: ColorScheme
 }
+
+interface PushButtonVariants {
+    val outline: BasicParams.(ColorScheme) -> Unit
+    val solid: BasicParams.(ColorScheme) -> Unit
+    val ghost: BasicParams.(ColorScheme) -> Unit
+    val link: BasicParams.(ColorScheme) -> Unit
+}
+
 
 
 /**

--- a/styling/src/jsMain/kotlin/dev.fritz2.styling/theme/definitions.kt
+++ b/styling/src/jsMain/kotlin/dev.fritz2.styling/theme/definitions.kt
@@ -623,7 +623,7 @@ interface AlertStacking {
 }
 
 interface AlertSeverity {
-    val color: ColorProperty
+    val colorScheme: ColorScheme
     val icon: IconDefinition
 }
 
@@ -634,22 +634,12 @@ interface AlertSeverities {
     val error: AlertSeverity
 }
 
-typealias AlertVariantStyleFactory = (ColorProperty) -> AlertVariantStyles
-
 interface AlertVariants {
-    val subtle: AlertVariantStyleFactory
-    val solid: AlertVariantStyleFactory
-    val leftAccent: AlertVariantStyleFactory
-    val topAccent: AlertVariantStyleFactory
-    val discreet: AlertVariantStyleFactory
-}
-
-interface AlertVariantStyles {
-    val background: Style<BasicParams>
-    val text: Style<BasicParams>
-    val accent: Style<BasicParams>
-    val decorationLeft: Style<BasicParams>
-    val decorationTop: Style<BasicParams>
+    val subtle: BasicParams.(AlertSeverity) -> Unit
+    val solid: BasicParams.(AlertSeverity) -> Unit
+    val leftAccent: BasicParams.(AlertSeverity) -> Unit
+    val topAccent: BasicParams.(AlertSeverity) -> Unit
+    val discreet: BasicParams.(AlertSeverity) -> Unit
 }
 
 

--- a/styling/src/jsMain/kotlin/dev.fritz2.styling/theme/definitions.kt
+++ b/styling/src/jsMain/kotlin/dev.fritz2.styling/theme/definitions.kt
@@ -1,7 +1,6 @@
 package dev.fritz2.styling.theme
 
 import dev.fritz2.styling.params.*
-import dev.fritz2.styling.params.BackgroundBlendModes.color
 
 /**
  * Defines a responsive [Property] that can have different values for different screen sizes.
@@ -484,8 +483,6 @@ interface PushButtonVariants {
     val ghost: BasicParams.(ColorScheme) -> Unit
     val link: BasicParams.(ColorScheme) -> Unit
 }
-
-
 
 /**
  * definition of the theme's modal

--- a/styling/src/jsMain/kotlin/dev.fritz2.styling/utils.kt
+++ b/styling/src/jsMain/kotlin/dev.fritz2.styling/utils.kt
@@ -1,5 +1,7 @@
 package dev.fritz2.styling
 
+import dev.fritz2.styling.theme.ColorScheme
+
 internal const val charsLength = 52
 
 /* start at 75 for 'a' until 'z' (25) and then start at 65 for capitalised letters */


### PR DESCRIPTION
Based on issue https://github.com/jwstegemann/fritz2/issues/315 

The colors `info` , `success`, `warning`, `danger` and `neutral` changed to `ColorScheme` 

The property `color` of our `button` component refactors to `type` and based on the `colorScheme` approach now.
Our default theme deliveres following predefinitions: `primary`, `secondary`, `info`,  `success`, `warning`, `danger` but you can to use an other `ColorScheme`. Button without a type uses the `primary` ColorScheme.

`ColorScheme` got a function named `inverted()` it returns a `ColorScheme` which switches base with highlight and baseContrast with highlightContrast. A default use case can be if you want to create easily an inverted theme.

```kotlin
 // old color configuration
clickButton {
    text("danger")
    color { danger }
}

// new colorScheme apporach
clickButton {
    text("danger")
    type { danger }
}
clickButton {
    text("custom")
    type { ColorScheme("#00A848","#2D3748","#E14F2A", "#2D3748") }
}
```

You've the possibility to setup the `button` Schemes independently of the Theme 
`colorSchemes`

```kotlin
override val button = object : PushButtonStyles {
      override val types: PushButtonTypes = object : PushButtonTypes {
          override val primary
              get() =  ColorScheme(
                  main = "#00A848",
                  mainContrast = "#2D3748",
                  highlight = "#E14F2A",
                  highlightContrast = "#2D3748"
              )
         //...
      }
}
```

`InputField` and `textArea` use now the backgroundColor and fontColor of Theme and can be configured by theme 

The `alert` component got a rework by `ColorScheme` too. Calling the component is the same as before, with the addition that a ColorScheme can now also be passed into it.
```kotlin
 alert {
      content("Severity: success")
      severity { success }
  }

alert {
      content("Severity: success")
      severity { 
         ColorScheme("#00A848","#2D3748","#E14F2A", "#2D3748")
      }
  }
```
