### PR TITLE
Deprecate `box` in favor of `div`

### DIFF
--- a/components/src/jsMain/kotlin/dev/fritz2/components/appFrame.kt
+++ b/components/src/jsMain/kotlin/dev/fritz2/components/appFrame.kt
@@ -123,7 +123,7 @@ open class AppFrameComponent : Component<Unit> {
         prefix: String
     ) {
         context.apply {
-            box({
+            div({
                 display(
                     sm = { block },
                     md = { none })

--- a/components/src/jsMain/kotlin/dev/fritz2/components/box.kt
+++ b/components/src/jsMain/kotlin/dev/fritz2/components/box.kt
@@ -33,13 +33,7 @@ import dev.fritz2.styling.params.GridParams
  * @param prefix the prefix for the generated CSS class resulting in the form ``$prefix-$hash``
  * @param content a lambda expression for setting up the content and events of the ``div`` element itself
  */
-@Deprecated(
-    "Use 'div' instead of 'box' (same functionality)",
-    ReplaceWith(
-        expression = "div(styling, baseClass, id, prefix) { content() }",
-        imports = ["dev.fritz2.styling.div"]
-    )
-)
+@Deprecated("Use 'div' instead of 'box' (same functionality)")
 fun RenderContext.box(
     styling: FlexParams.() -> Unit = {},
     baseClass: StyleClass = StyleClass.None,

--- a/components/src/jsMain/kotlin/dev/fritz2/components/box.kt
+++ b/components/src/jsMain/kotlin/dev/fritz2/components/box.kt
@@ -33,6 +33,7 @@ import dev.fritz2.styling.params.GridParams
  * @param prefix the prefix for the generated CSS class resulting in the form ``$prefix-$hash``
  * @param content a lambda expression for setting up the content and events of the ``div`` element itself
  */
+@Deprecated("Use 'div' instead of 'box' (same functionality)")
 fun RenderContext.box(
     styling: FlexParams.() -> Unit = {},
     baseClass: StyleClass = StyleClass.None,
@@ -44,7 +45,7 @@ fun RenderContext.box(
 
 /**
  * This component represents a layout component with *flex* property.
- * That is the ``display`` property is set to ``flex``. Besides that is totally resembles the [box] component
+ * That is the ``display`` property is set to ``flex``. Besides that is totally resembles the [div] component
  *
  * Example usage:
  * ```
@@ -81,7 +82,7 @@ fun RenderContext.flexBox(
 
 /**
  * This component represents a layout component with *grid* property.
- * That is the ``display`` property is set to ``grid``. Besides that is totally resembles the [box] component
+ * That is the ``display`` property is set to ``grid``. Besides that is totally resembles the [div] component
  *
  * Example usage:
  * ```

--- a/components/src/jsMain/kotlin/dev/fritz2/components/box.kt
+++ b/components/src/jsMain/kotlin/dev/fritz2/components/box.kt
@@ -33,7 +33,13 @@ import dev.fritz2.styling.params.GridParams
  * @param prefix the prefix for the generated CSS class resulting in the form ``$prefix-$hash``
  * @param content a lambda expression for setting up the content and events of the ``div`` element itself
  */
-@Deprecated("Use 'div' instead of 'box' (same functionality)")
+@Deprecated(
+    "Use 'div' instead of 'box' (same functionality)",
+    ReplaceWith(
+        expression = "div(styling, baseClass, id, prefix) { content() }",
+        imports = ["dev.fritz2.styling.div"]
+    )
+)
 fun RenderContext.box(
     styling: FlexParams.() -> Unit = {},
     baseClass: StyleClass = StyleClass.None,

--- a/components/src/jsMain/kotlin/dev/fritz2/components/forms/control/component.kt
+++ b/components/src/jsMain/kotlin/dev/fritz2/components/forms/control/component.kt
@@ -10,6 +10,7 @@ import dev.fritz2.components.validation.Severity
 import dev.fritz2.components.validation.validationMessages
 import dev.fritz2.dom.html.RenderContext
 import dev.fritz2.styling.StyleClass
+import dev.fritz2.styling.div
 import dev.fritz2.styling.p
 import dev.fritz2.styling.params.BasicParams
 import dev.fritz2.styling.params.BoxParams
@@ -482,7 +483,7 @@ open class FormControlComponent : Component<Unit>, FormProperties by FormMixin()
                 spacing { none }
                 items {
                     this@FormControlComponent.validationMessagesBuilder?.invoke()?.messages?.renderEach { message ->
-                        box({
+                        div({
                             width { "100%" }
                         }) {
                             this@FormControlComponent.validationMessageRendering.value.invoke(this, message)


### PR DESCRIPTION
This PR deprecates the `box` factory method in favor of `div` because, in combination with fritz2.styling, it offers the exact same functionality. All calls of `box` will have to be replaced eventually.

Closes #379 .