### PR TITLE
Harmonize orientation settings

### DIFF
--- a/components/src/jsMain/kotlin/dev/fritz2/components/checkboxGroup.kt
+++ b/components/src/jsMain/kotlin/dev/fritz2/components/checkboxGroup.kt
@@ -28,9 +28,9 @@ import org.w3c.dom.HTMLElement
  * In order to render a checkbox group use the [checkboxGroup] factory function!
  *
  * This class offers the following _configuration_ features:
- *  - the items as a List<T>
- *  - the preselected items via a ``Flow<List<T>>``
- *  - the label(mapping) of a switch (static, dynamic via a [Flow<String>] or customized content of a Div.RenderContext ) the the example below
+ *  - the items as a [List<T>]
+ *  - the preselected items via a [Flow<List<T>>]
+ *  - the label(mapping) of a switch (static, dynamic via a [Flow<String>] or customized content of a Div.RenderContext) the the example below
  *  - some predefined styling variants (size)
  *  - the style of the items (checkbox)
  *  - the style checked state
@@ -39,7 +39,7 @@ import org.w3c.dom.HTMLElement
  *  - choose the orientation of checkbox elements (vertical or horizontal)
  *
  *  This can be done within a functional expression that is the last parameter of the factory function, called
- *  ``build``. It offers an initialized instance of this [CheckboxGroupComponent] class as receiver, so every mutating
+ *  `build`. It offers an initialized instance of this [CheckboxGroupComponent] class as receiver, so every mutating
  *  method can be called for configuring the desired state for rendering the checkbox.
  *
  * Example usage
@@ -61,8 +61,8 @@ import org.w3c.dom.HTMLElement
  * }
  *
  * // use case showing some styling options and a store of List<Pair<Int,String>>
