### PR TITLE
Make track safe for unsafe operations

### DIFF
--- a/core/src/jsMain/kotlin/dev/fritz2/tracking/tracking.kt
+++ b/core/src/jsMain/kotlin/dev/fritz2/tracking/tracking.kt
@@ -36,12 +36,19 @@ class Tracker(
     /**
      * Tracks a given [operation].
      *
+     * Works also with unsafe operations that throw exceptions, as the tracking gets stopped. The exceptions are
+     * not swallowed though.
+     *
      * @param transaction text describing the transaction
      * @param operation function to track
      */
     suspend fun <T> track(transaction: String = defaultTransaction, operation: suspend () -> T): T {
         state.value = transaction
-        return operation().also { state.value = null }
+        return try {
+            operation()
+        } finally {
+            state.value = null
+        }
     }
 
     /**


### PR DESCRIPTION
Currently the tracker does expect safe operations in order to work, so the client has to make shure, that no exception is beeing thrown by the passed operation.

This is quite dangerous, as the tracker will not stop working by itself (and there would be the need for a kind of _reset_ handler to be called when dealing with the exception).

This example should work now: The tracker will be stopped, but the exception is not swallowed and could be handled appropriately where needed:
```kotlin
val fooStore = object : RootStore<Int>(0) {
    val t = tracker()

    val h = handle {
        t.track {
            // unsafe operation is passed to ``track``
            delay(500)
            throw Exception("Boom!")
            it + 1 // will never be reached
        }
    }
}
```

fixes #425