### PR TITLE
Improve Menu- and DropdownComponent

### DIFF
--- a/components/src/jsMain/kotlin/dev/fritz2/components/dropdown.kt
+++ b/components/src/jsMain/kotlin/dev/fritz2/components/dropdown.kt
@@ -17,21 +17,34 @@ import org.w3c.dom.HTMLElement
 
 
 /**
- * This class combines the _configuration_ and the core rendering of a dropdown.
+ * This class combines the _configuration_ and rendering of a dropdown.
  *
  * A dropdown consists of a toggle element as well as it's actual content in form of any fritz2-component. The
- * `content` property is used to specify the dropdown's content.
+ * `toggle` property can be used to specify a non-default toggle and the `content` property is used to specify the
+ * dropdown's content.
+ * A button with a standard menu-icon is used if no other toggle-element is specified.
  *
  * The dropdown floats around the toggle-element and can be closed by simply clicking outside the dropdown.
  * The opening an closing behavior can manually be controlled as well by specifying the `visible` property. It takes
- * a flow of values that determine whether the dropdown should be visible or not.
+ * a flow of values to determine whether the dropdown should be visible or not.
  *
- * The toggle-element can be any component as well and is passed via the `toggle` property. A button with a standard
- * menu-icon is used if no toggle-element is specified.
+ * The dropdown can be placed _to the left_, _to the right_, on top of, or _below_ the toggle-element. Additionally it
+ * can either be aligned to the start or end of the placement's cross-axis.
+ * This can be specified via the respective `placement` and `alignment` properties.
+ * The default positioning is bottom start.
  *
- * The dropdown can be placed _to the left_, _to the right_, on top of, or _below_ the toggle-element.
- * This can be specified via the `placement` property. The default placement is below the toggle. It's alignment on the
- * placement's cross-axis can be specified via the `alignment` property.
+ * Example usage:
+ * ```kotlin
+ * dropdown {
+ *     toggle {
+ *         // some layout
+ *     }
+ *     placement { bottom }
+ *     alignment { start }
+ *     content {
+ *         // some layout
+ *     }
+ * }
  * ```
  */
 open class DropdownComponent : Component<Unit> {

--- a/components/src/jsMain/kotlin/dev/fritz2/components/dropdown.kt
+++ b/components/src/jsMain/kotlin/dev/fritz2/components/dropdown.kt
@@ -8,7 +8,6 @@ import dev.fritz2.styling.div
 import dev.fritz2.styling.params.BasicParams
 import dev.fritz2.styling.params.BoxParams
 import dev.fritz2.styling.section
-import dev.fritz2.styling.style
 import dev.fritz2.styling.theme.Theme
 import kotlinx.coroutines.flow.debounce
 import kotlinx.coroutines.flow.map
@@ -122,12 +121,12 @@ open class DropdownComponent : Component<Unit> {
     }
 
     private fun renderDropdown(
-        renderContext: RenderContext,
+        context: RenderContext,
         styling: BoxParams.() -> Unit,
         baseClass: StyleClass,
         prefix: String
     ): HTMLElement {
-        return with(renderContext) {
+        return with(context) {
             section(style = {
                     styling()
                     Theme().dropdown.dropdown()

--- a/components/src/jsMain/kotlin/dev/fritz2/components/dropdown.kt
+++ b/components/src/jsMain/kotlin/dev/fritz2/components/dropdown.kt
@@ -4,6 +4,7 @@ import dev.fritz2.binding.RootStore
 import dev.fritz2.binding.watch
 import dev.fritz2.dom.html.RenderContext
 import dev.fritz2.styling.StyleClass
+import dev.fritz2.styling.div
 import dev.fritz2.styling.params.BasicParams
 import dev.fritz2.styling.params.BoxParams
 import dev.fritz2.styling.section
@@ -34,16 +35,6 @@ import org.w3c.dom.HTMLElement
  * ```
  */
 open class DropdownComponent : Component<Unit> {
-
-    private val containerCss = style("dropdown-container") {
-        position(
-            sm = { static },
-            md = { relative { } }
-        )
-        display { inlineFlex }
-        width { minContent }
-    }
-
 
     enum class Placement {
         Left,
@@ -96,7 +87,7 @@ open class DropdownComponent : Component<Unit> {
         prefix: String
     ) {
         context.apply {
-            div(this@DropdownComponent.containerCss.name, id) {
+            div(Theme().dropdown.container, id = id) {
                 div {
                     this@DropdownComponent.toggle.value(this)
                     clicks.events.map { } handledBy this@DropdownComponent.visibilityStore.toggle

--- a/components/src/jsMain/kotlin/dev/fritz2/components/menu.kt
+++ b/components/src/jsMain/kotlin/dev/fritz2/components/menu.kt
@@ -16,11 +16,11 @@ import org.w3c.dom.HTMLButtonElement
 /**
  * This class combines the _configuration_ and the core rendering of a menu.
  *
- * A Menu consists of different types of entries that are aligned vertically.
+ * A Menu consists of different types of children that are aligned vertically.
  * By default the following types can be added to the menu:
- * - Entries
- * - Headers
- * - Dividers
+ * - Entries (see [MenuEntry])
+ * - Headers (see [MenuHeader])
+ * - Dividers (see [MenuDivider])
  *
  * It is also possible to add any other fritz2 component via the `custom` context.
  * All menu items are created directly within the [MenuComponent]'s build context.
@@ -29,7 +29,7 @@ import org.w3c.dom.HTMLButtonElement
  * ```kotlin
  * menu {
  *      entry {
- *          leftIcon { add }
+ *          icon { add }
  *          text("Item")
  *      }
  *      divider()
@@ -42,17 +42,16 @@ import org.w3c.dom.HTMLButtonElement
  * ```
  *
  * The menu-entry-DSL can be extended via standard Kotlin extension methods. Custom entries must implement the
- * `Component<Unit>` interface and are added to the Menu via [MenuComponent.addChild]
+ * `Component<Unit>` interface and are added to the Menu via the [MenuComponent.addChild] method
  * which is accessible from within the extension method.
- * In a way these extension methods are similar to standard fritz2 factory methods.
  *
  * The following example adds an instance of `MyMenuEntry` to the Menu.
- * Notice that `addEntry` is invoked in the end; the entry wouldn't be added otherwise!
+ * Notice that `addChild` is invoked in the end; the entry wouldn't be added otherwise!
  *
  * ```kotlin
  * fun MenuComponent.example(build: MyMenuEntry.() -> Unit) = MyMenuEntry()
  *      .apply(build)
- *      .run(::addEntry)
+ *      .run(::addChild)
  * ```
  */
 open class MenuComponent : Component<Unit> {
@@ -134,7 +133,7 @@ open class MenuComponent : Component<Unit> {
 }
 
 /**
- * Creates a Menu.
+ * Creates a menu.
  *
  * @param styling a lambda expression for declaring the styling as fritz2's styling DSL
  * @param baseClass optional CSS class that should be applied to the element
@@ -167,7 +166,7 @@ interface MenuChild {
  * An entry is a special kind of button consisting of a label and an optional icon used in dropdown menus.
  * Just like a regular button it is clickable and can be enabled/disabled.
  *
- * It can be configured with an _icon_, a _text_ and a boolean-[Flow] to determine whether the item is enabled.
+ * It can be configured with an _icon_, a _text_ and can be enabled or disabled the same way as a regular button.
  *
  * @param styling Optional style to be applied to the underlying button-element
  */
@@ -218,7 +217,7 @@ open class CustomMenuEntry : MenuChild {
  * This class combines the _configuration_ and the core rendering of a [MenuHeader].
  *
  * A header can be used to introduce a group of menu entries and separate them from the entries above.
- * It simply consists of a static, styled _text_.
+ * It simply consists of a styled _text_.
  *
  * @param styling Optional styling to be applied to the underlying div-element
  */
@@ -239,7 +238,7 @@ open class MenuHeader(private val styling: Style<BasicParams> = { }) : MenuChild
  * This class combines the _configuration_ and the core rendering of a [MenuDivider].
  *
  * Similar to a header a divider can be used to group entries together.
- * Compared to a header a divider displays a thin line rather than text.
+ * Compared to a header a divider displays a thin line rather than a text.
  *
  * @param styling Optional styling to be applied to the underlying div-element
  */

--- a/components/src/jsMain/kotlin/dev/fritz2/components/menu.kt
+++ b/components/src/jsMain/kotlin/dev/fritz2/components/menu.kt
@@ -5,12 +5,12 @@ import dev.fritz2.dom.html.RenderContext
 import dev.fritz2.styling.StyleClass
 import dev.fritz2.styling.button
 import dev.fritz2.styling.div
-import dev.fritz2.styling.params.*
-import dev.fritz2.styling.staticStyle
+import dev.fritz2.styling.params.BoxParams
+import dev.fritz2.styling.params.Style
+import dev.fritz2.styling.params.plus
 import dev.fritz2.styling.theme.IconDefinition
 import dev.fritz2.styling.theme.Icons
 import dev.fritz2.styling.theme.Theme
-import kotlinx.coroutines.flow.Flow
 import org.w3c.dom.HTMLButtonElement
 
 /**
@@ -67,15 +67,15 @@ open class MenuComponent : Component<Unit> {
      *
      * @param build Lambda to configure the component itself
      */
-    fun entry(build: MenuEntry.() -> Unit) = entry(styling = { }, build)
+    fun entry(build: MenuEntry.() -> Unit) = entry({}, build)
 
     /**
      * Configures and adds a [MenuEntry] to the menu.
      *
-     * @param styling Styling to be applied to the component
+     * @param styling [Style] to be applied to the component
      * @param build Lambda to configure the component itself
      */
-    fun entry(styling: Style<FlexParams>, build: MenuEntry.() -> Unit) = MenuEntry(styling)
+    fun entry(styling: Style<BoxParams>, build: MenuEntry.() -> Unit) = MenuEntry(styling)
         .apply(build)
         .run(::addChild)
 
@@ -84,7 +84,15 @@ open class MenuComponent : Component<Unit> {
      *
      * @param build Lambda containing the layout to render
      */
-    fun custom(build: RenderContext.() -> Unit) = CustomMenuEntry()
+    fun custom(build: RenderContext.() -> Unit) = custom({}, build)
+
+    /**
+     * Adds a custom fritz2-component to the menu.
+     *
+     * @param styling [Style] to be applied to the component
+     * @param build Lambda containing the layout to render
+     */
+    fun custom(styling: Style<BoxParams>, build: RenderContext.() -> Unit) = CustomMenuEntry(styling)
         .apply { content(build) }
         .run(::addChild)
 
@@ -95,24 +103,24 @@ open class MenuComponent : Component<Unit> {
      *
      * @param text Text to be displayed in the header
      */
-    fun header(text: String) = header(styling = { }, text)
+    fun header(text: String) = header({}, text)
 
     /**
      * Configures and adds a [MenuHeader] to the menu.
      *
-     * @param styling Styling to be applied to the underlying component
+     * @param styling [Style] to be applied to the underlying component
      * @param text Text to be displayed in the header
      */
-    fun header(styling: Style<BasicParams>, text: String) = MenuHeader(styling)
+    fun header(styling: Style<BoxParams>, text: String) = MenuHeader(styling)
         .apply { text(text) }
         .run(::addChild)
 
     /**
      * Adds a [MenuDivider] to the menu.
      *
-     * @param styling Optional styling to be applied to the underlying component
+     * @param styling optional [Style] to be applied to the underlying component
      */
-    fun divider(styling: Style<BasicParams> = { }) = addChild(MenuDivider(styling))
+    fun divider(styling: Style<BoxParams> = {}) = addChild(MenuDivider(styling))
 
 
     override fun render(
@@ -142,7 +150,7 @@ open class MenuComponent : Component<Unit> {
  * @param build a lambda expression for setting up the component itself.
  */
 fun RenderContext.menu(
-    styling: BasicParams.() -> Unit = {},
+    styling: BoxParams.() -> Unit = {},
     baseClass: StyleClass = StyleClass.None,
     id: String? = null,
     prefix: String = "menu",
@@ -170,7 +178,7 @@ interface MenuChild {
  *
  * @param styling Optional style to be applied to the underlying button-element
  */
-open class MenuEntry(private val styling: Style<FlexParams> = { }) :
+open class MenuEntry(private val styling: Style<BoxParams> = {}) :
     MenuChild,
     EventProperties<HTMLButtonElement> by EventMixin(),
     FormProperties by FormMixin()
@@ -201,12 +209,12 @@ open class MenuEntry(private val styling: Style<FlexParams> = { }) :
  * A custom menu entry can be any fritz2 component. The component simply wraps any layout in a container and renders it
  * to the menu.
  */
-open class CustomMenuEntry : MenuChild {
+open class CustomMenuEntry(private val styling: Style<BoxParams> = {}) : MenuChild {
     val content = ComponentProperty<RenderContext.() -> Unit> { }
 
     override fun render(context: RenderContext) {
         context.apply {
-            div(Theme().menu.custom) {
+            div(Theme().menu.custom + this@CustomMenuEntry.styling) {
                 this@CustomMenuEntry.content.value(this)
             }
         }
@@ -221,7 +229,7 @@ open class CustomMenuEntry : MenuChild {
  *
  * @param styling Optional styling to be applied to the underlying div-element
  */
-open class MenuHeader(private val styling: Style<BasicParams> = { }) : MenuChild {
+open class MenuHeader(private val styling: Style<BoxParams> = {}) : MenuChild {
 
     val text = ComponentProperty("")
 
@@ -242,7 +250,7 @@ open class MenuHeader(private val styling: Style<BasicParams> = { }) : MenuChild
  *
  * @param styling Optional styling to be applied to the underlying div-element
  */
-open class MenuDivider(private val styling: Style<BasicParams> = { }) : MenuChild {
+open class MenuDivider(private val styling: Style<BoxParams> = {}) : MenuChild {
 
     override fun render(context: RenderContext) {
         context.apply {

--- a/components/src/jsMain/kotlin/dev/fritz2/components/menu.kt
+++ b/components/src/jsMain/kotlin/dev/fritz2/components/menu.kt
@@ -5,9 +5,7 @@ import dev.fritz2.dom.html.RenderContext
 import dev.fritz2.styling.StyleClass
 import dev.fritz2.styling.button
 import dev.fritz2.styling.div
-import dev.fritz2.styling.params.BasicParams
-import dev.fritz2.styling.params.BoxParams
-import dev.fritz2.styling.params.plus
+import dev.fritz2.styling.params.*
 import dev.fritz2.styling.staticStyle
 import dev.fritz2.styling.theme.IconDefinition
 import dev.fritz2.styling.theme.Icons
@@ -63,21 +61,59 @@ open class MenuComponent : Component<Unit> {
     fun addChild(child: MenuChild) = children.add(child)
 
 
-    fun entry(build: MenuEntry.() -> Unit) = MenuEntry()
+    /**
+     * Configures and adds a [MenuEntry] to the menu.
+     *
+     * Use the overloaded version of this method to specify additional styling.
+     *
+     * @param build Lambda to configure the component itself
+     */
+    fun entry(build: MenuEntry.() -> Unit) = entry(styling = { }, build)
+
+    /**
+     * Configures and adds a [MenuEntry] to the menu.
+     *
+     * @param styling Styling to be applied to the component
+     * @param build Lambda to configure the component itself
+     */
+    fun entry(styling: Style<FlexParams>, build: MenuEntry.() -> Unit) = MenuEntry(styling)
         .apply(build)
         .run(::addChild)
 
+    /**
+     * Adds a custom fritz2-component to the menu.
+     *
+     * @param build Lambda containing the layout to render
+     */
     fun custom(build: RenderContext.() -> Unit) = CustomMenuEntry()
         .apply { content(build) }
         .run(::addChild)
 
-    fun header(build: MenuHeader.() -> Unit) = MenuHeader()
-        .apply(build)
+    /**
+     * Configures and adds a [MenuHeader] to the menu.
+     *
+     * Use the overloaded version of this method to specify additional styling.
+     *
+     * @param text Text to be displayed in the header
+     */
+    fun header(text: String) = header(styling = { }, text)
+
+    /**
+     * Configures and adds a [MenuHeader] to the menu.
+     *
+     * @param styling Styling to be applied to the underlying component
+     * @param text Text to be displayed in the header
+     */
+    fun header(styling: Style<BasicParams>, text: String) = MenuHeader(styling)
+        .apply { text(text) }
         .run(::addChild)
 
-    fun header(text: String) = header { text(text) }
-
-    fun divider() = addChild(MenuDivider())
+    /**
+     * Adds a [MenuDivider] to the menu.
+     *
+     * @param styling Optional styling to be applied to the underlying component
+     */
+    fun divider(styling: Style<BasicParams> = { }) = addChild(MenuDivider(styling))
 
 
     override fun render(
@@ -132,8 +168,10 @@ interface MenuChild {
  * Just like a regular button it is clickable and can be enabled/disabled.
  *
  * It can be configured with an _icon_, a _text_ and a boolean-[Flow] to determine whether the item is enabled.
+ *
+ * @param styling Optional style to be applied to the underlying button-element
  */
-open class MenuEntry :
+open class MenuEntry(private val styling: Style<FlexParams> = { }) :
     MenuChild,
     EventProperties<HTMLButtonElement> by EventMixin(),
     FormProperties by FormMixin()
@@ -143,7 +181,7 @@ open class MenuEntry :
 
     override fun render(context: RenderContext) {
         context.apply {
-            button(Theme().menu.entry) {
+            button(Theme().menu.entry + this@MenuEntry.styling) {
                 this@MenuEntry.icon.value?.let {
                     icon({
                         margins { right { smaller } }
@@ -181,13 +219,16 @@ open class CustomMenuEntry : MenuChild {
  *
  * A header can be used to introduce a group of menu entries and separate them from the entries above.
  * It simply consists of a static, styled _text_.
+ *
+ * @param styling Optional styling to be applied to the underlying div-element
  */
-open class MenuHeader : MenuChild {
+open class MenuHeader(private val styling: Style<BasicParams> = { }) : MenuChild {
+
     val text = ComponentProperty("")
 
     override fun render(context: RenderContext) {
         context.apply {
-            div(Theme().menu.header) {
+            div(Theme().menu.header + this@MenuHeader.styling) {
                 +this@MenuHeader.text.value
             }
         }
@@ -199,12 +240,14 @@ open class MenuHeader : MenuChild {
  *
  * Similar to a header a divider can be used to group entries together.
  * Compared to a header a divider displays a thin line rather than text.
+ *
+ * @param styling Optional styling to be applied to the underlying div-element
  */
-open class MenuDivider : MenuChild {
+open class MenuDivider(private val styling: Style<BasicParams> = { }) : MenuChild {
 
     override fun render(context: RenderContext) {
         context.apply {
-            div(Theme().menu.divider) { }
+            div(Theme().menu.divider + this@MenuDivider.styling) { }
         }
     }
 }

--- a/components/src/jsMain/kotlin/dev/fritz2/components/menu.kt
+++ b/components/src/jsMain/kotlin/dev/fritz2/components/menu.kt
@@ -7,6 +7,7 @@ import dev.fritz2.styling.button
 import dev.fritz2.styling.div
 import dev.fritz2.styling.params.BasicParams
 import dev.fritz2.styling.params.BoxParams
+import dev.fritz2.styling.params.plus
 import dev.fritz2.styling.staticStyle
 import dev.fritz2.styling.theme.IconDefinition
 import dev.fritz2.styling.theme.Icons
@@ -58,26 +59,6 @@ import org.w3c.dom.HTMLButtonElement
  */
 open class MenuComponent : Component<Unit> {
 
-    companion object {
-        private val containerCss = staticStyle("menu-container") {
-            minWidth { "50px" }
-            maxWidth { maxContent }
-            paddings {
-                vertical { smaller }
-            }
-        }
-
-        val childCss = staticStyle("menu-child") {
-            width { "100%" }
-            paddings {
-                horizontal { normal }
-                vertical { smaller }
-            }
-            radius { "6px" }
-        }
-    }
-
-
     private val children = mutableListOf<MenuChild>()
     fun addChild(child: MenuChild) = children.add(child)
 
@@ -107,7 +88,7 @@ open class MenuComponent : Component<Unit> {
         prefix: String
     ) {
         context.apply {
-            div(styling, baseClass + containerCss, id, prefix) {
+            div(Theme().menu.container + styling, baseClass, id, prefix) {
                 this@MenuComponent.children.forEach {
                     it.render(this)
                 }
@@ -136,6 +117,9 @@ fun RenderContext.menu(
     .render(this, styling, baseClass, id, prefix)
 
 
+/**
+ * An interface for renderable sub-components of a Menu all children of a Menu must implement.
+ */
 @HtmlTagMarker
 interface MenuChild {
     fun render(context: RenderContext)
@@ -159,7 +143,7 @@ open class MenuEntry :
 
     override fun render(context: RenderContext) {
         context.apply {
-            button(Theme().menu.entry, MenuComponent.childCss) {
+            button(Theme().menu.entry) {
                 this@MenuEntry.icon.value?.let {
                     icon({
                         margins { right { smaller } }
@@ -181,12 +165,11 @@ open class MenuEntry :
  * to the menu.
  */
 open class CustomMenuEntry : MenuChild {
-
     val content = ComponentProperty<RenderContext.() -> Unit> { }
 
     override fun render(context: RenderContext) {
         context.apply {
-            div(MenuComponent.childCss.name) {
+            div(Theme().menu.custom) {
                 this@CustomMenuEntry.content.value(this)
             }
         }
@@ -200,12 +183,11 @@ open class CustomMenuEntry : MenuChild {
  * It simply consists of a static, styled _text_.
  */
 open class MenuHeader : MenuChild {
-
     val text = ComponentProperty("")
 
     override fun render(context: RenderContext) {
         context.apply {
-            div(Theme().menu.header, MenuComponent.childCss) {
+            div(Theme().menu.header) {
                 +this@MenuHeader.text.value
             }
         }
@@ -213,25 +195,16 @@ open class MenuHeader : MenuChild {
 }
 
 /**
- * This class combines the _configuration_ and the core rendering of a [MenuHeader].
+ * This class combines the _configuration_ and the core rendering of a [MenuDivider].
  *
  * Similar to a header a divider can be used to group entries together.
  * Compared to a header a divider displays a thin line rather than text.
  */
 open class MenuDivider : MenuChild {
 
-    companion object {
-        private val menuDividerCss = staticStyle("menu-divider") {
-            width { "100%" }
-            height { "1px" }
-            margins { vertical { smaller } }
-            background { color { gray300 } }
-        }
-    }
-
     override fun render(context: RenderContext) {
         context.apply {
-            div(baseClass = menuDividerCss.name) { }
+            div(Theme().menu.divider) { }
         }
     }
 }

--- a/styling/src/jsMain/kotlin/dev/fritz2/styling/theme/default.kt
+++ b/styling/src/jsMain/kotlin/dev/fritz2/styling/theme/default.kt
@@ -1938,7 +1938,7 @@ open class DefaultTheme : Theme {
             }
         }
 
-        override val entry: Style<FlexParams> = {
+        override val entry: Style<BoxParams> = {
             width { "100%" }
             display { flex }
             justifyContent { start }

--- a/styling/src/jsMain/kotlin/dev/fritz2/styling/theme/default.kt
+++ b/styling/src/jsMain/kotlin/dev/fritz2/styling/theme/default.kt
@@ -1796,6 +1796,15 @@ open class DefaultTheme : Theme {
 
 
     override val dropdown: DropdownStyles = object : DropdownStyles {
+        override val container: Style<BasicParams> = {
+            position(
+                sm = { static },
+                md = { relative { } }
+            )
+            display { inlineFlex }
+            width { minContent }
+        }
+
         override val dropdown: Style<BasicParams> = {
             width(
                 sm = { "100%" },
@@ -1911,9 +1920,34 @@ open class DefaultTheme : Theme {
 
 
     override val menu: MenuStyles = object : MenuStyles {
+
+        // base css for all menu children ('entry' uses special styling though)
+        private val base: Style<BasicParams> = {
+            width { "calc(100% - ${sizes.normal} * 2)" }
+            margins {
+                horizontal { normal }
+                vertical { smaller }
+            }
+        }
+
+        override val container: Style<BasicParams> = {
+            minWidth { "50px" }
+            maxWidth { maxContent }
+            paddings {
+                vertical { smaller }
+            }
+        }
+
         override val entry: Style<FlexParams> = {
+            width { "100%" }
             display { flex }
             justifyContent { start }
+            margin { auto }
+            paddings {
+                horizontal { normal }
+                vertical { smaller }
+            }
+            radius { "6px" }
             css("user-select: none")
 
             hover {
@@ -1927,10 +1961,21 @@ open class DefaultTheme : Theme {
         }
 
         override val header: Style<BasicParams> = {
+            base()
             color { secondary.main }
             fontSize { fontSizes.normal }
             fontWeight { bold }
             css("white-space: nowrap")
+        }
+
+        override val divider: Style<BasicParams> = {
+            base()
+            height { "1px" }
+            background { color { gray300 } }
+        }
+
+        override val custom: Style<BasicParams> = {
+            base()
         }
     }
 

--- a/styling/src/jsMain/kotlin/dev/fritz2/styling/theme/definitions.kt
+++ b/styling/src/jsMain/kotlin/dev/fritz2/styling/theme/definitions.kt
@@ -705,7 +705,7 @@ interface DropdownAlignments {
  */
 interface MenuStyles {
     val container: Style<BasicParams>
-    val entry: Style<FlexParams>
+    val entry: Style<BasicParams>
     val header: Style<BasicParams>
     val divider: Style<BasicParams>
     val custom: Style<BasicParams>

--- a/styling/src/jsMain/kotlin/dev/fritz2/styling/theme/definitions.kt
+++ b/styling/src/jsMain/kotlin/dev/fritz2/styling/theme/definitions.kt
@@ -679,6 +679,7 @@ interface ToastButton {
  * definition of the theme's dropdown
  */
 interface DropdownStyles {
+    val container: Style<BasicParams>
     val dropdown: Style<BasicParams>
     val placements: DropdownPlacements
     val alignments: DropdownAlignments
@@ -703,8 +704,11 @@ interface DropdownAlignments {
  * definition of the theme's menu
  */
 interface MenuStyles {
+    val container: Style<BasicParams>
     val entry: Style<FlexParams>
     val header: Style<BasicParams>
+    val divider: Style<BasicParams>
+    val custom: Style<BasicParams>
 }
 
 

--- a/styling/src/jsMain/kotlin/dev/fritz2/styling/theme/definitions.kt
+++ b/styling/src/jsMain/kotlin/dev/fritz2/styling/theme/definitions.kt
@@ -705,10 +705,10 @@ interface DropdownAlignments {
  */
 interface MenuStyles {
     val container: Style<BasicParams>
-    val entry: Style<BasicParams>
+    val entry: Style<BoxParams>
     val header: Style<BasicParams>
     val divider: Style<BasicParams>
-    val custom: Style<BasicParams>
+    val custom: Style<BoxParams>
 }
 
 


### PR DESCRIPTION
This PR reworks some parts of the menu- and dropdown-components based on feedback.

Changes:
- [X] Move all styling into the theme
- [X] Menu-subcomponents (entries, headers, dividers, ...) no longer extend `Component<T>` as they are not technically components. The newly added `MenuChild` interface replaces it in those cases. `MenuComponent.addEntry()` has been renamed to `MenuComponent.addChild()`.
- [x] Enable styling via parameter for menu children
- [x] Add missing documentation for some factory methods