### PR TITLE
Rename alert variant `discreet` to `ghost`

### DIFF
--- a/components/src/jsMain/kotlin/dev/fritz2/components/alert.kt
+++ b/components/src/jsMain/kotlin/dev/fritz2/components/alert.kt
@@ -31,8 +31,9 @@ import kotlinx.coroutines.flow.flowOf
  * - 'subtle': A subtle style using different shades of the severity's base color defined in the application theme.
  * - 'solid': A solid style using the severity's color from the application theme and a solid white color for the icon,
  * text and decorations.
- * - 'Top-Accent': A variation of the 'subtle' variant with a decoration element at the top.
- * - 'Left-Accent': A variation of the 'subtle' variant with a decoration element on the left.
+ * - 'leftAccent': A variation of the 'subtle' variant with a decoration element at the top.
+ * - 'topAccent': A variation of the 'subtle' variant with a decoration element on the left.
+ * - 'ghost': This variant does not have any decoration besides the icon (no background, similar to 'ghost' in push-buttons)
  * If no variant is specified, 'solid' is used by default.
  *
  * Usage examples:
@@ -73,7 +74,7 @@ open class AlertComponent : Component<Unit> {
     }
 
     enum class AlertVariant {
-        SOLID, SUBTLE, LEFT_ACCENT, TOP_ACCENT, DISCREET
+        SOLID, SUBTLE, LEFT_ACCENT, TOP_ACCENT, GHOST
     }
 
     object VariantContext {
@@ -81,7 +82,7 @@ open class AlertComponent : Component<Unit> {
         val subtle = AlertVariant.SUBTLE
         val leftAccent = AlertVariant.LEFT_ACCENT
         val topAccent = AlertVariant.TOP_ACCENT
-        val discreet = AlertVariant.DISCREET
+        val ghost = AlertVariant.GHOST
     }
 
     val icon = ComponentProperty<(Icons.() -> IconDefinition)?>(null)
@@ -146,7 +147,7 @@ open class AlertComponent : Component<Unit> {
                     AlertVariant.SUBTLE -> Theme().alert.variants.subtle
                     AlertVariant.LEFT_ACCENT -> Theme().alert.variants.leftAccent
                     AlertVariant.TOP_ACCENT -> Theme().alert.variants.topAccent
-                    AlertVariant.DISCREET -> Theme().alert.variants.discreet
+                    AlertVariant.GHOST -> Theme().alert.variants.ghost
                 }.invoke(this, this@AlertComponent.severity.value(Theme().alert.severities).colorScheme)
                 styling()
             }, alertCss) {

--- a/components/src/jsMain/kotlin/dev/fritz2/components/forms/control/component.kt
+++ b/components/src/jsMain/kotlin/dev/fritz2/components/forms/control/component.kt
@@ -232,7 +232,7 @@ open class FormControlComponent : Component<Unit>, FormProperties by FormMixin()
             message.asAlert(this) {
                 size(this@FormControlComponent.sizeBuilder)
                 stacking { compact }
-                variant { discreet }
+                variant { ghost }
             }
         }
 

--- a/styling/src/jsMain/kotlin/dev/fritz2/styling/theme/default.kt
+++ b/styling/src/jsMain/kotlin/dev/fritz2/styling/theme/default.kt
@@ -1527,7 +1527,7 @@ open class DefaultTheme : Theme {
                     }
                 }
             }
-            override val discreet: BasicParams.(ColorScheme) -> Unit = { _ ->
+            override val ghost: BasicParams.(ColorScheme) -> Unit = { _ ->
                 background { color { background } }
                 color { font }
             }

--- a/styling/src/jsMain/kotlin/dev/fritz2/styling/theme/definitions.kt
+++ b/styling/src/jsMain/kotlin/dev/fritz2/styling/theme/definitions.kt
@@ -644,7 +644,7 @@ interface AlertVariants {
     val solid: BasicParams.(ColorScheme) -> Unit
     val leftAccent: BasicParams.(ColorScheme) -> Unit
     val topAccent: BasicParams.(ColorScheme) -> Unit
-    val discreet: BasicParams.(ColorScheme) -> Unit
+    val ghost: BasicParams.(ColorScheme) -> Unit
 }
 
 


### PR DESCRIPTION
This PR renames the `discreet` alert-variant to `ghost` in order to match the common naming scheme of fritz2.

All references of `discreet` have to be changed:
```kotlin
alert {
    variant { discreet } // <-- previously
    variant { ghost } // <-- now
}
```

Closes #439 .