### PR TITLE
Fix selection forwarding to external store for DataTable component

### DIFF
--- a/components/src/jsMain/kotlin/dev/fritz2/components/datatable/component.kt
+++ b/components/src/jsMain/kotlin/dev/fritz2/components/datatable/component.kt
@@ -158,7 +158,7 @@ open class DataTableComponent<T, I>(val dataStore: RootStore<List<T>>, protected
         context.apply {
             this@DataTableComponent.dataStore.data handledBy this@DataTableComponent.selectionStore.syncHandler
 
-            // preset selection via external store or flow
+            // preset selection via external store or flow and forward selection to external store
             when (this@DataTableComponent.selection.value.selectionMode) {
                 SelectionMode.Single -> {
                     (this@DataTableComponent.selection.value.single?.store?.value?.data
@@ -194,25 +194,9 @@ open class DataTableComponent<T, I>(val dataStore: RootStore<List<T>>, protected
                 position { relative { } }
             }) {
                 this@DataTableComponent.renderTable(baseClass, id, prefix, this@DataTableComponent.rowIdProvider, this)
-
                 EventsContext(this, this@DataTableComponent.selectionStore).apply {
                     this@DataTableComponent.events.value(this)
                 }
-
-                // tie selection to external store if needed
-                /*
-                when (this@DataTableComponent.selection.value.selectionMode) {
-                    SelectionMode.Single -> this@DataTableComponent.selection.value.single!!.store.value?.let {
-                        this@DataTableComponent.events { selectedRow handledBy it.update }
-                    }
-                    SelectionMode.Multi -> this@DataTableComponent.selection.value.multi!!.store.value?.let {
-                        this@DataTableComponent.events { selectedRows handledBy it.update }
-                    }
-                    else -> Unit
-                }
-
-                 */
-
             }
         }
     }


### PR DESCRIPTION
It is now possible to pass an external selection store into a DataTable **and** additionally wire selection events within the DataTable's ``events`` context.

```kotlin
dataTable(
    rows = ..., rowIdProvider = ..., selection = someStore
) {
    events {
        // this events will now be handled *even though*
        // a selection store is passed via factory function!
        selectedRow handledBy someOtherStore.handler
        selectedRow handledBy evenAnotherStore.handler
        // ... and so on
    }
    columns {
        // ...
    }
}
```

Fixes #382