### PR TITLE
Repair centered modal

### DIFF
--- a/styling/src/jsMain/kotlin/dev/fritz2/styling/theme/default.kt
+++ b/styling/src/jsMain/kotlin/dev/fritz2/styling/theme/default.kt
@@ -1055,10 +1055,10 @@ open class DefaultTheme : Theme {
                 position {
                     fixed {
                         top { "50%" }
+                        left { "50%" }
                     }
                 }
-                // FIXME: does not work! overrides size-settings!
-                css("transform: translateY(-50%);")
+                css("transform: translateX(-50%) translateY(-50%);")
             }
         }
     }


### PR DESCRIPTION
Modal with variant ``centered`` now works as expected, as both axis are now included.

fixes #399