### PR TITLE
Add convenience functions to create toasts with alert-content

### DIFF
--- a/components/src/jsMain/kotlin/dev/fritz2/components/alert.kt
+++ b/components/src/jsMain/kotlin/dev/fritz2/components/alert.kt
@@ -73,21 +73,21 @@ open class AlertComponent : Component<Unit> {
         }
     }
 
-    enum class AlertVariant {
+    enum class Variant {
         SOLID, SUBTLE, LEFT_ACCENT, TOP_ACCENT, GHOST
     }
 
     object VariantContext {
-        val solid = AlertVariant.SOLID
-        val subtle = AlertVariant.SUBTLE
-        val leftAccent = AlertVariant.LEFT_ACCENT
-        val topAccent = AlertVariant.TOP_ACCENT
-        val ghost = AlertVariant.GHOST
+        val solid = Variant.SOLID
+        val subtle = Variant.SUBTLE
+        val leftAccent = Variant.LEFT_ACCENT
+        val topAccent = Variant.TOP_ACCENT
+        val ghost = Variant.GHOST
     }
 
     val icon = ComponentProperty<(Icons.() -> IconDefinition)?>(null)
     val severity = ComponentProperty<(AlertSeverities.() -> AlertSeverity)> { info }
-    val variant = ComponentProperty<VariantContext.() -> AlertVariant> { solid }
+    val variant = ComponentProperty<VariantContext.() -> Variant> { solid }
     val size = ComponentProperty<FormSizes.() -> Style<BasicParams>> { normal }
     val stacking = ComponentProperty<AlertStacking.() -> Style<BasicParams>> { separated }
 
@@ -143,11 +143,11 @@ open class AlertComponent : Component<Unit> {
                 this@AlertComponent.size.value(Theme().alert.sizes)()
                 this@AlertComponent.stacking.value(Theme().alert.stacking)()
                 when (this@AlertComponent.variant.value(VariantContext)) {
-                    AlertVariant.SOLID -> Theme().alert.variants.solid
-                    AlertVariant.SUBTLE -> Theme().alert.variants.subtle
-                    AlertVariant.LEFT_ACCENT -> Theme().alert.variants.leftAccent
-                    AlertVariant.TOP_ACCENT -> Theme().alert.variants.topAccent
-                    AlertVariant.GHOST -> Theme().alert.variants.ghost
+                    Variant.SOLID -> Theme().alert.variants.solid
+                    Variant.SUBTLE -> Theme().alert.variants.subtle
+                    Variant.LEFT_ACCENT -> Theme().alert.variants.leftAccent
+                    Variant.TOP_ACCENT -> Theme().alert.variants.topAccent
+                    Variant.GHOST -> Theme().alert.variants.ghost
                 }.invoke(this, this@AlertComponent.severity.value(Theme().alert.severities).colorScheme)
                 styling()
             }, alertCss) {

--- a/components/src/jsMain/kotlin/dev/fritz2/components/alert.kt
+++ b/components/src/jsMain/kotlin/dev/fritz2/components/alert.kt
@@ -31,8 +31,9 @@ import kotlinx.coroutines.flow.flowOf
  * - 'subtle': A subtle style using different shades of the severity's base color defined in the application theme.
  * - 'solid': A solid style using the severity's color from the application theme and a solid white color for the icon,
  * text and decorations.
- * - 'Top-Accent': A variation of the 'subtle' variant with a decoration element at the top.
- * - 'Left-Accent': A variation of the 'subtle' variant with a decoration element on the left.
+ * - 'leftAccent': A variation of the 'subtle' variant with a decoration element at the top.
+ * - 'topAccent': A variation of the 'subtle' variant with a decoration element on the left.
+ * - 'ghost': This variant does not have any decoration besides the icon (no background, similar to 'ghost' in push-buttons)
  * If no variant is specified, 'solid' is used by default.
  *
  * Usage examples:
@@ -73,7 +74,7 @@ open class AlertComponent : Component<Unit> {
     }
 
     enum class AlertVariant {
-        SOLID, SUBTLE, LEFT_ACCENT, TOP_ACCENT, DISCREET
+        SOLID, SUBTLE, LEFT_ACCENT, TOP_ACCENT, GHOST
     }
 
     object VariantContext {
@@ -81,7 +82,7 @@ open class AlertComponent : Component<Unit> {
         val subtle = AlertVariant.SUBTLE
         val leftAccent = AlertVariant.LEFT_ACCENT
         val topAccent = AlertVariant.TOP_ACCENT
-        val discreet = AlertVariant.DISCREET
+        val ghost = AlertVariant.GHOST
     }
 
     val icon = ComponentProperty<(Icons.() -> IconDefinition)?>(null)
@@ -146,7 +147,7 @@ open class AlertComponent : Component<Unit> {
                     AlertVariant.SUBTLE -> Theme().alert.variants.subtle
                     AlertVariant.LEFT_ACCENT -> Theme().alert.variants.leftAccent
                     AlertVariant.TOP_ACCENT -> Theme().alert.variants.topAccent
-                    AlertVariant.DISCREET -> Theme().alert.variants.discreet
+                    AlertVariant.GHOST -> Theme().alert.variants.ghost
                 }.invoke(this, this@AlertComponent.severity.value(Theme().alert.severities).colorScheme)
                 styling()
             }, alertCss) {

--- a/components/src/jsMain/kotlin/dev/fritz2/components/forms/control/component.kt
+++ b/components/src/jsMain/kotlin/dev/fritz2/components/forms/control/component.kt
@@ -232,7 +232,7 @@ open class FormControlComponent : Component<Unit>, FormProperties by FormMixin()
             message.asAlert(this) {
                 size(this@FormControlComponent.sizeBuilder)
                 stacking { compact }
-                variant { discreet }
+                variant { ghost }
             }
         }
 

