### PR TITLE
Fixed self type loss after using global functions on `Listener` like `preventDefault` etc.

### DIFF
--- a/core/src/jsTest/kotlin/dev/fritz2/dom/listener.kt
+++ b/core/src/jsTest/kotlin/dev/fritz2/dom/listener.kt
@@ -34,7 +34,7 @@ class ListenerTest {
             section {
                 input(id = inputId) {
                     value(store.data)
-                    changes.values() handledBy store.update
+                    changes.preventDefault().values() handledBy store.update
                     inputs.values() handledBy store.update
                 }
             }
@@ -79,7 +79,7 @@ class ListenerTest {
                     store.data.asText()
                 }
                 button(id = buttonId) {
-                    clicks handledBy store.addADot
+                    clicks.preventDefault() handledBy store.addADot
                 }
             }
         }


### PR DESCRIPTION
Fixes the following code example:
```kotlin
input {
    value(store.data)
    // not compiling, because of returning Listener instead of DomListener after using preventDefault()
    changes.preventDefault().values() handledBy store.update
}
```