### PR TITLE
Fixes for using media breakpoints

### DIFF
--- a/styling/src/jsMain/kotlin/dev/fritz2/styling/params/alignment.kt
+++ b/styling/src/jsMain/kotlin/dev/fritz2/styling/params/alignment.kt
@@ -84,7 +84,7 @@ interface Alignment : StyleParams {
      *
      * Example call:
      * ```
-     * justify-content { flexStart }
+     * justifyContent { flexStart }
      * ```
      *
      * @param value extension function parameter for small media devices, recommended to use
@@ -99,7 +99,7 @@ interface Alignment : StyleParams {
      *
      * Example call:
      * ```
-     * justify-content(
+     * justifyContent(
      *     sm = { flexStart },
      *     lg = { center }
      * )
@@ -131,7 +131,7 @@ interface Alignment : StyleParams {
      *
      * Example call:
      * ```
-     * align-items { flexStart }
+     * alignItems { flexStart }
      * ```
      *
      * @param value extension function parameter for small media devices, recommended to use
@@ -146,7 +146,7 @@ interface Alignment : StyleParams {
      *
      * Example call:
      * ```
-     * align-items(
+     * alignItems(
      *     sm = { flexStart },
      *     lg = { center }
      * )

--- a/styling/src/jsMain/kotlin/dev/fritz2/styling/params/background.kt
+++ b/styling/src/jsMain/kotlin/dev/fritz2/styling/params/background.kt
@@ -412,7 +412,7 @@ class BackgroundContext(
      *
      * @param value function parameter in order to return an arbitrary [String]
      */
-    fun color(value: Colors.() -> Property): Unit = property(backgroundColorKey, Theme().colors, value)
+    fun color(value: Colors.() -> Property): Unit = property(backgroundColorKey, Theme().colors, value, target)
 }
 
 /**

--- a/styling/src/jsMain/kotlin/dev/fritz2/styling/params/border.kt
+++ b/styling/src/jsMain/kotlin/dev/fritz2/styling/params/border.kt
@@ -148,7 +148,7 @@ class BorderContext(
      *              into the scope of the functional expression
      */
     fun style(value: BorderStyleValues.() -> BorderStyleProperty) =
-        property(styleKey, BorderStyleValues.value(), smProperties)
+        property(styleKey, BorderStyleValues.value(), target)
 
     /**
      * This function is used to set the _color_ of a border for the

--- a/styling/src/jsMain/kotlin/dev/fritz2/styling/params/params.kt
+++ b/styling/src/jsMain/kotlin/dev/fritz2/styling/params/params.kt
@@ -69,7 +69,7 @@ const val cssDelimiter = ";"
 fun StyleParams.property(
     key: String,
     value: Property,
-    target: StringBuilder = smProperties
+    target: StringBuilder
 ) {
     target.append(key, value, cssDelimiter)
 }
@@ -108,7 +108,7 @@ inline fun <T> StyleParams.property(
     key: String,
     base: T,
     value: T.() -> Property,
-    target: StringBuilder = smProperties
+    target: StringBuilder
 ) =
     property(key, base.value(), target)
 


### PR DESCRIPTION
The `color` of `BackgroundContext` and `style` of `BorderContext` works now with media breakpoints

solved: #342 