### PR TITLE
Using `ComponentProperty` for setting an `IconDefinition` for a button

### DIFF
--- a/components/src/jsMain/kotlin/dev/fritz2/components/alert.kt
+++ b/components/src/jsMain/kotlin/dev/fritz2/components/alert.kt
@@ -4,10 +4,10 @@ import dev.fritz2.components.validation.ComponentValidationMessage
 import dev.fritz2.components.validation.Severity
 import dev.fritz2.dom.html.RenderContext
 import dev.fritz2.styling.StyleClass
+import dev.fritz2.styling.div
 import dev.fritz2.styling.params.BasicParams
 import dev.fritz2.styling.params.BoxParams
 import dev.fritz2.styling.params.Style
-import dev.fritz2.styling.*
 import dev.fritz2.styling.span
 import dev.fritz2.styling.style
 import dev.fritz2.styling.theme.*
@@ -84,7 +84,7 @@ open class AlertComponent : Component<Unit> {
         val discreet = AlertVariant.DISCREET
     }
 
-    val icon = ComponentProperty<(Icons.() -> IconDefinition)?>(value = null)
+    val icon = ComponentProperty<(Icons.() -> IconDefinition)?>(null)
     val severity = ComponentProperty<(AlertSeverities.() -> AlertSeverity)> { info }
     val variant = ComponentProperty<VariantContext.() -> AlertVariant> { solid }
     val size = ComponentProperty<FormSizes.() -> Style<BasicParams>> { normal }

--- a/components/src/jsMain/kotlin/dev/fritz2/components/appFrame.kt
+++ b/components/src/jsMain/kotlin/dev/fritz2/components/appFrame.kt
@@ -107,7 +107,7 @@ open class AppFrameComponent : Component<Unit> {
             margins { left { "-.5rem" } }
         }) {
             variant { link }
-            icon { fromTheme { menu } }
+            icon { menu }
         } handledBy sidebarToggle
     }
     val nav = ComponentProperty<TextElement.() -> Unit> {}

--- a/components/src/jsMain/kotlin/dev/fritz2/components/components.kt
+++ b/components/src/jsMain/kotlin/dev/fritz2/components/components.kt
@@ -6,7 +6,6 @@ import dev.fritz2.dom.DomListener
 import dev.fritz2.dom.EventContext
 import dev.fritz2.dom.HtmlTagMarker
 import dev.fritz2.dom.html.RenderContext
-import dev.fritz2.identification.uniqueId
 import dev.fritz2.styling.*
 import dev.fritz2.styling.params.BasicParams
 import dev.fritz2.styling.params.BoxParams
@@ -553,9 +552,9 @@ class CloseButtonMixin(
         clickButton({
             defaultStyle()
             closeButtonStyle.value()
-        }, id = "close-button-${uniqueId()}", prefix = closeButtonPrefix) {
+        }, prefix = closeButtonPrefix) {
             variant { ghost }
-            icon { def(closeButtonIcon.value(Theme().icons)) }
+            icon { closeButtonIcon.value(Theme().icons) }
         }
     }
 }

--- a/components/src/jsMain/kotlin/dev/fritz2/components/dropdown.kt
+++ b/components/src/jsMain/kotlin/dev/fritz2/components/dropdown.kt
@@ -72,7 +72,7 @@ open class DropdownComponent : Component<Unit> {
 
     val toggle = ComponentProperty<RenderContext.() -> Unit> {
         pushButton {
-            icon { fromTheme { menu } }
+            icon { menu }
             variant { ghost }
         }
     }

--- a/components/src/jsMain/kotlin/dev/fritz2/components/file.kt
+++ b/components/src/jsMain/kotlin/dev/fritz2/components/file.kt
@@ -105,7 +105,7 @@ abstract class FileSelectionBaseComponent {
 
     protected var context: RenderContext.(HTMLInputElement) -> Unit = { input ->
         pushButton(prefix = "file-button") {
-            icon { fromTheme { cloudUpload } }
+            icon { cloudUpload }
             element {
                 domNode.onclick = {
                     input.click()


### PR DESCRIPTION
This API change for `pushButton`, `clickButton` and `linkButton` harmonizes the way for setting an icon to it.
```kotlin
// before
pushButton {
    type { info }
    icon { fromTheme { circleInformation } }
    text("Info")
}

// now
pushButton {
    type { info }
    icon { circleInformation }
    text("Info")
}
```
In most cases it is enough to remove the `fromTheme()` function.

Fixes #392