- *   val myPairs = listOf((1 to "ffffff"), (2 to "rrrrrr" ), (3 to "iiiiii"), (4 to "tttttt"), ( 5 to "zzzzzz"), (6 to "222222"))
- *  val myStore = storeOf(<List<Pair<Int,String>>)
+ * val myPairs = listOf((1 to "ffffff"), (2 to "rrrrrr" ), (3 to "iiiiii"), (4 to "tttttt"), ( 5 to "zzzzzz"), (6 to "222222"))
+ * val myStore = storeOf(<List<Pair<Int,String>>)
  * checkboxGroup(items = myPairs, values = myStore) {
  *      label { it.second }
  *      size { large }
@@ -103,14 +103,14 @@ open class CheckboxGroupComponent<T>(
     }
 
     object DirectionContext {
-        @Deprecated("Use ``orientation { vertical }`` instead", ReplaceWith("vertical"))
+        @Deprecated("Use orientation { vertical } instead", ReplaceWith("vertical"))
         val column: Direction = Direction.COLUMN
 
-        @Deprecated("Use ``orientation { horizontal }`` instead", ReplaceWith("horizontal"))
+        @Deprecated("Use orientation { horizontal } instead", ReplaceWith("horizontal"))
         val row: Direction = Direction.ROW
     }
 
-    @Deprecated("Use ``orientation`` instead", ReplaceWith("orientation"))
+    @Deprecated("Use orientation instead", ReplaceWith("orientation"))
     val direction = ComponentProperty<DirectionContext.() -> Direction> { column }
 
     val itemStyle = ComponentProperty(Theme().checkbox.default)
@@ -209,7 +209,7 @@ open class CheckboxGroupComponent<T>(
  * @param values a store of List<T>
  * @param baseClass optional CSS class that should be applied to the element
  * @param id the ID of the element
- * @param prefix the prefix for the generated CSS class resulting in the form ``$prefix-$hash``
+ * @param prefix the prefix for the generated CSS class resulting in the form `$prefix-$hash`
  * @param build a lambda expression for setting up the component itself. Details in [CheckboxGroupComponent]
  */
 fun <T> RenderContext.checkboxGroup(

--- a/components/src/jsMain/kotlin/dev/fritz2/components/components.kt
+++ b/components/src/jsMain/kotlin/dev/fritz2/components/components.kt
@@ -559,3 +559,45 @@ class CloseButtonMixin(
         }
     }
 }
+
+
+/**
+ * Definition of the layout orientation of a form.
+ */
+enum class Orientation {
+    HORIZONTAL, VERTICAL
+}
+
+/**
+ * A context class for allowing an expressive DSL for component's configuration:
+ *
+ * ```
+ * // 'orientation' is provided by ``OrientationProperty.orientation``
+ * orientation { horizontal }
+ * orientation { vertical }
+ * ```
+ */
+object OrientationContext {
+    val horizontal: Orientation = Orientation.HORIZONTAL
+    val vertical: Orientation = Orientation.VERTICAL
+}
+
+/**
+ * This interface add an orientation property for position the component's element(s) into an horizontal or
+ * vertical orientation.
+ */
+interface OrientationProperty {
+    val orientation: ComponentProperty<OrientationContext.() -> Orientation>
+}
+
+/**
+ * Default implementation of the [OrientationProperty] interface in order to apply this as mixin for a component
+ *
+ * @param default set the default orientation for the implementing component (checkBoxGroup needs vertical, but
+ *                slider horizontal orientation for example)
+ */
+class OrientationMixin(default: Orientation) : OrientationProperty {
+    override val orientation: ComponentProperty<OrientationContext.() -> Orientation> by lazy {
+        ComponentProperty { default }
+    }
+}

--- a/components/src/jsMain/kotlin/dev/fritz2/components/radioGroup.kt
+++ b/components/src/jsMain/kotlin/dev/fritz2/components/radioGroup.kt
@@ -25,9 +25,9 @@ import org.w3c.dom.HTMLElement
  * In order to render a checkbox group use the [radioGroup] factory function!
  *
  * This class offers the following _configuration_ features:
- *  - the items as a ``List<T>``
- *  - optionally set a predefined item; if nothing is set or ``null``, nothing gets selected at first
- *  - the label(mapping) of a switch (static, dynamic via a [Flow<String>] or customized content of a Div.RenderContext ) the the example below
+ *  - the items as a [List<T>]
+ *  - optionally set a predefined item; if nothing is set or "null", nothing gets selected at first
+ *  - the label(mapping) of a switch (static, dynamic via a [Flow<String>] or customized content of a Div.RenderContext) the the example below
  *  - some predefined styling variants (size)
  *  - the style of the items (radio)
  *  - the style selected state
@@ -49,7 +49,7 @@ import org.w3c.dom.HTMLElement
  * // one can handle the events and preselected item also manually if needed:
  * val options = listOf("A", "B", "C")
  * radioGroup(items = options) {
- *      selectedItem("A") // or ``null`` (default) if nothing should be selected at all
+ *      selectedItem("A") // or "null" (default) if nothing should be selected at all
  *      events {
  *          selected handledBy someStoreOfString
  *      }
@@ -74,7 +74,7 @@ open class RadioGroupComponent<T>(protected val items: List<T>, protected val va
     OrientationProperty by OrientationMixin(Orientation.VERTICAL) {
 
     companion object {
-        // TODO: Remove ``direction`` part and therefore ``if`` branch
+        // TODO: Remove `direction` part and therefore `if` branch
         fun layoutOf(orientation: Orientation, direction: Direction): Style<BasicParams> = {
             display {
                 if (direction == Direction.ROW) {
@@ -95,14 +95,14 @@ open class RadioGroupComponent<T>(protected val items: List<T>, protected val va
     }
 
     object DirectionContext {
-        @Deprecated("Use ``orientation { vertical }`` instead", ReplaceWith("vertical"))
+        @Deprecated("Use orientation { vertical } instead", ReplaceWith("vertical"))
         val column: Direction = Direction.COLUMN
 
-        @Deprecated("Use ``orientation { horizontal }`` instead", ReplaceWith("horizontal"))
+        @Deprecated("Use orientation { horizontal } instead", ReplaceWith("horizontal"))
         val row: Direction = Direction.ROW
     }
 
-    @Deprecated("Use ``orientation`` instead", ReplaceWith("orientation"))
+    @Deprecated("Use orientation instead", ReplaceWith("orientation"))
     val direction = ComponentProperty<DirectionContext.() -> Direction> { column }
 
     val itemStyle = ComponentProperty(Theme().radio.default)
@@ -176,7 +176,7 @@ open class RadioGroupComponent<T>(protected val items: List<T>, protected val va
  * ```
  * val options = listOf("A", "B", "C")
  * radioGroup(items = options, value = selectedItemStore) {
- *     selectedItem(options[1]) // pre select "B", or ``null`` (default) to select nothing
+ *     selectedItem(options[1]) // pre select "B", or "null" (default) to select nothing
  * }
  * ```
  *

--- a/components/src/jsMain/kotlin/dev/fritz2/components/slider/component.kt
+++ b/components/src/jsMain/kotlin/dev/fritz2/components/slider/component.kt
@@ -44,13 +44,6 @@ internal enum class Direction {
 }
 
 /**
- * Definition of the layout orientation of a slider.
- */
-enum class Orientation {
-    HORIZONTAL, VERTICAL
-}
-
-/**
  * This class acts as central UI model for the [StateStore] and [SliderComponent].
  * @param progress backups the pure values of a slider managed by [Progress]
  * @param movementTracking this flag signals the current state of movement, that is whether some sliding action takes
@@ -278,7 +271,8 @@ internal class StateStore(
 open class SliderComponent(protected val store: Store<Int>? = null) :
     Component<Unit>,
     FormProperties by FormMixin(),
-    SeverityProperties by SeverityMixin() {
+    SeverityProperties by SeverityMixin(),
+    OrientationProperty by OrientationMixin(Orientation.HORIZONTAL) {
 
     companion object {
         const val cssDataFocus = "data-focus"
@@ -328,13 +322,6 @@ open class SliderComponent(protected val store: Store<Int>? = null) :
     val track = ComponentProperty<Style<BoxParams>> {}
     val trackFilled = ComponentProperty<BoxParams.(Int) -> Unit> {}
     val size = ComponentProperty<FormSizes.() -> Style<BasicParams>> { Theme().slider.sizes.normal }
-
-    object OrientationContext {
-        val horizontal: Orientation = Orientation.HORIZONTAL
-        val vertical: Orientation = Orientation.VERTICAL
-    }
-
-    val orientation = ComponentProperty<OrientationContext.() -> Orientation> { horizontal }
 
     override fun render(
         context: RenderContext,


### PR DESCRIPTION
- add new  general concepts for the *orientation* aspect of a component: That is align its item(s) in an *horizontal* or *vertical* way.
- offer a new mixin ``OrientationMixin`` for components
- add this mixin for the following components:
  - Slider (no API change!)
  - CheckBoxGroup: new ``orientation`` API, old ``direction`` marked as deprecated
  - RadioGroup: new ``orientation`` API, old ``direction`` marked as deprecated

## Migration

- ``direction`` → ``orientation``
- ``row`` → ``horizontal``
- ``column`` → ``vertical``

```kotlin
// old one with deprecation warning as:
// 'direction: ComponentProperty<CheckboxGroupComponent.DirectionContext.() -> CheckboxGroupComponent.Direction>' is deprecated. Use ``orientation`` instead
// 'row: CheckboxGroupComponent.Direction' is deprecated. Use ``orientation { horizontal }`` instead
checkboxGroup(values = someStore, items = someItems) {
    direction { row }
}

// change like this
checkboxGroup(values = someStore, items = someItems) {
    orientation { horizontal }
}
```

fixes #393
