### PR TITLE
Use any element/component as a label in radio- and checkbox-groups

### DIFF
--- a/components/src/jsMain/kotlin/dev/fritz2/components/checkboxGroup.kt
+++ b/components/src/jsMain/kotlin/dev/fritz2/components/checkboxGroup.kt
@@ -2,6 +2,7 @@ package dev.fritz2.components
 
 import dev.fritz2.binding.Store
 import dev.fritz2.dom.EventContext
+import dev.fritz2.dom.html.Div
 import dev.fritz2.dom.html.RenderContext
 import dev.fritz2.dom.states
 import dev.fritz2.identification.uniqueId
@@ -96,6 +97,7 @@ open class CheckboxGroupComponent<T>(
 
     val icon = ComponentProperty<Icons.() -> IconDefinition> { Theme().icons.check }
     val label = ComponentProperty<(item: T) -> String> { it.toString() }
+    val labelRenderer = ComponentProperty<(RenderContext.(item: T) -> Unit)?>(value = null)
     val size = ComponentProperty<FormSizes.() -> Style<BasicParams>> { Theme().checkbox.sizes.normal }
 
     enum class Direction {
@@ -154,7 +156,12 @@ open class CheckboxGroupComponent<T>(
                         icon { this@CheckboxGroupComponent.icon.value(Theme().icons) }
                         labelStyle(this@CheckboxGroupComponent.labelStyle.value)
                         checkedStyle(this@CheckboxGroupComponent.checkedStyle.value)
-                        label(this@CheckboxGroupComponent.label.value(item))
+                        this@CheckboxGroupComponent.labelRenderer.value
+                            ?.let { renderer ->
+                                label { renderer(this, item) }
+                            } ?: run {
+                            label(this@CheckboxGroupComponent.label.value(item))
+                        }
                         checked(checkedFlow)
                         disabled(this@CheckboxGroupComponent.disabled.values)
                         severity(this@CheckboxGroupComponent.severity.values)

--- a/components/src/jsMain/kotlin/dev/fritz2/components/checkboxGroup.kt
+++ b/components/src/jsMain/kotlin/dev/fritz2/components/checkboxGroup.kt
@@ -2,7 +2,6 @@ package dev.fritz2.components
 
 import dev.fritz2.binding.Store
 import dev.fritz2.dom.EventContext
-import dev.fritz2.dom.html.Div
 import dev.fritz2.dom.html.RenderContext
 import dev.fritz2.dom.states
 import dev.fritz2.identification.uniqueId
@@ -71,6 +70,21 @@ import org.w3c.dom.HTMLElement
  *           background { color {"green"} }
  *      }
  * }
+ *
+ * // use custom layouts for the checkbox labels by specifying a label-renderer:
+ * val options = listOf("A", "B", "C")
+ * checkboxGroup(items = options) {
+ *      labelRendering { item ->
+ *          span({
+ *              fontFamily { mono }
+ *              background {
+ *                  color { primary.highlight }
+ *              }
+ *          }) {
+ *              +item
+ *          }
+*      }
+ * }
  * ```
  */
 open class CheckboxGroupComponent<T>(
@@ -97,7 +111,11 @@ open class CheckboxGroupComponent<T>(
 
     val icon = ComponentProperty<Icons.() -> IconDefinition> { Theme().icons.check }
     val label = ComponentProperty<(item: T) -> String> { it.toString() }
-    val labelRenderer = ComponentProperty<(RenderContext.(item: T) -> Unit)?>(value = null)
+    val labelRendering = ComponentProperty<RenderContext.(item: T) -> Unit> {
+        span {
+            +this@CheckboxGroupComponent.label.value(it)
+        }
+    }
     val size = ComponentProperty<FormSizes.() -> Style<BasicParams>> { Theme().checkbox.sizes.normal }
 
     enum class Direction {
@@ -156,12 +174,7 @@ open class CheckboxGroupComponent<T>(
                         icon { this@CheckboxGroupComponent.icon.value(Theme().icons) }
                         labelStyle(this@CheckboxGroupComponent.labelStyle.value)
                         checkedStyle(this@CheckboxGroupComponent.checkedStyle.value)
-                        this@CheckboxGroupComponent.labelRenderer.value
-                            ?.let { renderer ->
-                                label { renderer(this, item) }
-                            } ?: run {
-                            label(this@CheckboxGroupComponent.label.value(item))
-                        }
+                        label { this@CheckboxGroupComponent.labelRendering.value(this, item) }
                         checked(checkedFlow)
                         disabled(this@CheckboxGroupComponent.disabled.values)
                         severity(this@CheckboxGroupComponent.severity.values)

--- a/components/src/jsMain/kotlin/dev/fritz2/components/radioGroup.kt
+++ b/components/src/jsMain/kotlin/dev/fritz2/components/radioGroup.kt
@@ -66,6 +66,21 @@ import org.w3c.dom.HTMLElement
  *          background { color {"green"} }
  *     }
  * }
+ *
+ * // use custom layouts for the checkbox labels by specifying a label-renderer:
+ * val options = listOf("A", "B", "C")
+ * radioGroup(items = options) {
+ *      labelRendering { item ->
+ *          span({
+ *              fontFamily { mono }
+ *              background {
+ *                  color { primary.highlight }
+ *              }
+ *          }) {
+ *              +item
+ *          }
+ *      }
+ * }
  * ```
  */
 open class RadioGroupComponent<T>(protected val items: List<T>, protected val value: Store<T>? = null) :
@@ -89,7 +104,7 @@ open class RadioGroupComponent<T>(protected val items: List<T>, protected val va
     }
 
     val label = ComponentProperty<(item: T) -> String> { it.toString() }
-    val labelRenderer = ComponentProperty<(Div.(item: T) -> Unit)?>(value = null)
+    val labelRendering = ComponentProperty<Div.(item: T) -> Unit> { +this@RadioGroupComponent.label.value(it) }
     val size = ComponentProperty<FormSizes.() -> Style<BasicParams>> { Theme().radio.sizes.normal }
 
     enum class Direction {
@@ -146,12 +161,7 @@ open class RadioGroupComponent<T>(protected val items: List<T>, protected val va
                         this.size { this@RadioGroupComponent.size.value.invoke(Theme().radio.sizes) }
                         labelStyle(this@RadioGroupComponent.labelStyle.value)
                         selectedStyle(this@RadioGroupComponent.selectedStyle.value)
-                        this@RadioGroupComponent.labelRenderer.value
-                            ?.let { renderer ->
-                                label { renderer(this, item) }
-                            } ?: run {
-                                label(this@RadioGroupComponent.label.value(item))
-                            }
+                        label { this@RadioGroupComponent.labelRendering.value(this, item) }
                         selected(checkedFlow)
                         disabled(this@RadioGroupComponent.disabled.values)
                         severity(this@RadioGroupComponent.severity.values)

--- a/components/src/jsMain/kotlin/dev/fritz2/components/radioGroup.kt
+++ b/components/src/jsMain/kotlin/dev/fritz2/components/radioGroup.kt
@@ -2,6 +2,7 @@ package dev.fritz2.components
 
 import dev.fritz2.binding.Store
 import dev.fritz2.dom.EventContext
+import dev.fritz2.dom.html.Div
 import dev.fritz2.dom.html.RenderContext
 import dev.fritz2.dom.states
 import dev.fritz2.identification.uniqueId
@@ -88,6 +89,7 @@ open class RadioGroupComponent<T>(protected val items: List<T>, protected val va
     }
 
     val label = ComponentProperty<(item: T) -> String> { it.toString() }
+    val labelRenderer = ComponentProperty<(Div.(item: T) -> Unit)?>(value = null)
     val size = ComponentProperty<FormSizes.() -> Style<BasicParams>> { Theme().radio.sizes.normal }
 
     enum class Direction {
@@ -144,7 +146,12 @@ open class RadioGroupComponent<T>(protected val items: List<T>, protected val va
                         this.size { this@RadioGroupComponent.size.value.invoke(Theme().radio.sizes) }
                         labelStyle(this@RadioGroupComponent.labelStyle.value)
                         selectedStyle(this@RadioGroupComponent.selectedStyle.value)
-                        label(this@RadioGroupComponent.label.value(item))
+                        this@RadioGroupComponent.labelRenderer.value
+                            ?.let { renderer ->
+                                label { renderer(this, item) }
+                            } ?: run {
+                                label(this@RadioGroupComponent.label.value(item))
+                            }
                         selected(checkedFlow)
                         disabled(this@RadioGroupComponent.disabled.values)
                         severity(this@RadioGroupComponent.severity.values)


### PR DESCRIPTION
This PR adds the option to use any element or component for the label of the items in a radio- or checkbox-group.
Previously it was only possible to generate Strings from the underlying objects by using the `label` property:
```kotlin
val label = ComponentProperty<(item: T) -> String> { it.toString() }
```

Both components now feature a dedicated `labelRendering` property that can be used to override the default rendering process and specify custom layouts.  
The `labelRendering` property is a lambda that takes each underlying `item: T` and renders the respective label.  
By default the label is rendered based on the `label` property.

```kotlin
// RadioGroupComponent:
val labelRendering = ComponentProperty<Div.(item: T) -> Unit> { /* rendering based on 'label' by default */ }

// CheckboxGroupComponent:
val labelRendering = ComponentProperty<RenderContext.(item: T) -> Unit> { /* rendering based on 'label' by default */ }
```

Usage example:
```kotlin
checkboxGroup(values = /* ... */, items = /* ... */) {
    labelRendering { item ->
        span({
            // styling
        }) {
            +item
        }
    }
}
```

---

Solves #437