--- a/components/src/jsMain/kotlin/dev/fritz2/components/toast.kt
+++ b/components/src/jsMain/kotlin/dev/fritz2/components/toast.kt
@@ -54,6 +54,22 @@ abstract class ToastComponentBase : ManagedComponent<Unit>,
 
         fun appearsFromBottom(toasts: List<ToastFragment>): Boolean = toasts.isNotEmpty()
                 && setOf(bottom, bottomRight, bottomLeft).contains(toasts.first().placement)
+
+        /**
+         * Extracts the horizontal alignment of the toast out of the general placement.
+         * This can be useful for aligning the messages according to their horizontal placement.
+         *
+         * @param placement placement string of a toast
+         */
+        fun alignmentOf(placement: String) = when (placement) {
+            bottom -> "center"
+            top -> "center"
+            bottomLeft -> "left"
+            topLeft -> "left"
+            bottomRight -> "right"
+            topRight -> "right"
+            else -> "center"
+        }
     }
 
     object ToastStore : RootStore<List<ToastFragment>>(listOf(), id = "toast-store") {
@@ -230,7 +246,10 @@ abstract class ToastComponentBase : ManagedComponent<Unit>,
         ) {
             li({
                 listStyle()
-                alignItems { center }
+                Theme().toast.alignment(
+                    this,
+                    Placement.alignmentOf(this@ToastComponentBase.placement.value(Placement))
+                )
             }, baseClass, id, prefix) {
                 div({
                     Theme().toast.base()
@@ -241,7 +260,9 @@ abstract class ToastComponentBase : ManagedComponent<Unit>,
                 }) {
                     this@ToastComponentBase.renderContent(this, styling, baseClass, id, prefix)
                     if (this@ToastComponentBase.hasCloseButton.value) {
-                        this@ToastComponentBase.closeButtonRendering.value(this).map { localId } handledBy ToastStore.remove
+                        this@ToastComponentBase.closeButtonRendering.value(this).map {
+                            localId
+                        } handledBy ToastStore.remove
                     }
                 }
             }
@@ -354,7 +375,7 @@ open class AlertToastComponent : ToastComponentBase() {
             this@AlertToastComponent.closeButtonStyle(Theme().toast.closeButton.close + {
                 color {
                     val colorScheme = alertComponent.severity.value(Theme().alert.severities).colorScheme
-                    when(alertComponent.variant.value(AlertComponent.VariantContext)) {
+                    when (alertComponent.variant.value(AlertComponent.VariantContext)) {
                         AlertComponent.Variant.SUBTLE -> colorScheme.main
                         AlertComponent.Variant.TOP_ACCENT -> colorScheme.main
                         AlertComponent.Variant.LEFT_ACCENT -> colorScheme.main
@@ -449,7 +470,7 @@ fun toast(
 }
 
 /**
- * This factory method creates a toast with an alert as it's content and displays it _right away_.
+ * This factory method creates a toast with an alert as its content and displays it _right away_.
  * Use [alertToast] in order to display a toast delayed, e.g. when a button is pressed.
  *
  * Usage example:
@@ -526,6 +547,6 @@ fun alertToast(
 }
 
 
-private fun asHandler(action: () -> Unit): SimpleHandler<Unit> = object : RootStore<Unit>(Unit) {
+internal fun asHandler(action: () -> Unit): SimpleHandler<Unit> = object : RootStore<Unit>(Unit) {
     val handler = handle { action() }
 }.handler

--- a/components/src/jsMain/kotlin/dev/fritz2/components/toast.kt
+++ b/components/src/jsMain/kotlin/dev/fritz2/components/toast.kt
@@ -363,6 +363,8 @@ fun toast(
  * The build-lambda of this method configures the _alert_, not the _toast_. Use the [buildToast] parameter to configure
  * properties of the underlying [ToastComponent].
  *
+ * Please note: All parameters (styling, id, prefix, etc.) are applied to the alert, not the toast.
+ *
  * Usage example:
  * ```
  * showAlertToast({
@@ -389,7 +391,7 @@ fun showAlertToast(
     buildToast: ToastComponent.() -> Unit = {},
     baseClass: StyleClass = StyleClass.None,
     id: String? = null,
-    prefix: String = ToastComponent.defaultToastContainerPrefix,
+    prefix: String = "toast-alert",
     build: AlertComponent.() -> Unit
 ) {
     val alertComponent = AlertComponent()
@@ -422,6 +424,8 @@ fun showAlertToast(
  * triggered, eg. on a button press (similar to [toast]). The same configuration options as in [showAlertToast] are
  * provided.
  *
+ * Please note: All parameters (styling, id, prefix, etc.) are applied to the alert, not the toast.
+ *
  * Usage example:
  * ```
  * clickButton {
@@ -450,7 +454,7 @@ fun alertToast(
     buildToast: ToastComponent.() -> Unit = {},
     baseClass: StyleClass = StyleClass.None,
     id: String? = null,
-    prefix: String = ToastComponent.defaultToastContainerPrefix,
+    prefix: String = "toast-alert",
     build: AlertComponent.() -> Unit
 ): SimpleHandler<Unit> = asHandler {
     showAlertToast(styling, buildToast, baseClass, id, prefix, build)

--- a/components/src/jsMain/kotlin/dev/fritz2/components/toast.kt
+++ b/components/src/jsMain/kotlin/dev/fritz2/components/toast.kt
@@ -352,7 +352,7 @@ fun toast(
     id: String? = null,
     prefix: String = ToastComponent.defaultToastContainerPrefix,
     build: ToastComponent.() -> Unit
-): SimpleHandler<Unit> = launchViaHandler {
+): SimpleHandler<Unit> = asHandler {
     showToast(styling, baseClass, id, prefix, build)
 }
 
@@ -392,7 +392,6 @@ fun showAlertToast(
     prefix: String = ToastComponent.defaultToastContainerPrefix,
     build: AlertComponent.() -> Unit
 ) {
-
     val alertComponent = AlertComponent()
         .apply(build)
         .apply {
@@ -453,14 +452,11 @@ fun alertToast(
     id: String? = null,
     prefix: String = ToastComponent.defaultToastContainerPrefix,
     build: AlertComponent.() -> Unit
-): SimpleHandler<Unit> = launchViaHandler {
+): SimpleHandler<Unit> = asHandler {
     showAlertToast(styling, buildToast, baseClass, id, prefix, build)
 }
 
 
-private fun launchViaHandler(action: () -> Unit): SimpleHandler<Unit> {
-    val pendingStore = object : RootStore<Unit>(Unit) {
-        val run = handle { action() }
-    }
-    return pendingStore.run
-}
+private fun asHandler(action: () -> Unit): SimpleHandler<Unit> = object : RootStore<Unit>(Unit) {
+    val handler = handle { action() }
+}.handler

--- a/styling/src/jsMain/kotlin/dev/fritz2/styling/theme/default.kt
+++ b/styling/src/jsMain/kotlin/dev/fritz2/styling/theme/default.kt
@@ -1566,6 +1566,14 @@ open class DefaultTheme : Theme {
                 margin { normal }
                 padding { normal }
             }
+            override val toast: Style<BasicParams> = {
+                margin { none }
+                paddings {
+                    vertical { normal }
+                    left { normal }
+                    right { huge } // needed to not be overlapped by the close-button
+                }
+            }
         }
     }
 

--- a/styling/src/jsMain/kotlin/dev/fritz2/styling/theme/default.kt
+++ b/styling/src/jsMain/kotlin/dev/fritz2/styling/theme/default.kt
@@ -1641,6 +1641,7 @@ open class DefaultTheme : Theme {
                 fontSize { "10px" }
                 css("outline: 0px;")
                 css("transition: all 0.2s ease 0s;")
+                color { info.mainContrast }
 
                 focus {
                     css("outline: none;")

--- a/styling/src/jsMain/kotlin/dev/fritz2/styling/theme/default.kt
+++ b/styling/src/jsMain/kotlin/dev/fritz2/styling/theme/default.kt
@@ -1527,7 +1527,7 @@ open class DefaultTheme : Theme {
                     }
                 }
             }
-            override val discreet: BasicParams.(ColorScheme) -> Unit = { _ ->
+            override val ghost: BasicParams.(ColorScheme) -> Unit = { _ ->
                 background { color { background } }
                 color { font }
             }

--- a/styling/src/jsMain/kotlin/dev/fritz2/styling/theme/default.kt
+++ b/styling/src/jsMain/kotlin/dev/fritz2/styling/theme/default.kt
@@ -991,7 +991,7 @@ open class DefaultTheme : Theme {
 
         override val width: BasicParams.(String, Property) -> Unit = { key, value ->
             maxWidth { value }
-            if(key.lowercase() != "full") {
+            if (key.lowercase() != "full") {
                 margins {
                     top { "var(--modal-level)" }
                     left { "var(--modal-level)" }
@@ -1608,8 +1608,18 @@ open class DefaultTheme : Theme {
                 css("bottom:0px")
                 css("right:0px")
             }
-
         }
+
+        override val alignment: BoxParams.(String) -> Unit = { horizontal ->
+            alignItems {
+                when (horizontal) {
+                    "left" -> flexStart
+                    "right" -> flexEnd
+                    else -> center
+                }
+            }
+        }
+
         override val status = object : ToastStatus {
             override val success: Style<BasicParams> = {
                 background { color { success.main } }

--- a/styling/src/jsMain/kotlin/dev/fritz2/styling/theme/definitions.kt
+++ b/styling/src/jsMain/kotlin/dev/fritz2/styling/theme/definitions.kt
@@ -625,6 +625,7 @@ interface AlertStyles {
 interface AlertStacking {
     val compact: Style<BasicParams>
     val separated: Style<BasicParams>
+    val toast: Style<BasicParams>
 }
 
 interface AlertSeverity {

--- a/styling/src/jsMain/kotlin/dev/fritz2/styling/theme/definitions.kt
+++ b/styling/src/jsMain/kotlin/dev/fritz2/styling/theme/definitions.kt
@@ -644,7 +644,7 @@ interface AlertVariants {
     val solid: BasicParams.(ColorScheme) -> Unit
     val leftAccent: BasicParams.(ColorScheme) -> Unit
     val topAccent: BasicParams.(ColorScheme) -> Unit
-    val discreet: BasicParams.(ColorScheme) -> Unit
+    val ghost: BasicParams.(ColorScheme) -> Unit
 }
 
 

--- a/styling/src/jsMain/kotlin/dev/fritz2/styling/theme/definitions.kt
+++ b/styling/src/jsMain/kotlin/dev/fritz2/styling/theme/definitions.kt
@@ -655,6 +655,13 @@ interface AlertVariants {
 interface ToastStyles {
     val base: Style<BasicParams>
     val placement: ToastPlacement
+
+    /**
+     * Styling to align the messages according to their horizontal position.
+     * Possible values to react are `left`, `center` and `right`.
+     */
+    val alignment: BoxParams.(String) -> Unit
+
     val status: ToastStatus
     val closeButton: ToastButton
 }


### PR DESCRIPTION
This PR adds two convenience functions `alertToast` and `showAlertToast` which can be used to easily create toasts with alert's as their content.

New functions:
```kotlin
fun showAlertToast(
    styling: BasicParams.() -> Unit = {},
    baseClass: StyleClass = StyleClass.None,
    id: String? = null,
    prefix: String = "toast-alert",
    build: AlertComponent.() -> Unit
)

fun alertToast(
    styling: BasicParams.() -> Unit = {},
    baseClass: StyleClass = StyleClass.None,
    id: String? = null,
    prefix: String = "toast-alert",
    build: AlertComponent.() -> Unit
): SimpleHandler<Unit>
```

Example usage:
```kotlin
showAlertToast(buildToast = {
   
}) { 
    // toast-properties:
    duration(6000)

    // setup of the alert
    alert {
        title("Alert-Toast")
        content("Alert in a toast")
        severity { /* some severity */ }
        variant { leftAccent }
    }
}

// 'alertToast' is used similarly and bound to a flow  like 'toast'
```

<details>
<summary>Previous usage</summary>

```kotlin
val alertComponent = AlertComponent()
    .apply {
        content("...")
        stacking { toast }
    }

showToast {
    // adjust the close-button to match the alert's color-scheme:
    closeButtonStyle(Theme().toast.closeButton.close + {
        color {
            val colorScheme = alertComponent.severity.value(Theme().alert.severities).colorScheme
            when(alertComponent.variant.value(AlertComponent.VariantContext)) {
                AlertComponent.AlertVariant.SUBTLE -> colorScheme.main
                AlertComponent.AlertVariant.TOP_ACCENT -> colorScheme.main
                AlertComponent.AlertVariant.LEFT_ACCENT -> colorScheme.main
                else -> colorScheme.mainContrast
            }
        }
    })
    content {
        alertComponent.render(this, styling, baseClass, id, prefix)
    }
}
```

</details>

Result:
![Bildschirmfoto 2021-07-06 um 10 35 19](https://user-images.githubusercontent.com/12587543/124569102-ee79c700-de45-11eb-95eb-e4f15a45d169.png)


---

Closes #476 .