### PR TITLE
Use constant values for z-indices in components

### DIFF
--- a/components/src/jsMain/kotlin/dev/fritz2/components/appFrame.kt
+++ b/components/src/jsMain/kotlin/dev/fritz2/components/appFrame.kt
@@ -76,8 +76,7 @@ open class AppFrameComponent : Component<Unit> {
     )
 
     private fun mobileSidebar(topPosition: Property): Style<BasicParams> = {
-        //FIXME: add to Theme!
-        zIndex { "5000" }
+        zIndex { appFrame }
         width(sm = { Theme().appFrame.mobileSidebarWidth }, md = { unset })
         css(sm = "transform: translateX(-110vw);", md = "transform: unset;")
         position(sm = {
@@ -139,7 +138,7 @@ open class AppFrameComponent : Component<Unit> {
                 width { "100vw" }
                 height { "min(100vh, 100%)" }
                 css("height: -webkit-fill-available;")
-                zIndex { "4000" }
+                zIndex { appFrame - 10 }
                 css("transition: opacity .3s ease-in;")
             }, prefix = "backdrop") {
                 className(this@AppFrameComponent.showBackdrop.whenever(this@AppFrameComponent.sidebarStatus.data).name)

--- a/components/src/jsMain/kotlin/dev/fritz2/components/appFrame.kt
+++ b/components/src/jsMain/kotlin/dev/fritz2/components/appFrame.kt
@@ -138,7 +138,7 @@ open class AppFrameComponent : Component<Unit> {
                 width { "100vw" }
                 height { "min(100vh, 100%)" }
                 css("height: -webkit-fill-available;")
-                zIndex { appFrame - 10 }
+                zIndex { appFrame raiseBy -10 }
                 css("transition: opacity .3s ease-in;")
             }, prefix = "backdrop") {
                 className(this@AppFrameComponent.showBackdrop.whenever(this@AppFrameComponent.sidebarStatus.data).name)

--- a/components/src/jsMain/kotlin/dev/fritz2/components/datatable/component.kt
+++ b/components/src/jsMain/kotlin/dev/fritz2/components/datatable/component.kt
@@ -284,7 +284,7 @@ open class DataTableComponent<T, I>(val dataStore: RootStore<List<T>>, protected
                         top { "0" }
                     }
                 }
-                zIndex { "1" }
+                zIndex { tableHeader }
             }, baseClass, "$id-fixedHeader", "$prefix-fixedHeader") {
                 attr("style", gridCols)
                 this@DataTableComponent.renderHeader({}, this)

--- a/components/src/jsMain/kotlin/dev/fritz2/components/managed.kt
+++ b/components/src/jsMain/kotlin/dev/fritz2/components/managed.kt
@@ -46,7 +46,6 @@ interface ManagedComponent<T> {
          * @param job [Job] used in this [RenderContext]
          */
         internal fun managedRenderContext(id: String, job: Job): RenderContext {
-            console.log("neue managedRenderContext Methode aufgerufen...")
             val element = document.getElementById(id)
             return if (element != null) {
                 Tag("div", element.id, job = job, domNode = (element as HTMLElement))

--- a/components/src/jsMain/kotlin/dev/fritz2/components/modal.kt
+++ b/components/src/jsMain/kotlin/dev/fritz2/components/modal.kt
@@ -28,7 +28,7 @@ interface Overlay {
 }
 
 internal fun ZIndices.modal(level: Int, offset: Int = 0): Property {
-    return modal + (10 * (level - 1) + offset)
+    return modal raiseBy (10 * (level - 1) + offset)
 }
 
 class DefaultOverlay(

--- a/components/src/jsMain/kotlin/dev/fritz2/components/modal.kt
+++ b/components/src/jsMain/kotlin/dev/fritz2/components/modal.kt
@@ -10,9 +10,7 @@ import dev.fritz2.styling.StyleClass
 import dev.fritz2.styling.params.BasicParams
 import dev.fritz2.styling.params.BoxParams
 import dev.fritz2.styling.params.Style
-import dev.fritz2.styling.theme.ModalSizes
-import dev.fritz2.styling.theme.ModalVariants
-import dev.fritz2.styling.theme.Theme
+import dev.fritz2.styling.theme.*
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.map
 
@@ -29,13 +27,17 @@ interface Overlay {
     fun render(renderContext: RenderContext, level: Int)
 }
 
+internal fun ZIndices.modal(level: Int, offset: Int = 0): Property {
+    return modal + (10 * (level - 1) + offset)
+}
+
 class DefaultOverlay(
     override val method: OverlayMethod = OverlayMethod.CoveringTopMost,
     override val styling: Style<BasicParams> = Theme().modal.overlay
 ) : Overlay {
     override fun render(renderContext: RenderContext, level: Int) {
         renderContext.box({
-            zIndex { modal(level, offset = -1) }
+            zIndex { modal(level, -1) }
             styling()
         }, prefix = "modal-overlay") {
         }

--- a/components/src/jsMain/kotlin/dev/fritz2/components/navbar.kt
+++ b/components/src/jsMain/kotlin/dev/fritz2/components/navbar.kt
@@ -3,9 +3,11 @@ package dev.fritz2.components
 import dev.fritz2.dom.html.RenderContext
 import dev.fritz2.styling.StyleClass
 import dev.fritz2.styling.div
+import dev.fritz2.styling.nav
 import dev.fritz2.styling.params.BasicParams
 import dev.fritz2.styling.params.BoxParams
 import dev.fritz2.styling.staticStyle
+import dev.fritz2.styling.theme.Theme
 
 open class NavbarComponent : Component<Unit> {
     companion object {
@@ -16,8 +18,6 @@ open class NavbarComponent : Component<Unit> {
                 transition: box-shadow 0.2s;
                 position: fixed;
                 top: 0;
-                z-index: 199;
-                background: #FFFFFF;
                 left: 0;
                 right: 0;
                 width: 100%;
@@ -30,10 +30,7 @@ open class NavbarComponent : Component<Unit> {
                 display: flex;
                 align-items: center;
                 justify-content: space-between;
-                height: 4.5rem;
                 width: 100%;
-                padding-left: 1.5rem;
-                padding-right: 1.5rem;
             """
         )
 
@@ -64,24 +61,14 @@ open class NavbarComponent : Component<Unit> {
         id: String?,
         prefix: String
     ) {
-        with(context) {
-            nav((staticHeaderCss + baseClass).name, id) {
+        context.apply {
+            nav({
+                Theme().navBar.header()
+            }, staticHeaderCss + baseClass, id) {
                 div({
-                    borders {
-                        top {
-                            width { "6px" }
-                            style { solid }
-                            color { primary.main }
-                        }
-
-                        bottom {
-                            width { "2px" }
-                            style { solid }
-                            color { gray300 }
-                        }
-                    }
+                    Theme().navBar.content()
                     styling()
-                }, baseClass = staticContentCss, prefix = prefix) {
+                }, staticContentCss, prefix) {
                     div(staticBrandCss.name) {
                         this@NavbarComponent.brand.value(this)
                     }

--- a/components/src/jsMain/kotlin/dev/fritz2/components/toast.kt
+++ b/components/src/jsMain/kotlin/dev/fritz2/components/toast.kt
@@ -122,11 +122,9 @@ open class ToastComponent : ManagedComponent<Unit>,
             "toastContainer",
             """
                position: fixed; 
-               z-index: 5500;
                pointer-events: none;
                display: flex;
                flex-direction: column;
-           
                """
         )
 
@@ -152,13 +150,13 @@ open class ToastComponent : ManagedComponent<Unit>,
             radius { "0.375rem" }
 
             css("pointer-events: auto;")
-            css("  -webkit-box-align: start;")
-            css(" align-items: start;")
-            css(" box-shadow: rgba(0, 0, 0, 0.1) 0px 10px 15px -3px, rgba(0, 0, 0, 0.05) 0px 4px 6px -2px;")
+            css("-webkit-box-align: start;")
+            css("align-items: start;")
+            css("box-shadow: rgba(0, 0, 0, 0.1) 0px 10px 15px -3px, rgba(0, 0, 0, 0.05) 0px 4px 6px -2px;")
         }
 
         private val job = Job()
-        private val globalId = "f2c-modals-${randomId()}"
+        private val globalId = "f2c-toasts-${randomId()}"
         const val defaultToastContainerPrefix = "ul-toast-container"
 
         init {
@@ -177,6 +175,7 @@ open class ToastComponent : ManagedComponent<Unit>,
 
                     ul({
                         placementStyle()
+                        zIndex { toast }
                     }, toastContainerStaticCss, uniqueId(), defaultToastContainerPrefix) {
                         ToastStore.data
                             .map { toasts ->

--- a/styling/src/jsMain/kotlin/dev/fritz2/styling/theme/default.kt
+++ b/styling/src/jsMain/kotlin/dev/fritz2/styling/theme/default.kt
@@ -223,7 +223,16 @@ open class DefaultTheme : Theme {
             danger = shadow("0", "0", "0", "1px", color = colors.danger.main)
         )
 
-    override val zIndices = ZIndices(1, 100, 2, 200, 300, 2, 400, 2)
+    override val zIndices = ZIndices(
+        10,
+        100,
+        200,
+        300,
+        1000,
+        1100,
+        2000,
+        3000
+    )
 
     override val opacities = WeightedValue(
         normal = "0.5"
@@ -1934,6 +1943,32 @@ open class DefaultTheme : Theme {
         }
     }
 
+    override val navBar: NavBarStyles = object : NavBarStyles {
+        override val header: Style<BasicParams> = {
+            zIndex { navbar }
+            background { color { neutral.main } }
+        }
+        override val content: Style<BasicParams> = {
+            height { "4.5rem" }
+            paddings {
+                left { larger }
+                right { larger }
+            }
+            borders {
+                top {
+                    width { "6px" }
+                    style { solid }
+                    color { primary.main }
+                }
+
+                bottom {
+                    width { "2px" }
+                    style { solid }
+                    color { gray300 }
+                }
+            }
+        }
+    }
 
     override val appFrame: AppFrameStyles = object : AppFrameStyles {
         override val headerHeight: Property = "3.6rem"

--- a/styling/src/jsMain/kotlin/dev/fritz2/styling/theme/default.kt
+++ b/styling/src/jsMain/kotlin/dev/fritz2/styling/theme/default.kt
@@ -224,14 +224,14 @@ open class DefaultTheme : Theme {
         )
 
     override val zIndices = ZIndices(
-        10,
-        100,
-        200,
-        300,
-        1000,
-        1000,
-        2000,
-        3000
+        tableHeader = 10,
+        tooltip = 100,
+        dropdown = 200,
+        popover = 300,
+        appFrame = 1000,
+        navbar = 1000,
+        toast = 2000,
+        modal = 3000
     )
 
     override val opacities = WeightedValue(

--- a/styling/src/jsMain/kotlin/dev/fritz2/styling/theme/default.kt
+++ b/styling/src/jsMain/kotlin/dev/fritz2/styling/theme/default.kt
@@ -229,7 +229,7 @@ open class DefaultTheme : Theme {
         200,
         300,
         1000,
-        1100,
+        1000,
         2000,
         3000
     )
@@ -520,7 +520,6 @@ open class DefaultTheme : Theme {
                 }
 
                 focus {
-                    zIndex { "1" }
                     background {
                         color { "transparent" }
                     }
@@ -1086,7 +1085,7 @@ open class DefaultTheme : Theme {
                 }
                 radius { small }
                 boxShadow { flat }
-                zIndex { "20" }
+                zIndex { popover }
 
             }
             override val auto: Style<BasicParams> = {
@@ -1128,7 +1127,7 @@ open class DefaultTheme : Theme {
         override val placement = object : PopoverPlacements {
             private val basic: Style<BasicParams> = {
                 css("transition: transform .2s;")
-                zIndex { "50" }
+                zIndex { popover }
             }
             override val top: Style<BasicParams> = {
                 basic()
@@ -1182,14 +1181,10 @@ open class DefaultTheme : Theme {
                     color { inherit }
                 }
                 before {
-                    zIndex { "-1" }
                     css("content:\"\";")
                     width { "1rem" }
                     height { "1rem" }
-                    position {
-                        absolute {
-                        }
-                    }
+                    position { absolute {} }
                 }
             }
             override val top: Style<BasicParams> = {
@@ -1280,7 +1275,7 @@ open class DefaultTheme : Theme {
                     display { none }
                     overflow { hidden }
                     opacity { "0" }
-                    zIndex { "20" }
+                    zIndex { tooltip }
                     position {
                         absolute {
                             left { "50%" }
@@ -1735,7 +1730,6 @@ open class DefaultTheme : Theme {
                 }
 
                 focus {
-                    zIndex { "1" }
                     background {
                         color { "transparent" }
                     }
@@ -1816,7 +1810,7 @@ open class DefaultTheme : Theme {
             )
             radius { "6px" }
 
-            zIndex { layer(1) }
+            zIndex { dropdown }
             boxShadow { raised }
             background { color { background } }
 

--- a/styling/src/jsMain/kotlin/dev/fritz2/styling/theme/definitions.kt
+++ b/styling/src/jsMain/kotlin/dev/fritz2/styling/theme/definitions.kt
@@ -127,10 +127,7 @@ class ZIndices(
     val toast: Property = toast.toString()
     val modal: Property = modal.toString()
 
-    operator fun Property.minus(value: Int): Property =
-        (this.toInt() - value).toString()
-
-    operator fun Property.plus(value: Int): Property =
+    infix fun Property.raiseBy(value: Int): Property =
         (this.toInt() + value).toString()
 }
 

--- a/styling/src/jsMain/kotlin/dev/fritz2/styling/theme/definitions.kt
+++ b/styling/src/jsMain/kotlin/dev/fritz2/styling/theme/definitions.kt
@@ -97,21 +97,28 @@ class Sizes(
 }
 
 /**
- * Defines the scheme for zIndices in fritz2
+ * Defines the scheme for zIndices of fritz2 components
  *
- * @property baseValue z-index for normal content ("bottom")
- * @property layer start z-index for layers
- * @property layerStep step to add for each new layer
- * @property overlayValue z-index for an overlay
- * @property toast start z-index for toasts
- * @property toastStep step to add for each new toast
- * @property modal start z-index for modals
- * @property modalStep step to add for each new modal
  */
 class ZIndices(
-    private val baseValue: Int, private val layer: Int, private val layerStep: Int, private val overlayValue: Int,
-    private val toast: Int, private val toastStep: Int, private val modal: Int, private val modalStep: Int,
+    tableHeader: Int,
+    tooltip: Int,
+    dropdown: Int,
+    popover: Int,
+    appFrame: Int,
+    navbar: Int,
+    toast: Int,
+    modal: Int,
 ) {
+
+    val tableHeader: Property = tableHeader.toString()
+    val tooltip: Property = tooltip.toString()
+    val dropdown: Property = dropdown.toString()
+    val popover: Property = popover.toString()
+    val appFrame: Property = appFrame.toString()
+    val navbar: Property = navbar.toString()
+    val toast: Property = toast.toString()
+    val modal: Property = modal.toString()
 
     companion object {
         /**
@@ -119,51 +126,6 @@ class ZIndices(
          */
         const val key: Property = "z-index: "
     }
-
-    /**
-     * [Property] for base z-index
-     */
-    val base: Property = "$baseValue"
-
-    /**
-     * [Property] for overlay z-index
-     */
-    val overlay: Property = "$overlayValue"
-
-    /**
-     * creates [Property] for a specific layer z-index
-     *
-     * Use self defined constants for the different layers of your UI.
-     *
-     * @param value number of layer the z-index should be calculated for
-     */
-    fun layer(value: Int): Property = zIndexFrom(layer, layerStep, value, 0)
-
-    /**
-     * creates [Property] for a specific toast z-index
-     *
-     * @param value number of toast the z-index should be calculated for
-     */
-    fun toast(value: Int): Property = zIndexFrom(toast, toastStep, value, 0)
-
-    /**
-     * creates [Property] for a specific modals z-index
-     *
-     * @param value number of modal the z-index should be calculated for
-     */
-    fun modal(value: Int): Property = zIndexFrom(modal, modalStep, value, 0)
-
-    /**
-     * creates [Property] for a specific modals z-index shifted by an offset
-     *
-     * @param value number of modal the z-index should be calculated for
-     * @param offset number to add to the final z-index in order to place an element below (negative value!) or on top
-     *               (positive value) of a regularly defined modal.
-     */
-    fun modal(value: Int, offset: Int): Property = zIndexFrom(modal, modalStep, value, offset)
-
-    private fun zIndexFrom(level: Int, step: Int, value: Int, offset: Int) =
-        "${level + step * (value - 1) + offset}"
 }
 
 /**
@@ -707,6 +669,13 @@ interface MenuStyles {
     val header: Style<BasicParams>
 }
 
+/**
+ * definition of the theme's navbar
+ */
+interface NavBarStyles {
+    val header: Style<BasicParams>
+    val content: Style<BasicParams>
+}
 
 /**
  * definition of the theme's appFrame

--- a/styling/src/jsMain/kotlin/dev/fritz2/styling/theme/definitions.kt
+++ b/styling/src/jsMain/kotlin/dev/fritz2/styling/theme/definitions.kt
@@ -111,6 +111,13 @@ class ZIndices(
     modal: Int,
 ) {
 
+    companion object {
+        /**
+         * key to set z-index-property
+         */
+        const val key: Property = "z-index: "
+    }
+
     val tableHeader: Property = tableHeader.toString()
     val tooltip: Property = tooltip.toString()
     val dropdown: Property = dropdown.toString()
@@ -120,12 +127,11 @@ class ZIndices(
     val toast: Property = toast.toString()
     val modal: Property = modal.toString()
 
-    companion object {
-        /**
-         * key to set z-index-property
-         */
-        const val key: Property = "z-index: "
-    }
+    operator fun Property.minus(value: Int): Property =
+        (this.toInt() - value).toString()
+
+    operator fun Property.plus(value: Int): Property =
+        (this.toInt() + value).toString()
 }
 
 /**

--- a/styling/src/jsMain/kotlin/dev/fritz2/styling/theme/theme.kt
+++ b/styling/src/jsMain/kotlin/dev/fritz2/styling/theme/theme.kt
@@ -216,6 +216,8 @@ interface Theme {
 
     val appFrame: AppFrameStyles
 
+    val navBar: NavBarStyles
+
     val dataTableStyles: DataTableStyles
 
     val slider: SliderStyles


### PR DESCRIPTION
Components which need a z-index an their default values defined in `DefaultTheme`:
```
tableHeader (10)
tooltip (100)
dropdown (200)
popover (300)
appFrame (1000)
navbar (1000) -- will be replaced by appFrame
toast (2000)
modal (3000)
```

Fixes #395 and fixes #371