### PR TITLE
fixed slider styling with delegations

### DIFF
--- a/components/src/jsMain/kotlin/dev/fritz2/components/slider/component.kt
+++ b/components/src/jsMain/kotlin/dev/fritz2/components/slider/component.kt
@@ -17,10 +17,7 @@ import dev.fritz2.styling.name
 import dev.fritz2.styling.params.BasicParams
 import dev.fritz2.styling.params.BoxParams
 import dev.fritz2.styling.params.Style
-import dev.fritz2.styling.theme.FormSizes
-import dev.fritz2.styling.theme.IconDefinition
-import dev.fritz2.styling.theme.Icons
-import dev.fritz2.styling.theme.Theme
+import dev.fritz2.styling.theme.*
 import kotlinx.coroutines.flow.*
 import org.w3c.dom.DOMRect
 import org.w3c.dom.HTMLDivElement

--- a/styling/src/jsMain/kotlin/dev/fritz2/styling/theme/definitions.kt
+++ b/styling/src/jsMain/kotlin/dev/fritz2/styling/theme/definitions.kt
@@ -730,9 +730,9 @@ interface SliderStyles : SeverityAware {
     val sizes: FormSizes
     val horizontal: SliderCoreStyles
     val vertical: SliderCoreStyles
+}
 
-    fun core(orientation: String) = when (orientation) {
-        "HORIZONTAL" -> Theme().slider.horizontal
-        else -> Theme().slider.vertical
-    }
+fun SliderStyles.core(orientation: String) = when (orientation) {
+    "HORIZONTAL" -> horizontal
+    else -> vertical
 }

--- a/styling/src/jsMain/kotlin/dev/fritz2/styling/theme/definitions.kt
+++ b/styling/src/jsMain/kotlin/dev/fritz2/styling/theme/definitions.kt
@@ -732,7 +732,7 @@ interface SliderStyles : SeverityAware {
     val vertical: SliderCoreStyles
 
     fun core(orientation: String) = when (orientation) {
-        "HORIZONTAL" -> horizontal
-        else -> vertical
+        "HORIZONTAL" -> Theme().slider.horizontal
+        else -> Theme().slider.vertical
     }
 }


### PR DESCRIPTION
I tried to override the Slider Themes in a custom Theme using:

    private val _slider = super.slider
    override val slider: SliderStyles = object : SliderStyles by _slider {
        override val horizontal: SliderCoreStyles = object : SliderCoreStyles by _slider.horizontal {
           ...
        }
    }

But it did not work. I realized, that the problem is with the SliderStyles.core(...) in:
https://github.com/jwstegemann/fritz2/blob/71d13d7888de1914c537c4c93ec071c81ea90fb1/styling/src/jsMain/kotlin/dev/fritz2/styling/theme/definitions.kt#L734

The Problem is that when using delegations, we actually have two SliderStyles instances, the base instance, and the custom instance which uses delegations to extend the base instance. 
The SliderStyles.core(...) runs in the base implementation instead of the custom implementation and returns the wrong instance of the SliderCoreStyles.

Here is a minimal example of the problem https://pl.kotl.in/00foZksY1