### PR TITLE
Fix close-button margin in `ToastComponent`

### DIFF
--- a/components/src/jsMain/kotlin/dev/fritz2/components/toast.kt
+++ b/components/src/jsMain/kotlin/dev/fritz2/components/toast.kt
@@ -258,6 +258,7 @@ open class ToastComponent : ManagedComponent<Unit>,
                 alignItems { center }
             }, baseClass, id, prefix) {
                 div({
+                    Theme().toast.base()
                     toastStyle()
                     background { color(this@ToastComponent.background.value) }
                     alignItems { center }

--- a/styling/src/jsMain/kotlin/dev/fritz2/styling/theme/default.kt
+++ b/styling/src/jsMain/kotlin/dev/fritz2/styling/theme/default.kt
@@ -1570,6 +1570,9 @@ open class DefaultTheme : Theme {
     }
 
     override val toast = object : ToastStyles {
+        override val base: Style<BasicParams> = {
+            minHeight { "40px" }
+        }
         override val placement = object : ToastPlacement {
             override val top: Style<BasicParams> = {
                 css("top:0px")
@@ -1581,7 +1584,6 @@ open class DefaultTheme : Theme {
                 css("top:0px")
             }
             override val topRight: Style<BasicParams> = {
-
                 css("top:0px")
                 css("right:0px")
             }
@@ -1589,16 +1591,12 @@ open class DefaultTheme : Theme {
                 css("bottom:0px")
                 css("right:0px")
                 css("left:0px")
-
-
             }
             override val bottomLeft: Style<BasicParams> = {
-
                 css("bottom:0px")
                 css("left:0px")
             }
             override val bottomRight: Style<BasicParams> = {
-
                 css("bottom:0px")
                 css("right:0px")
             }

--- a/styling/src/jsMain/kotlin/dev/fritz2/styling/theme/default.kt
+++ b/styling/src/jsMain/kotlin/dev/fritz2/styling/theme/default.kt
@@ -1627,7 +1627,8 @@ open class DefaultTheme : Theme {
             override val close: Style<BasicParams> = {
                 position {
                     absolute {
-                        right { small }
+                        top { smaller }
+                        right { smaller }
                     }
                 }
 

--- a/styling/src/jsMain/kotlin/dev/fritz2/styling/theme/default.kt
+++ b/styling/src/jsMain/kotlin/dev/fritz2/styling/theme/default.kt
@@ -1625,17 +1625,16 @@ open class DefaultTheme : Theme {
         }
         override val closeButton = object : ToastButton {
             override val close: Style<BasicParams> = {
-                radius { "0.375rem" }
-                width { "24px" }
-                height { "1rem" }
+                position {
+                    absolute {
+                        right { small }
+                    }
+                }
+
                 fontSize { "10px" }
                 css("outline: 0px;")
-                flex { shrink { "0" } }
-                display { flex }
-                css("align-items: center;")
-                css("justify-content: center;")
                 css("transition: all 0.2s ease 0s;")
-                paddings { left { "1rem" } }
+
                 focus {
                     css("outline: none;")
                     boxShadow { none }

--- a/styling/src/jsMain/kotlin/dev/fritz2/styling/theme/default.kt
+++ b/styling/src/jsMain/kotlin/dev/fritz2/styling/theme/default.kt
@@ -1571,7 +1571,7 @@ open class DefaultTheme : Theme {
 
     override val toast = object : ToastStyles {
         override val base: Style<BasicParams> = {
-            minHeight { "40px" }
+            minHeight { giant }
         }
         override val placement = object : ToastPlacement {
             override val top: Style<BasicParams> = {

--- a/styling/src/jsMain/kotlin/dev/fritz2/styling/theme/definitions.kt
+++ b/styling/src/jsMain/kotlin/dev/fritz2/styling/theme/definitions.kt
@@ -652,6 +652,7 @@ interface AlertVariants {
  * definition of the theme's toasts
  */
 interface ToastStyles {
+    val base: Style<BasicParams>
     val placement: ToastPlacement
     val status: ToastStatus
     val closeButton: ToastButton


### PR DESCRIPTION
`ToastComponent`s close-button is now rendered above the underlying content and uses correct margins.

Closes #465 .