### PR TITLE
Rework modal

### DIFF
--- a/components/src/jsMain/kotlin/dev/fritz2/components/components.kt
+++ b/components/src/jsMain/kotlin/dev/fritz2/components/components.kt
@@ -545,11 +545,22 @@ class CloseButtonMixin(
     override val closeButtonPrefix: String = "close-button",
     private val defaultStyle: Style<BasicParams>
 ) : CloseButtonProperty {
+
+    private val resetButtonStyles: Style<BasicParams> = {
+        lineHeight { "unset" }
+        radius { "unset" }
+        fontWeight { "unset" }
+        padding { "unset" }
+        height { "unset" }
+        minWidth { "unset" }
+    }
+
     override val closeButtonStyle = ComponentProperty<Style<BasicParams>> {}
     override val closeButtonIcon = ComponentProperty<Icons.() -> IconDefinition> { Theme().icons.close }
     override val hasCloseButton = ComponentProperty(true)
     override val closeButtonRendering = ComponentProperty<RenderContext.() -> DomListener<MouseEvent, HTMLElement>> {
         clickButton({
+            resetButtonStyles()
             defaultStyle()
             closeButtonStyle.value()
         }, prefix = closeButtonPrefix) {

--- a/components/src/jsMain/kotlin/dev/fritz2/components/modal.kt
+++ b/components/src/jsMain/kotlin/dev/fritz2/components/modal.kt
@@ -11,8 +11,11 @@ import dev.fritz2.styling.params.BasicParams
 import dev.fritz2.styling.params.BoxParams
 import dev.fritz2.styling.params.Style
 import dev.fritz2.styling.theme.*
+import dev.fritz2.styling.*
+import kotlinx.browser.document
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.map
+import org.w3c.dom.get
 
 typealias ModalRenderContext = RenderContext.(level: Int) -> Div
 
@@ -76,8 +79,8 @@ open class ModalComponent(protected val build: ModalComponent.(SimpleHandler<Uni
     CloseButtonProperty by CloseButtonMixin("modal-close-button", {
         position {
             absolute {
-                right { none }
-                top { none }
+                right { smaller }
+                top { smaller }
             }
         }
     }) {
@@ -98,6 +101,7 @@ open class ModalComponent(protected val build: ModalComponent.(SimpleHandler<Uni
         val overlay = storeOf<Overlay>(DefaultOverlay())
         private val job = Job()
         private val globalId = "f2c-modals-${randomId()}"
+        private val myStaticStyle = staticStyle("disableOverflowForModal", "overflow:hidden !important;")
 
         fun setOverlayHandler(overlay: Overlay) {
             ModalComponent.overlay.update(overlay)
@@ -105,6 +109,7 @@ open class ModalComponent(protected val build: ModalComponent.(SimpleHandler<Uni
 
         init {
             stack.data.map { modals ->
+                configureBodyScrolling(modals)
                 ManagedComponent.managedRenderContext(globalId, job).apply {
                     val currentOverlay = overlay.current
                     if (currentOverlay.method == OverlayMethod.CoveringTopMost && modals.isNotEmpty()) {
@@ -122,11 +127,63 @@ open class ModalComponent(protected val build: ModalComponent.(SimpleHandler<Uni
             }.watch()
         }
 
+        private fun configureBodyScrolling(modals: List<ModalRenderContext>) {
+            val bodyElementClasses = document.getElementsByTagName("body")[0]?.classList
+            if (modals.isNotEmpty()) {
+                bodyElementClasses?.add(myStaticStyle.name)
+            } else {
+                bodyElementClasses?.remove(myStaticStyle.name)
+            }
+        }
+
     }
 
     val content = ComponentProperty<(RenderContext.() -> Unit)?>(null)
-    val size = ComponentProperty<ModalSizes.() -> Style<BasicParams>> { Theme().modal.sizes.normal }
+
+    @Deprecated(message = "Use width property instead.")
+    val size = ComponentProperty<(ModalSizes.() -> Style<BasicParams>)?>(null)
+
+    @Deprecated(message = "Use placement property instead.")
     val variant = ComponentProperty<ModalVariants.() -> Style<BasicParams>> { Theme().modal.variants.auto }
+
+    enum class Placement {
+        TOP, CENTER, BOTTOM, STRETCH
+    }
+
+    object PlacementContext {
+        val top = Placement.TOP
+        val center = Placement.CENTER
+        val bottom = Placement.BOTTOM
+        val stretch = Placement.STRETCH
+
+        fun flexValueOf(placement: Placement) = when (placement) {
+            Placement.TOP -> "flex-start"
+            Placement.CENTER -> "center"
+            Placement.BOTTOM -> "flex-end"
+            Placement.STRETCH -> "stretch"
+        }
+
+        fun externalScrollingPossible(placement: Placement) = placement == Placement.TOP
+    }
+
+    val placement = ComponentProperty<PlacementContext.() -> Placement> { Placement.TOP }
+
+    object WidthContext {
+        val small = "small"
+        val normal = "normal"
+        val large = "large"
+        val full = "full"
+
+        fun asCssWidthExpression(value: Property) = when (value) {
+            small -> Theme().modal.widths.small
+            normal -> Theme().modal.widths.normal
+            large -> Theme().modal.widths.large
+            full -> Theme().modal.widths.full
+            else -> value
+        }
+    }
+
+    val width = ComponentProperty<WidthContext.() -> String> { normal }
 
     override fun render(
         styling: BoxParams.() -> Unit,
@@ -138,17 +195,47 @@ open class ModalComponent(protected val build: ModalComponent.(SimpleHandler<Uni
         val component = this.apply { build(close) }
 
         val modal: ModalRenderContext = { level ->
-            box({
-                css("--main-level: ${level}rem;")
+            flexBox({
                 zIndex { modal(level) }
-                component.size.value.invoke(Theme().modal.sizes)()
-                component.variant.value.invoke(Theme().modal.variants)()
-                styling(this as BoxParams)
-            }, baseClass, id, prefix) {
-                if (component.hasCloseButton.value) {
-                    component.closeButtonRendering.value(this) handledBy close
+                position {
+                    fixed {
+                        left { "0px" }
+                        top { "0px" }
+                    }
                 }
-                component.content.value?.let { it() }
+                width { "100vw" }
+                height { "100vh" }
+                if (PlacementContext.externalScrollingPossible(component.placement.value(PlacementContext))) {
+                    overflow { auto }
+                }
+                justifyContent { center }
+                alignItems { PlacementContext.flexValueOf(component.placement.value(PlacementContext)) }
+            }) {
+                div({
+                    css("--modal-level: ${level}rem;")
+                    zIndex { modal(level, 1) }
+                    position { relative { } }
+                    Theme().modal.base()
+                    if (component.size.value != null) {
+                        // TODO: remove if-branch when ``size`` gets removed; keep only else body!
+                        component.size.value!!.invoke(Theme().modal.sizes)()
+                    } else {
+                        Theme().modal.width(
+                            this,
+                            component.width.value(WidthContext),
+                            WidthContext.asCssWidthExpression(component.width.value(WidthContext))
+                        )
+                    }
+                    if (!PlacementContext.externalScrollingPossible(component.placement.value(PlacementContext))) {
+                        Theme().modal.internalScrolling()
+                    }
+                    styling(this)
+                }, baseClass, id, prefix) {
+                    if (component.hasCloseButton.value) {
+                        component.closeButtonRendering.value(this) handledBy close
+                    }
+                    component.content.value?.let { it() }
+                }
             }
         }
 

--- a/styling/src/jsMain/kotlin/dev/fritz2/styling/theme/default.kt
+++ b/styling/src/jsMain/kotlin/dev/fritz2/styling/theme/default.kt
@@ -967,6 +967,16 @@ open class DefaultTheme : Theme {
 
     override val modal = object : ModalStyles {
 
+        override val base: Style<BasicParams> = {
+            background {
+                color { neutral.main }
+            }
+            padding { normal }
+            radius { tiny }
+            boxShadow { raisedFurther }
+            width { "100%" }
+        }
+
         override val overlay: Style<BasicParams> = {
             position {
                 fixed {
@@ -979,95 +989,70 @@ open class DefaultTheme : Theme {
             }
         }
 
+        override val width: BasicParams.(String, Property) -> Unit = { key, value ->
+            maxWidth { value }
+            if(key.lowercase() != "full") {
+                margins {
+                    top { "var(--modal-level)" }
+                    left { "var(--modal-level)" }
+                    right { "1rem" }
+                    bottom { "1rem" }
+                }
+            }
+        }
+
+        override val widths = object : ModalWidths {
+            override val full = "100vw"
+            override val small = "calc(50vw - var(--modal-level))"
+            override val normal = "calc(70vw - var(--modal-level))"
+            override val large = "100vw"
+        }
+
         override val sizes = object : ModalSizes {
 
-            private val basic: Style<BasicParams> = {
-                background {
-                    color { neutral.main }
+            private val withMargin: Style<BasicParams> = {
+                margins {
+                    top { "var(--modal-level)" }
+                    left { "var(--modal-level)" }
+                    right { "1rem" }
+                    bottom { "1rem" }
                 }
-                padding { normal }
-                radius { tiny }
-                boxShadow { raisedFurther }
             }
 
             override val full: Style<BasicParams> = {
-                basic()
-                width { "100%" }
-                height { "100%" }
-                position {
-                    fixed {
-                        horizontal { "0" }
-                        vertical { "0" }
-                    }
-                }
+                maxWidth { "100vw" }
             }
 
             override val large: Style<BasicParams> = {
-                basic()
-                position {
-                    fixed {
-                        left { "var(--main-level)" }
-                        top { "var(--main-level)" }
-                        right { normal }
-                    }
-                }
-                minHeight { wide.smaller }
+                maxWidth { "100vw" }
+                withMargin()
             }
 
             override val normal: Style<BasicParams> = {
-                basic()
-                position {
-                    fixed {
-                        top { "var(--main-level)" }
-                        left { "50%" }
-                    }
-                }
-                minHeight { wide.smaller }
-                minWidth { "50%" }
-                css("transform: translateX(-50%);")
+                maxWidth { "calc(70vw - var(--modal-level))" }
+                withMargin()
             }
 
             override val small: Style<BasicParams> = {
-                basic()
-                position {
-                    fixed {
-                        top { "var(--main-level)" }
-                        left { "65%" }
-                        bottom { normal }
-                    }
-                }
-                minHeight { wide.smaller }
-                minWidth { "35%" }
-                css("transform: translateX(-90%);")
+                maxWidth { "calc(50vw - var(--modal-level))" }
+                withMargin()
             }
         }
 
         override val variants = object : ModalVariants {
             override val auto: Style<BasicParams> = {
-                position {
-                    fixed {
-                        bottom { auto }
-                    }
-                }
             }
 
             override val verticalFilled: Style<BasicParams> = {
-                position {
-                    fixed {
-                        bottom { normal }
-                    }
-                }
             }
 
             override val centered: Style<BasicParams> = {
-                position {
-                    fixed {
-                        top { "50%" }
-                    }
-                }
-                // FIXME: does not work! overrides size-settings!
-                css("transform: translateY(-50%);")
             }
+        }
+
+        override val internalScrolling: Style<BasicParams> = {
+            overflow { auto }
+            maxHeight { "calc(100vh - var(--modal-level) - 1rem)" }
         }
     }
 
@@ -1853,7 +1838,7 @@ open class DefaultTheme : Theme {
                         }
                     }
                 )
-                }
+            }
             override val top: Style<BasicParams> = {
                 position(
                     sm = { absolute { left { "0px" } } }
@@ -2314,7 +2299,6 @@ open class DefaultTheme : Theme {
         }
 
 
-
         override val horizontal = object : SliderCoreStyles {
             override val main: Style<FlexParams> = {
                 alignItems { center }
@@ -2349,7 +2333,7 @@ open class DefaultTheme : Theme {
                 radius { "9999px" }
                 position { relative { } }
                 background { color { primary.main } }
-                display { flex  }
+                display { flex }
                 justifyContent { flexEnd }
                 alignItems { center }
                 children("&[data-disabled]") {

--- a/styling/src/jsMain/kotlin/dev/fritz2/styling/theme/definitions.kt
+++ b/styling/src/jsMain/kotlin/dev/fritz2/styling/theme/definitions.kt
@@ -455,22 +455,35 @@ interface PushButtonVariants {
  * definition of the theme's modal
  */
 interface ModalStyles {
+    val base: Style<BasicParams>
     val overlay: Style<BasicParams>
+    val width: BasicParams.(String, Property) -> Unit
+    val widths: ModalWidths
     val sizes: ModalSizes
     val variants: ModalVariants
+    val internalScrolling: Style<BasicParams>
 }
 
+@Deprecated(message = "Use placement property of ModalComponent instead.")
 interface ModalVariants {
     val auto: Style<BasicParams>
     val verticalFilled: Style<BasicParams>
     val centered: Style<BasicParams>
 }
 
+@Deprecated(message = "Use width property of ModalComponent instead.")
 interface ModalSizes {
     val full: Style<BasicParams>
     val small: Style<BasicParams>
     val normal: Style<BasicParams>
     val large: Style<BasicParams>
+}
+
+interface ModalWidths {
+    val full: Property
+    val small: Property
+    val normal: Property
+    val large: Property
 }
 
 


### PR DESCRIPTION
This PR improves the following aspects of a modal:
- scrolling behaviour: Per default there are some settings to enable scrolling automatically without any client side effort.
- width settings (API change): new name ``width`` instead of ``size`` to make the intention of the property more expressive. The predefined values remains the same, but it is also possible now to provide a custom width value like ``30rem`` or alike. The old API calls will be applied and result in the same visual apperance for now.
- vertical placement (API change): This replaces the old ``variant`` property, which won't lead into an error, but the functionality is disabled. Instead use the ``placement`` property to align a modal vartically: ``top`` (default), ``center``, ``bottom`` and ``stretch`` are the possible values.

Example:
```kotlin
clickButton {
    text("Open")
} handledBy modal({
    minHeight { "30rem" }
}) {
    width { "800px" }
    placement { center }
    content {
        // some content
    }
}
```

The old API calls for ``size`` and ``variant`` don't break your code, but they will be removed in future versions. So please follow the mrigration guide to recplace them.

Be aware that also the interfaces ``ModalVariants`` and ``ModalSizes`` from the theme are deprecated and will disappear in future versions.

For a complete overview have a look at our [KitchenSink](https://components.fritz2.dev/#Modal).

### Migration advices:

``size`` to ``width``:
```kotlin
modal {
    // old:
    // size { small }

    // new
    width { small }
}
```

``variant`` to ``placement``:
- ``auto`` → ``top``
- ``verticalFilled`` → ``stretch``
- ``centered`` → ``center``


```kotlin
modal {
    // old:
    // variant { verticalFilled }

    // new
    placement { stretch }
}
```

Theming migration:
- Define new predefined values in ``ModalWidths`` with the values taken from ``ModalSizes``.
- ``ModalVariants`` just disappears. There is no more theme element that replaces this one. For probably adavanced settings applied here, integrate those into ``ModalStyles`` properties ``base``, ``width`` and ``internalScrolling``.

fixes #399 
fixes #400 