### PR TITLE
Use explicit type specification for `Icons`  in `DefaultTheme`

### DIFF
--- a/styling/src/jsMain/kotlin/dev/fritz2/styling/theme/default.kt
+++ b/styling/src/jsMain/kotlin/dev/fritz2/styling/theme/default.kt
@@ -422,7 +422,7 @@ open class DefaultTheme : Theme {
         """.trimIndent()
     }
 
-    override val icons = MonoIcons()
+    override val icons: Icons = MonoIcons()
 
     override val input = object : InputFieldStyles {
         override val sizes = object : FormSizes {


### PR DESCRIPTION
Fixes #433