### PR TITLE
Add TypeAhead Component

### DIFF
--- a/components/src/jsMain/kotlin/dev/fritz2/components/forms/control/component.kt
+++ b/components/src/jsMain/kotlin/dev/fritz2/components/forms/control/component.kt
@@ -13,6 +13,8 @@ import dev.fritz2.components.selectField.SelectFieldComponent
 import dev.fritz2.components.slider.SliderComponent
 import dev.fritz2.components.switch.SwitchComponent
 import dev.fritz2.components.textarea.TextAreaComponent
+import dev.fritz2.components.typeAhead.Proposal
+import dev.fritz2.components.typeAhead.TypeAheadComponent
 import dev.fritz2.components.validation.ComponentValidationMessage
 import dev.fritz2.components.validation.Severity
 import dev.fritz2.components.validation.validationMessages
@@ -95,6 +97,7 @@ open class FormControlComponent : Component<Unit>, FormProperties by FormMixin()
             const val checkbox = "checkbox"
             const val checkboxGroup = "checkboxGroup"
             const val slider = "slider"
+            const val typeAhead = "typeAhead"
         }
     }
 
@@ -239,7 +242,8 @@ open class FormControlComponent : Component<Unit>, FormProperties by FormMixin()
             ControlNames.textArea,
             ControlNames.selectField,
             ControlNames.checkbox,
-            ControlNames.slider
+            ControlNames.slider,
+            ControlNames.typeAhead
         ).forEach { put(it, singleRenderer) }
         put(ControlNames.checkboxGroup, groupRenderer)
         put(ControlNames.radioGroup, groupRenderer)
