### PR TITLE
Improve `ComponentValidationMessage.asAlert()`

### DIFF
--- a/components/src/jsMain/kotlin/dev/fritz2/components/alert.kt
+++ b/components/src/jsMain/kotlin/dev/fritz2/components/alert.kt
@@ -196,14 +196,16 @@ fun RenderContext.alert(
 /**
  * Convenience extension to display a [ComponentValidationMessage] as an alert.
  * The alert's severity and content are determined from the validation message's properties.
+ * Custom styling via the [styling] parameter is optionally supported, as well as any other customization via the
+ * [build]-lambda.
  *
  * @param renderContext RenderContext to render the alert in
  * @param styling a lambda expression for declaring the styling of the toast using fritz2's styling DSL
  * @param build a lambda expression for setting up the component itself
  */
 fun ComponentValidationMessage.asAlert(
-    renderContext: RenderContext,
     styling: BasicParams.() -> Unit = { },
+    renderContext: RenderContext,
     build: AlertComponent.() -> Unit = { }
 ) {
     val receiver = this
@@ -221,3 +223,17 @@ fun ComponentValidationMessage.asAlert(
         build()
     }
 }
+
+/**
+ * Convenience extension to display a [ComponentValidationMessage] as an alert.
+ * The alert's severity and content are determined from the validation message's properties.
+ * Customization of the underlying [AlertComponent] is supported via the [build]-lambda. Custom styling can be applyied
+ * via the overloaded [ComponentValidationMessage.asAlert] method.
+ *
+ * @param renderContext RenderContext to render the alert in
+ * @param build a lambda expression for setting up the component itself
+ */
+fun ComponentValidationMessage.asAlert(
+    renderContext: RenderContext,
+    build: AlertComponent.() -> Unit = { }
+) = asAlert({ }, renderContext, build)

--- a/components/src/jsMain/kotlin/dev/fritz2/components/alert.kt
+++ b/components/src/jsMain/kotlin/dev/fritz2/components/alert.kt
@@ -138,7 +138,7 @@ open class AlertComponent : Component<Unit> {
         prefix: String,
     ) {
         context.apply {
-            flexBox(baseClass = alertCss, styling = {
+            flexBox(baseClass = alertCss, styling = { this as BoxParams
                 this@AlertComponent.sizes.value(Theme().alert.sizes)()
                 this@AlertComponent.stacking.value(Theme().alert.stacking)()
 
@@ -149,6 +149,8 @@ open class AlertComponent : Component<Unit> {
                     AlertVariant.TOP_ACCENT -> Theme().alert.variants.topAccent
                     AlertVariant.DISCREET -> Theme().alert.variants.discreet
                 }.invoke(this, this@AlertComponent.severity.value(Theme().alert.severities).colorScheme)
+
+                styling()
             }) {
                 box(styling = {
                     css("margin-right: var(--al-icon-margin)")
@@ -195,17 +197,17 @@ fun RenderContext.alert(
  * Convenience extension to display a [ComponentValidationMessage] as an alert.
  * The alert's severity and content are determined from the validation message's properties.
  *
- * @param renderContext RenderContext to render the alert in.
- * @param size Optional property for the text and icon size.
- * @param stacking Optional property for the margins around one alert.
+ * @param renderContext RenderContext to render the alert in
+ * @param styling a lambda expression for declaring the styling of the toast using fritz2's styling DSL
+ * @param build a lambda expression for setting up the component itself
  */
 fun ComponentValidationMessage.asAlert(
     renderContext: RenderContext,
-    size: FormSizes.() -> Style<BasicParams> = { normal },
-    stacking: AlertStacking.() -> Style<BasicParams> = { separated }
+    styling: BasicParams.() -> Unit = { },
+    build: AlertComponent.() -> Unit = { }
 ) {
     val receiver = this
-    renderContext.alert {
+    renderContext.alert(styling) {
         severity {
             when (receiver.severity) {
                 Severity.Info -> info
@@ -215,8 +217,7 @@ fun ComponentValidationMessage.asAlert(
             }
         }
         variant { discreet }
-        sizes { size() }
-        stacking { stacking() }
         content(message)
+        build()
     }
 }

--- a/components/src/jsMain/kotlin/dev/fritz2/components/alert.kt
+++ b/components/src/jsMain/kotlin/dev/fritz2/components/alert.kt
@@ -7,6 +7,7 @@ import dev.fritz2.styling.StyleClass
 import dev.fritz2.styling.params.BasicParams
 import dev.fritz2.styling.params.BoxParams
 import dev.fritz2.styling.params.Style
+import dev.fritz2.styling.*
 import dev.fritz2.styling.span
 import dev.fritz2.styling.style
 import dev.fritz2.styling.theme.*
@@ -60,13 +61,12 @@ open class AlertComponent : Component<Unit> {
 
     companion object {
         private val alertCss = style("alert") {
+            display { flex }
             alignItems { center }
-            padding { normal }
         }
 
         private val alertContentCss = style("alert-content") {
             display { inlineBlock }
-            verticalAlign { middle }
             width { "100%" }
             lineHeight { "1.2em" }
         }
@@ -87,7 +87,7 @@ open class AlertComponent : Component<Unit> {
     val icon = ComponentProperty<(Icons.() -> IconDefinition)?>(value = null)
     val severity = ComponentProperty<(AlertSeverities.() -> AlertSeverity)> { info }
     val variant = ComponentProperty<VariantContext.() -> AlertVariant> { solid }
-    val sizes = ComponentProperty<FormSizes.() -> Style<BasicParams>> { normal }
+    val size = ComponentProperty<FormSizes.() -> Style<BasicParams>> { normal }
     val stacking = ComponentProperty<AlertStacking.() -> Style<BasicParams>> { separated }
 
     private val actualIcon: IconDefinition
@@ -138,21 +138,20 @@ open class AlertComponent : Component<Unit> {
         prefix: String,
     ) {
         context.apply {
-            flexBox(baseClass = alertCss, styling = { this as BoxParams
-                this@AlertComponent.sizes.value(Theme().alert.sizes)()
+            div({
+                this@AlertComponent.size.value(Theme().alert.sizes)()
                 this@AlertComponent.stacking.value(Theme().alert.stacking)()
-
-                when(this@AlertComponent.variant.value(VariantContext)) {
+                when (this@AlertComponent.variant.value(VariantContext)) {
                     AlertVariant.SOLID -> Theme().alert.variants.solid
                     AlertVariant.SUBTLE -> Theme().alert.variants.subtle
                     AlertVariant.LEFT_ACCENT -> Theme().alert.variants.leftAccent
                     AlertVariant.TOP_ACCENT -> Theme().alert.variants.topAccent
                     AlertVariant.DISCREET -> Theme().alert.variants.discreet
                 }.invoke(this, this@AlertComponent.severity.value(Theme().alert.severities).colorScheme)
-
                 styling()
-            }) {
-                box(styling = {
+            }, alertCss) {
+                div({
+                    display { inlineFlex }
                     css("margin-right: var(--al-icon-margin)")
                 }) {
                     icon({
@@ -163,7 +162,7 @@ open class AlertComponent : Component<Unit> {
                     }
                 }
 
-                box(baseClass = alertContentCss) {
+                div(alertContentCss.name) {
                     this@AlertComponent.title?.invoke(this)
                     this@AlertComponent.content?.invoke(this)
                 }
@@ -218,7 +217,6 @@ fun ComponentValidationMessage.asAlert(
                 Severity.Error -> error
             }
         }
-        variant { discreet }
         content(message)
         build()
     }

--- a/components/src/jsMain/kotlin/dev/fritz2/components/formcontrol.kt
+++ b/components/src/jsMain/kotlin/dev/fritz2/components/formcontrol.kt
@@ -198,8 +198,9 @@ open class FormControlComponent : Component<Unit>, FormProperties by FormMixin()
     val validationMessageRendering =
         ComponentProperty<RenderContext.(ComponentValidationMessage) -> Unit> { message ->
             message.asAlert(this) {
-                sizes(this@FormControlComponent.sizeBuilder)
+                size(this@FormControlComponent.sizeBuilder)
                 stacking { compact }
+                variant { discreet }
             }
         }
 

--- a/components/src/jsMain/kotlin/dev/fritz2/components/formcontrol.kt
+++ b/components/src/jsMain/kotlin/dev/fritz2/components/formcontrol.kt
@@ -197,7 +197,10 @@ open class FormControlComponent : Component<Unit>, FormProperties by FormMixin()
 
     val validationMessageRendering =
         ComponentProperty<RenderContext.(ComponentValidationMessage) -> Unit> { message ->
-            message.asAlert(this, size = this@FormControlComponent.sizeBuilder, stacking = { compact })
+            message.asAlert(this) {
+                sizes(this@FormControlComponent.sizeBuilder)
+                stacking { compact }
+            }
         }
 
     init {

--- a/styling/src/jsMain/kotlin/dev/fritz2/styling/theme/default.kt
+++ b/styling/src/jsMain/kotlin/dev/fritz2/styling/theme/default.kt
@@ -1572,9 +1572,11 @@ open class DefaultTheme : Theme {
         override val stacking = object : AlertStacking {
             override val compact: Style<BasicParams> = {
                 margin { none }
+                padding { none }
             }
             override val separated: Style<BasicParams> = {
                 margin { normal }
+                padding { normal }
             }
         }
     }


### PR DESCRIPTION
This PR enables both custom styling and customization of the underlying `AlertComponent` for `ComponentValidationMessage.asAlert()`.

---

### Breaking changes (not breaking for most users)

1. The property to adapt the size has changed from ``sizes`` to simply ``size`` to be compliant with the rest of the components! (see issue #412)

2. **This change is API-breaking only if`asAlert()` is called manually in your code.** In most cases this should not be the case as it is mainly used internally by the `ComponentValidationMessage`.
The method signature of `ComponentValidationMessage.asAlert()` has changed from
    ```kotlin
    fun ComponentValidationMessage.asAlert(
        renderContext: RenderContext,
        size: FormSizes.() -> Style<BasicParams> = { normal },
        stacking: AlertStacking.() -> Style<BasicParams> = { separated }
    )
    ```
    to
    ```kotlin
    fun ComponentValidationMessage.asAlert(
        styling: BasicParams.() -> Unit = { },
        renderContext: RenderContext,
        build: AlertComponent.() -> Unit = { }
    )
    ```
    in order to be able to customize the Alert.

#### Usage examples

Custom styling:
```kotlin
someMessage.asAlert({
    // custom styling goes here
}, this)
```

Customization via build-lambda:
```kotlin
someMessage.asAlert(this) {
    // customization of the Alert's properties such as it's text
}
```

Both:
```kotlin
someMessage.asAlert({
    // custom styling goes here
}, this) {
    // customization of the Alert's properties such as it's text
}
```

Note that the current `RenderContext` always has to be passed as an argument!

#### Migration

Here's an example of how to migrate an existing call of `asAlert()` that specifies a size and stacking to the new format:

Previously:
```kotlin
someMessage.asAlert(this, size = this@FormControlComponent.sizeBuilder, stacking = { compact })
```

Now:
```kotlin
someMessage.asAlert(this) {
    sizes(this@FormControlComponent.sizeBuilder)
    stacking { compact }
}
```
---

Closes #292.