### PR TITLE
Move background & font colors to `Colors` interface

### DIFF
--- a/styling/src/jsMain/kotlin/dev/fritz2/styling/theme/default.kt
+++ b/styling/src/jsMain/kotlin/dev/fritz2/styling/theme/default.kt
@@ -115,17 +115,12 @@ open class DefaultTheme : Theme {
                     highlightContrast = gray700
                 )
 
+            //FIXME: move to typography section
+            override val font = neutral.mainContrast
+            override val background = neutral.main
             override val disabled = gray300
             override val focus = primary.highlight
         }
-
-    //FIXME: move to typography section
-
-    override val backgroundColor
-        get() = colors.neutral.main
-
-    override val fontColor
-        get() = colors.neutral.mainContrast
 
     override val fontFamilies = object : FontFamilies {
         override val normal =
@@ -250,9 +245,9 @@ open class DefaultTheme : Theme {
         }
             
         body {
-            color: ${fontColor};
+            color: ${colors.font};
             font-family: ${fontFamilies.normal};
-            background-color: ${backgroundColor};
+            background-color: ${colors.background};
             font-feature-settings: "kern";
         }
         
@@ -460,8 +455,8 @@ open class DefaultTheme : Theme {
             private val basic: Style<BasicParams> = {
                 radius { normal }
                 fontWeight { normal }
-                color { fontColor }
-                background { color { backgroundColor } }
+                color { font }
+                background { color { background } }
 
                 border {
                     width { thin }
@@ -1458,8 +1453,8 @@ open class DefaultTheme : Theme {
 
                 }
 
-                background { backgroundColor }
-                color { fontColor }
+                background { color { background } }
+                color { font }
 
                 disabled {
                     background {
@@ -1545,10 +1540,8 @@ open class DefaultTheme : Theme {
                 }
             }
             override val discreet: BasicParams.(ColorScheme) -> Unit = { _ ->
-                background {
-                    color { backgroundColor }
-                }
-                color { fontColor }
+                background { color { background } }
+                color { font }
             }
         }
 
@@ -1675,8 +1668,8 @@ open class DefaultTheme : Theme {
                 fontSize { "1rem" }
                 height { "2.5rem" }
                 radius { normal }
-                background { backgroundColor }
-                color { fontColor }
+                background { color { background } }
+                color { font }
                 focus {
                     focus {
                         border {

--- a/styling/src/jsMain/kotlin/dev/fritz2/styling/theme/definitions.kt
+++ b/styling/src/jsMain/kotlin/dev/fritz2/styling/theme/definitions.kt
@@ -203,6 +203,8 @@ interface Colors {
     val info: ColorScheme
     val neutral: ColorScheme
 
+    val background: ColorProperty
+    val font: ColorProperty
     val disabled: ColorProperty
     val focus: ColorProperty
 

--- a/styling/src/jsMain/kotlin/dev/fritz2/styling/theme/theme.kt
+++ b/styling/src/jsMain/kotlin/dev/fritz2/styling/theme/theme.kt
@@ -4,7 +4,6 @@ import dev.fritz2.dom.Tag
 import dev.fritz2.dom.html.MountTargetNotFoundException
 import dev.fritz2.dom.html.RenderContext
 import dev.fritz2.dom.html.render
-import dev.fritz2.styling.params.ColorProperty
 import dev.fritz2.styling.resetCss
 import kotlinx.browser.document
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -111,16 +110,6 @@ interface Theme {
      * definition of the theme's colors
      */
     val colors: Colors
-
-    /**
-     * definition of the theme's background color
-     */
-    val backgroundColor: ColorProperty
-
-    /**
-     * definition of the theme's font colors
-     */
-    val fontColor: ColorProperty
 
     /**
      * definition of the theme's fonts


### PR DESCRIPTION
Move backgroundColor and fontColor from the `Theme` interface to the `Colors` interface.

Example:
```kotlin
// before
Theme().fontColor
Theme().backgroundColor

// now
Theme().colors.font
Theme().colors.background

// or in color styling DSL
{  
    background {
        color {
            font //or background
        }
    }
}
```
Fixes #347