@@ -353,6 +357,30 @@ open class FormControlComponent : Component<Unit>, FormProperties by FormMixin()
             ControlNames.inputField,
             {
                 inputField(styling, value, baseClass, id, prefix) {
+                    size { this@FormControlComponent.sizeBuilder(this) }
+                    severity(validationMessagesBuilder().hasSeverity)
+                    build()
+                }
+            },
+            { this.validationMessagesBuilder = validationMessagesBuilder }
+        )
+    }
+
+    open fun typeAhead(
+        styling: BasicParams.() -> Unit = {},
+        value: Store<String>? = null,
+        items: Proposal,
+        baseClass: StyleClass = StyleClass.None,
+        id: String? = value?.id,
+        prefix: String = ControlNames.typeAhead,
+        build: TypeAheadComponent.() -> Unit = {}
+    ) {
+        val validationMessagesBuilder = ValidationResult.builderOf(this, value)
+        registerControl(
+            id,
+            ControlNames.typeAhead,
+            {
+                typeAhead(styling, value, items, baseClass, id, prefix) {
                     size { this@FormControlComponent.sizeBuilder(this) }
                     severity(validationMessagesBuilder().hasSeverity)
                     build()

--- a/components/src/jsMain/kotlin/dev/fritz2/components/foundations/mixins.kt
+++ b/components/src/jsMain/kotlin/dev/fritz2/components/foundations/mixins.kt
@@ -10,10 +10,7 @@ import dev.fritz2.styling.StyleClass
 import dev.fritz2.styling.params.BasicParams
 import dev.fritz2.styling.params.Style
 import dev.fritz2.styling.style
-import dev.fritz2.styling.theme.IconDefinition
-import dev.fritz2.styling.theme.Icons
-import dev.fritz2.styling.theme.SeverityStyles
-import dev.fritz2.styling.theme.Theme
+import dev.fritz2.styling.theme.*
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.emptyFlow
 import kotlinx.coroutines.flow.flowOf
@@ -188,6 +185,41 @@ interface InputFormProperties : FormProperties {
  */
 class InputFormMixin : InputFormProperties, FormMixin() {
     override val readonly = DynamicComponentProperty(flowOf(false))
+}
+
+/**
+ * This interface offers a convenience property for inputField based components.
+ *
+ * Example usage:
+ * ```
+ * open class MyComponent : InputFieldProperties by InputFieldMixin() {
+ * }
+ *
+ * // use the property offered by the interface
+ * myControl {
+ *      variant { outline }
+ *      size { small }
+ *      placeholder("Password")
+ * }
+ * ```
+ */
+interface InputFieldProperties {
+    val variant: ComponentProperty<InputFieldVariants.() -> Style<BasicParams>>
+    val size: ComponentProperty<FormSizes.() -> Style<BasicParams>>
+    val placeholder: DynamicComponentProperty<String>
+}
+
+/**
+ * Default implementation of the [InputFieldProperties] interface in order to apply this as mixin for a component
+ */
+class InputFieldMixin : InputFieldProperties {
+    override val variant = ComponentProperty<InputFieldVariants.() -> Style<BasicParams>> {
+        Theme().input.variants.outline
+    }
+    override val size = ComponentProperty<FormSizes.() -> Style<BasicParams>> {
+        Theme().input.sizes.normal
+    }
+    override val placeholder = DynamicComponentProperty(flowOf(""))
 }
 
 /**

--- a/components/src/jsMain/kotlin/dev/fritz2/components/foundations/mixins.kt
+++ b/components/src/jsMain/kotlin/dev/fritz2/components/foundations/mixins.kt
@@ -205,7 +205,7 @@ class InputFormMixin : InputFormProperties, FormMixin() {
  */
 interface InputFieldProperties {
     val variant: ComponentProperty<InputFieldVariants.() -> Style<BasicParams>>
-    val size: ComponentProperty<FormSizes.() -> Style<BasicParams>>
+    val size: ComponentProperty<FormSizesStyles.() -> Style<BasicParams>>
     val placeholder: DynamicComponentProperty<String>
 }
 
@@ -216,7 +216,7 @@ class InputFieldMixin : InputFieldProperties {
     override val variant = ComponentProperty<InputFieldVariants.() -> Style<BasicParams>> {
         Theme().input.variants.outline
     }
-    override val size = ComponentProperty<FormSizes.() -> Style<BasicParams>> {
+    override val size = ComponentProperty<FormSizesStyles.() -> Style<BasicParams>> {
         Theme().input.sizes.normal
     }
     override val placeholder = DynamicComponentProperty(flowOf(""))

--- a/components/src/jsMain/kotlin/dev/fritz2/components/inputField/component.kt
+++ b/components/src/jsMain/kotlin/dev/fritz2/components/inputField/component.kt
@@ -10,10 +10,7 @@ import dev.fritz2.styling.input
 import dev.fritz2.styling.name
 import dev.fritz2.styling.params.BasicParams
 import dev.fritz2.styling.params.BoxParams
-import dev.fritz2.styling.params.Style
 import dev.fritz2.styling.staticStyle
-import dev.fritz2.styling.theme.FormSizesStyles
-import dev.fritz2.styling.theme.InputFieldVariants
 import dev.fritz2.styling.theme.Theme
 import kotlinx.coroutines.flow.flowOf
 import org.w3c.dom.HTMLInputElement
@@ -73,7 +70,8 @@ open class InputFieldComponent(protected val valueStore: Store<String>?) :
     EventProperties<HTMLInputElement> by EventMixin(),
     ElementProperties<Input> by ElementMixin(),
     InputFormProperties by InputFormMixin(),
-    SeverityProperties by SeverityMixin() {
+    SeverityProperties by SeverityMixin(),
+    InputFieldProperties by InputFieldMixin() {
 
     companion object {
         val staticCss = staticStyle(
@@ -94,11 +92,7 @@ open class InputFieldComponent(protected val valueStore: Store<String>?) :
         )
     }
 
-    val variant = ComponentProperty<InputFieldVariants.() -> Style<BasicParams>> { Theme().input.variants.outline }
-    val size = ComponentProperty<FormSizesStyles.() -> Style<BasicParams>> { Theme().input.sizes.normal }
-
     val value = DynamicComponentProperty(flowOf(""))
-    val placeholder = DynamicComponentProperty(flowOf(""))
     val type = DynamicComponentProperty(flowOf(""))
     val step = DynamicComponentProperty(flowOf(""))
 

--- a/components/src/jsMain/kotlin/dev/fritz2/components/typeAhead.kt
+++ b/components/src/jsMain/kotlin/dev/fritz2/components/typeAhead.kt
@@ -8,11 +8,24 @@ import dev.fritz2.styling.StyleClass
 import dev.fritz2.styling.params.BasicParams
 
 /**
+ * The [typeAhead] factory function creates a [TypeAheadComponent].
+ *
+ * It offers the possibility to input some [String] and get some list of proposals to choose from.
+ * Internally this is achieved by adding some datalist to the input field
+ * (https://developer.mozilla.org/en-US/docs/Web/HTML/Element/datalist).
+ *
+ * The typical (and minimal) usage might look like this:
+ * ```
+ * val proposals = listOf("Kotlin", "Scala", "Java", "OCaml", "Haskell").asProposals()
+ * val choice = storeOf("")
+ * typeAhead(value = choice, items = proposals) { }
+ * ```
  *
  * @see TypeAheadComponent
  *
  * @param styling a lambda expression for declaring the styling as fritz2's styling DSL
- * @param value optional [Store] that holds the data of the input
+ * @param value optional [Store] that holds the data of the result
+ * @param items
  * @param baseClass optional CSS class that should be applied to the element
  * @param id the ID of the element
  * @param prefix the prefix for the generated CSS class resulting in the form ``$prefix-$hash``

--- a/components/src/jsMain/kotlin/dev/fritz2/components/typeAhead.kt
+++ b/components/src/jsMain/kotlin/dev/fritz2/components/typeAhead.kt
@@ -11,8 +11,9 @@ import dev.fritz2.styling.params.BasicParams
  * The [typeAhead] factory function creates a [TypeAheadComponent].
  *
  * It offers the possibility to input some [String] and get some list of proposals to choose from.
- * Internally this is achieved by adding some datalist to the input field
- * (https://developer.mozilla.org/en-US/docs/Web/HTML/Element/datalist).
+ * Internally this is achieved by adding some
+ * [datalist](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/datalist)
+ * to the input field.
  *
  * The typical (and minimal) usage might look like this:
  * ```

--- a/components/src/jsMain/kotlin/dev/fritz2/components/typeAhead.kt
+++ b/components/src/jsMain/kotlin/dev/fritz2/components/typeAhead.kt
@@ -1,0 +1,29 @@
+package dev.fritz2.components
+
+import dev.fritz2.binding.Store
+import dev.fritz2.components.typeAhead.TypeAheadComponent
+import dev.fritz2.dom.html.RenderContext
+import dev.fritz2.styling.StyleClass
+import dev.fritz2.styling.params.BasicParams
+
+/**
+ *
+ * @see TypeAheadComponent
+ *
+ * @param styling a lambda expression for declaring the styling as fritz2's styling DSL
+ * @param value optional [Store] that holds the data of the input
+ * @param baseClass optional CSS class that should be applied to the element
+ * @param id the ID of the element
+ * @param prefix the prefix for the generated CSS class resulting in the form ``$prefix-$hash``
+ * @param build a lambda expression for setting up the component itself. Details in [TypeAheadComponent]
+ */
+fun RenderContext.typeAhead(
+    styling: BasicParams.() -> Unit = {},
+    value: Store<String>? = null,
+    baseClass: StyleClass = StyleClass.None,
+    id: String? = null,
+    prefix: String = "typeAhead",
+    build: TypeAheadComponent.() -> Unit = {}
+) {
+    TypeAheadComponent(value).apply(build).render(this, styling, baseClass, id, prefix)
+}

--- a/components/src/jsMain/kotlin/dev/fritz2/components/typeAhead.kt
+++ b/components/src/jsMain/kotlin/dev/fritz2/components/typeAhead.kt
@@ -1,6 +1,7 @@
 package dev.fritz2.components
 
 import dev.fritz2.binding.Store
+import dev.fritz2.components.typeAhead.Proposal
 import dev.fritz2.components.typeAhead.TypeAheadComponent
 import dev.fritz2.dom.html.RenderContext
 import dev.fritz2.styling.StyleClass
@@ -20,10 +21,11 @@ import dev.fritz2.styling.params.BasicParams
 fun RenderContext.typeAhead(
     styling: BasicParams.() -> Unit = {},
     value: Store<String>? = null,
+    items: Proposal,
     baseClass: StyleClass = StyleClass.None,
     id: String? = null,
     prefix: String = "typeAhead",
     build: TypeAheadComponent.() -> Unit = {}
 ) {
-    TypeAheadComponent(value).apply(build).render(this, styling, baseClass, id, prefix)
+    TypeAheadComponent(value, items).apply(build).render(this, styling, baseClass, id, prefix)
 }

--- a/components/src/jsMain/kotlin/dev/fritz2/components/typeAhead/component.kt
+++ b/components/src/jsMain/kotlin/dev/fritz2/components/typeAhead/component.kt
@@ -95,7 +95,7 @@ internal data class State(
  *
  * It also offers a function to [preselect] some item initially.
  */
-internal class StateStore(private val propose: Proposal, accepted: Accepted, limit: Int) :
+internal class StateStore(private val propose: Proposal, accepted: Accepted, limit: Int, draftThreshold: Int) :
     RootStore<State>(State()) {
     val draft = data.map { it.draft }
     val selected = data.map { it.selected }
@@ -121,7 +121,7 @@ internal class StateStore(private val propose: Proposal, accepted: Accepted, lim
     private var preselectEnabled = true
 
     val preselect = handle<String> { state, draft ->
-        if (preselectEnabled) {
+        if (preselectEnabled && draft.length >= draftThreshold) {
             preselectEnabled = false
             val proposals = propose(flowOf(draft)).first()
             State(draft, selected = accepted(proposals, draft), proposals = proposals)
@@ -241,7 +241,7 @@ open class TypeAheadComponent(protected val valueStore: Store<String>?, protecte
         prefix: String
     ) {
         val accepted = if (strict.value) acceptOnlyProposals else acceptDraft
-        val internalStore = StateStore(items, accepted, limit.value)
+        val internalStore = StateStore(items, accepted, limit.value, draftThreshold.value)
         val proposalsId = "proposals-{${uniqueId()}}"
 
         context.apply {

--- a/components/src/jsMain/kotlin/dev/fritz2/components/typeAhead/component.kt
+++ b/components/src/jsMain/kotlin/dev/fritz2/components/typeAhead/component.kt
@@ -1,0 +1,121 @@
+package dev.fritz2.components.typeAhead
+
+import dev.fritz2.binding.RootStore
+import dev.fritz2.binding.Store
+import dev.fritz2.binding.storeOf
+import dev.fritz2.components.*
+import dev.fritz2.dom.EventContext
+import dev.fritz2.dom.html.RenderContext
+import dev.fritz2.identification.uniqueId
+import dev.fritz2.styling.StyleClass
+import dev.fritz2.styling.params.BasicParams
+import dev.fritz2.styling.params.BoxParams
+import dev.fritz2.styling.params.Style
+import dev.fritz2.styling.theme.FormSizes
+import dev.fritz2.styling.theme.InputFieldVariants
+import dev.fritz2.styling.theme.Theme
+import kotlinx.coroutines.MainScope
+import kotlinx.coroutines.flow.*
+import org.w3c.dom.HTMLElement
+
+
+typealias Proposal = (String) -> Flow<List<String>>
+
+class DraftStore(private val propose: Proposal, timeout: Long) : RootStore<String>("") {
+    val proposals = data
+        .debounce(timeout)
+        .flatMapLatest { propose(it) }
+        .stateIn(MainScope(), SharingStarted.Lazily, emptyList())
+
+    fun acceptOnlyProposals(value: String) = if (isProposal(value)) value else ""
+    fun acceptDraft(value: String) = value
+
+    private fun isProposal(draft: String) = proposals.value.contains(draft)
+}
+
+/**
+ * This component class manages the configuration of a [formGroup] and does the rendering.
+ *
+ * For details of the usage see its factory function [formGroup].
+ *
+ * @see formGroup
+ */
+open class TypeAheadComponent(protected val valueStore: Store<String>?) :
+    Component<Unit>,
+    InputFormProperties by InputFormMixin(),
+    SeverityProperties by SeverityMixin() {
+
+    val value = DynamicComponentProperty(flowOf(""))
+    val propose = ComponentProperty<Proposal> { draft -> flowOf(listOf(draft)) }
+    val strict = ComponentProperty(true)
+    val debounce = ComponentProperty(250L)
+
+    // TODO: Check if there is a nicer way to expose those input specific properties!
+    val variant = ComponentProperty<InputFieldVariants.() -> Style<BasicParams>> { Theme().input.variants.outline }
+    val size = ComponentProperty<FormSizes.() -> Style<BasicParams>> { Theme().input.sizes.normal }
+    val placeholder = DynamicComponentProperty(flowOf(""))
+
+    class EventsContext<String>(private val element: RenderContext, val value: Flow<String>) :
+        EventContext<HTMLElement> by element
+
+    val events = ComponentProperty<EventsContext<String>.() -> Unit> {}
+
+    protected val result = storeOf("")
+
+    override fun render(
+        context: RenderContext,
+        styling: BoxParams.() -> Unit,
+        baseClass: StyleClass,
+        id: String?,
+        prefix: String
+    ) {
+        val draft = DraftStore(propose.value, debounce.value)
+        val proposalsId = "proposals-{${uniqueId()}}"
+        val resultPicker = if (strict.value) draft::acceptOnlyProposals else draft::acceptDraft
+
+        context.apply {
+            (this@TypeAheadComponent.valueStore?.data
+                ?: this@TypeAheadComponent.value.values) handledBy this@TypeAheadComponent.result.update
+            // TODO: How do take first draft from value flow too if store is null?
+            this@TypeAheadComponent.valueStore?.current?.let { draft.update(it) }
+
+            inputField(
+                {
+                    this as BoxParams
+                    styling(this)
+                },
+                value = draft, baseClass, id, prefix
+            ) {
+                variant { this@TypeAheadComponent.variant.value(Theme().input.variants) }
+                size { this@TypeAheadComponent.size.value(Theme().input.sizes) }
+                placeholder(this@TypeAheadComponent.placeholder.values)
+                element {
+                    attr("list", proposalsId)
+                    autocomplete("off") // needed for FF
+                }
+                events {
+                    inputs.events.map { domNode.value } handledBy draft.update
+                    // TODO: Extract this for better doccumenting!
+                    //  e.g. give examples with states!
+                    blurs.events.combine(this@TypeAheadComponent.result.data) { _, result -> result }.map {
+                        it.ifBlank { "" }
+                    } handledBy draft.update
+                    // must be called *after* blurs!!! -> changing draft after valid result shall not clean draft!
+                    inputs.events.map { resultPicker(domNode.value) } handledBy this@TypeAheadComponent.result.update
+                }
+            }
+            datalist(id = proposalsId) {
+                draft.proposals.renderEach {
+                    option {
+                        attr("value", it)
+                    }
+                }
+            }
+
+            EventsContext(this, this@TypeAheadComponent.result.data).apply {
+                this@TypeAheadComponent.events.value(this)
+                this@TypeAheadComponent.valueStore?.let { value handledBy it.update }
+            }
+        }
+    }
+}

--- a/components/src/jsMain/kotlin/dev/fritz2/components/typeAhead/component.kt
+++ b/components/src/jsMain/kotlin/dev/fritz2/components/typeAhead/component.kt
@@ -17,30 +17,119 @@ import kotlinx.coroutines.flow.*
 import org.w3c.dom.HTMLElement
 
 
-internal typealias Proposal = (String) -> Flow<List<String>>
+/**
+ * This type alias defines the type of the proposal function of a [TypeAheadComponent]
+ *
+ * The typical pattern of writing such a function is to start with the implicit `it` and use common [Flow] operators
+ * on it (pun intended):
+ * ```
+ * // just map the draft to a list:
+ * val proposal: Proposal = {
+ *     it.map { draft -> /* ... some API call or alike */ }
+ * }
+ *
+ * // combine the draft with some other Flow (controlled by some other component)
+ * val languages = storeOf(listOf("Kotlin", "Scala", "Java", "OCaml", "Haskell"))
+ * val proposal: Proposal = {
+ *     it.combine(languages.data) { draft, languages -> /* check if draft is contained or alike */ }
+ * }
+ *
+ * ```
+ */
+typealias Proposal = suspend (Flow<String>) -> Flow<List<String>>
+
+/**
+ * This extension function offers a short, convenience method to use a static [List] as [Proposal].
+ *
+ * As default behaviour it checks, whether the current draft is contained in any item of the list ignoring case
+ * sensitivity:
+ * ```
+ * val languages = listOf("Kotlin", "Scala", "Java", "OCaml", "Haskell")
+ * val proposal = languages.asProposal() // called with draft = "ca" -> ["Scala", "OCaml"]
+ *                                       //                                ^^       ^^
+ * ```
+ *
+ * A predicate factory for the filter function can be passed as optional parameter:
+ * ```
+ * // just take only items from the list, that starts with draft:
+ * languages.asProposal { draft -> { item -> item.startsWith(draft) } }
+ *
+ * @param predicate a factory for a predicate function applied to the internal filter; the current draft is the
+ *                  outer parameter, the inner one is the current element of the list.
+ * ```
+ */
+fun List<String>.asProposal(
+    predicate: (String) -> (String) -> Boolean = { draft ->
+        { item ->
+            item.contains(
+                draft,
+                ignoreCase = true
+            )
+        }
+    }
+): Proposal = {
+    it.map { draft -> this.filter(predicate(draft)) }
+}
+
+/**
+ * Some internal abbreviation for the transformation of the current draft to an exposed result.
+ * This is used for the two options offered by [TypeAheadComponent.strict]:
+ * - `true` -> only return a value, if draft matches exactly one item of [TypeAheadComponent.items]
+ * - `false` -> just return the draft as it is
+ *
+ * @see StateStore
+ * @see TypeAheadComponent
+ */
 internal typealias Accepted = (List<String>, String) -> String
 
+/**
+ * The fitting state type for the internal state handling of the [TypeAheadComponent] used by [StateStore].
+ */
 internal data class State(
     val draft: String = "",
     val selected: String = "",
     val proposals: List<String> = emptyList()
 )
 
+/**
+ * The store for managing the state of [TypeAheadComponent].
+ *
+ * It offers specific data [Flow]s for the current [draft], the [selected] item and the current valid [proposals]
+ * excluding the current draft if it would be part of.
+ *
+ * It also offers a function to [preselect] some item initially.
+ */
 internal class StateStore(private val propose: Proposal, accepted: Accepted) : RootStore<State>(State()) {
     val draft = data.map { it.draft }
     val selected = data.map { it.selected }
     val proposals = data.map { it.proposals.filter { proposal -> proposal != it.draft } }
 
+    /**
+     * This flag is used to enable the preselection possibility just for exactly one time at first rendering of
+     * the [TypeAheadComponent]. This is important to break the circuit between external store and current draft!
+     * Without this safety belt, the draft would be deleted completely immediately after dropping the last char
+     * of the draft for example:
+     * ```
+     * // during some later point in time:
+     * (1) draft: Germany -> selected: Germany -> external Store: Germany
+     * (2) user presses `Backspace`
+     * (3) draft: German -> selected: <empty> -> external Store: <empty> -{preselect}-> draft: <empty>
+     * //         ^^^^^^                                                 ^^^^^^^^^^^^^^
+     * //         we want to keep this!                                  this must be prohibited!
+     * //
+     * // with unsecured preselect <empty> would be passed as draft by the external store to the internal state store!
+     * ```
+     * Have a look at [TypeAheadComponent.render] to see how [preselect] is getting called!
+     */
     private var preselectEnabled = true
 
     val preselect = handle<String> { state, draft ->
         if (preselectEnabled) {
             preselectEnabled = false
-            val proposals = propose(draft).first()
+            val proposals = propose(flowOf(draft)).first()
             State(draft, selected = accepted(proposals, draft), proposals = proposals)
         } else state
     }
-
 }
 
 /**
@@ -50,13 +139,12 @@ internal class StateStore(private val propose: Proposal, accepted: Accepted) : R
  *
  * @see formGroup
  */
-open class TypeAheadComponent(protected val valueStore: Store<String>?) :
+open class TypeAheadComponent(protected val valueStore: Store<String>?, protected val items: Proposal) :
     Component<Unit>,
     InputFormProperties by InputFormMixin(),
     SeverityProperties by SeverityMixin() {
 
     val value = DynamicComponentProperty(flowOf(""))
-    val propose = ComponentProperty<Proposal> { draft -> flowOf(listOf(draft)) }
     val strict = ComponentProperty(true)
     val debounce = ComponentProperty(250L)
 
@@ -70,11 +158,13 @@ open class TypeAheadComponent(protected val valueStore: Store<String>?) :
 
     val events = ComponentProperty<EventsContext<String>.() -> Unit> {}
 
-    private fun acceptOnlyProposals(proposals: List<String>, value: String) =
+    private val acceptOnlyProposals: Accepted = { proposals, value ->
         if (proposals.contains(value)) value else ""
+    }
 
-    // TODO: Howto drop warning "unused param" here? (Signature *must* remain imho!)
-    private fun acceptDraft(proposals: List<String>, value: String) = value
+    private val acceptDraft: Accepted = { _, value -> value }
+
+    private val draft: MutableStateFlow<String> = MutableStateFlow("")
 
     override fun render(
         context: RenderContext,
@@ -83,8 +173,8 @@ open class TypeAheadComponent(protected val valueStore: Store<String>?) :
         id: String?,
         prefix: String
     ) {
-        val accepted = if (strict.value) ::acceptOnlyProposals else ::acceptDraft
-        val internalStore = StateStore(propose.value, accepted)
+        val accepted = if (strict.value) acceptOnlyProposals else acceptDraft
+        val internalStore = StateStore(items, accepted)
         val proposalsId = "proposals-{${uniqueId()}}"
 
         context.apply {
@@ -108,7 +198,8 @@ open class TypeAheadComponent(protected val valueStore: Store<String>?) :
                 value(internalStore.draft)
                 events {
                     inputs.events.debounce(this@TypeAheadComponent.debounce.value)
-                        .flatMapLatest { this@TypeAheadComponent.propose.value(domNode.value) }
+                        .onEach { this@TypeAheadComponent.draft.value = domNode.value }
+                        .flatMapLatest { this@TypeAheadComponent.items(this@TypeAheadComponent.draft) }
                         .map { proposals ->
                             with(domNode.value) {
                                 State(this, accepted(proposals, this), proposals)

--- a/components/src/jsMain/kotlin/dev/fritz2/components/typeAhead/component.kt
+++ b/components/src/jsMain/kotlin/dev/fritz2/components/typeAhead/component.kt
@@ -3,6 +3,7 @@ package dev.fritz2.components.typeAhead
 import dev.fritz2.binding.RootStore
 import dev.fritz2.binding.Store
 import dev.fritz2.components.*
+import dev.fritz2.components.foundations.*
 import dev.fritz2.dom.EventContext
 import dev.fritz2.dom.html.RenderContext
 import dev.fritz2.identification.uniqueId

--- a/core/src/jsMain/kotlin/dev/fritz2/binding/store.kt
+++ b/core/src/jsMain/kotlin/dev/fritz2/binding/store.kt
@@ -1,5 +1,6 @@
 package dev.fritz2.binding
 
+import dev.fritz2.identification.RootInspector
 import dev.fritz2.lenses.Lens
 import dev.fritz2.lenses.Lenses
 import dev.fritz2.remote.Socket
@@ -256,3 +257,5 @@ open class RootStore<T>(
  * @param id the id of this store. ids of [SubStore]s will be concatenated.
  */
 fun <T> storeOf(initialData: T, id: String = "") = RootStore(initialData, id)
+
+fun <T> Store<T>.inspect(data: T) = RootInspector(data, id)


### PR DESCRIPTION
Adds a TypeAhead component to fritz2's component portfolio.

A TypeAhead offers the possibility to input some string and get some list of proposals to choose from. This is reasonable for large static lists, that can't be managed by SelectFields or RadioGroups or where the proposals rely on a remote resource.

Example usage:
```kotlin
 val proposals = listOf("Kotlin", "Scala", "Java", "OCaml", "Haskell").asProposals()
 val choice = storeOf("")
 typeAhead(value = choice, items = proposals) { }
```

For further details have a look at our [KitchenSink](https://components.fritz2.dev/#TypeAhead)

fixes #373