### PR TITLE
Use colors in `appFrame` and added `submenu` in `menu` component

### DIFF
--- a/components/src/jsMain/kotlin/dev/fritz2/components/appFrame.kt
+++ b/components/src/jsMain/kotlin/dev/fritz2/components/appFrame.kt
@@ -13,8 +13,8 @@ import dev.fritz2.styling.theme.Theme
  * It offers the following sections
  * - sidebar with brand, navbar section and optional complementary on the left
  * - header at the top with actions section on the right
- * - main section
- * - optional navigation tablist at the bottom of main section
+ * - content section
+ * - optional navigation tablist at the bottom of content section
  *
  * The sidebar is moved off-screen on small screens and can be opened by a hamburger-button,
  * that appears at the left edge of the header.
@@ -42,7 +42,7 @@ import dev.fritz2.styling.theme.Theme
  *     actions { //optional
  *         //...
  *     }
- *     main {
+ *     content {
  *         //...
  *     }
  *     tablist { //optional

--- a/components/src/jsMain/kotlin/dev/fritz2/components/appFrame/component.kt
+++ b/components/src/jsMain/kotlin/dev/fritz2/components/appFrame/component.kt
@@ -17,7 +17,12 @@ import dev.fritz2.styling.params.Style
 import dev.fritz2.styling.theme.Property
 import dev.fritz2.styling.theme.Theme
 
-
+internal class AppFrameSection<S : BasicParams>(
+    val styling: Style<S>? = null,
+    val baseClass: StyleClass = StyleClass.None,
+    val id: String? = null,
+    val context: RenderContext.() -> Unit = {}
+)
 
 /**
  * This class combines the _configuration_ and the core rendering of the [appFrame].
@@ -104,74 +109,74 @@ open class AppFrameComponent : Component<Unit> {
         boxShadow(sm = { flat }, md = { none })
     }
 
-    private var brand = Pair<Style<FlexParams>?, (RenderContext.() -> Unit)?>(null, null)
+    private var brand = AppFrameSection<FlexParams>()
     fun brand(
         styling: Style<FlexParams>? = null,
         baseClass: StyleClass = StyleClass.None,
         id: String? = null,
         context: RenderContext.() -> Unit
     ) {
-        brand = styling to context
+        brand = AppFrameSection(styling, baseClass, id, context)
     }
 
-    private var header = Pair<Style<FlexParams>?, (RenderContext.() -> Unit)?>(null, null)
+    private var header = AppFrameSection<FlexParams>()
     fun header(
         styling: Style<FlexParams>? = null,
         baseClass: StyleClass = StyleClass.None,
         id: String? = null,
         context: RenderContext.() -> Unit
     ) {
-        header = styling to context
+        header = AppFrameSection(styling, baseClass, id, context)
     }
 
-    private var actions = Pair<Style<BoxParams>?, (RenderContext.() -> Unit)?>(null, null)
+    private var actions = AppFrameSection<BoxParams>()
     fun actions(
         styling: Style<BoxParams>? = null,
         baseClass: StyleClass = StyleClass.None,
         id: String? = null,
         context: RenderContext.() -> Unit
     ) {
-        actions = styling to context
+        actions = AppFrameSection(styling, baseClass, id, context)
     }
 
-    private var content = Pair<Style<BoxParams>?, (RenderContext.() -> Unit)?>(null, null)
+    private var content = AppFrameSection<BoxParams>()
     fun content(
         styling: Style<BoxParams>? = null,
         baseClass: StyleClass = StyleClass.None,
         id: String? = null,
         context: RenderContext.() -> Unit
     ) {
-        content = styling to context
+        content = AppFrameSection(styling, baseClass, id, context)
     }
 
-    private var complementary: Pair<Style<BoxParams>?, (RenderContext.() -> Unit)?>? = null
+    private var complementary: AppFrameSection<BoxParams>? = null
     fun complementary(
         styling: Style<BoxParams>? = null,
         baseClass: StyleClass = StyleClass.None,
         id: String? = null,
         context: RenderContext.() -> Unit
     ) {
-        complementary = styling to context
+        complementary = AppFrameSection(styling, baseClass, id, context)
     }
 
-    private var tablist: Pair<Style<FlexParams>?, (RenderContext.() -> Unit)?>? = null
+    private var tablist: AppFrameSection<FlexParams>? = null
     fun tablist(
         styling: Style<FlexParams>? = null,
         baseClass: StyleClass = StyleClass.None,
         id: String? = null,
         context: RenderContext.() -> Unit
     ) {
-        tablist = styling to context
+        tablist = AppFrameSection(styling, baseClass, id, context)
     }
 
-    private var navigation = Pair<Style<BoxParams>?, (RenderContext.() -> Unit)?>(null, null)
+    private var navigation = AppFrameSection<BoxParams>()
     fun navigation(
         styling: Style<BoxParams>? = null,
         baseClass: StyleClass = StyleClass.None,
         id: String? = null,
         context: RenderContext.() -> Unit
     ) {
-        navigation = styling to context
+        navigation = AppFrameSection(styling, baseClass, id, context)
     }
 
     val sidebarToggle = ComponentProperty<PushButtonComponent.() -> Unit> {
@@ -219,9 +224,9 @@ open class AppFrameComponent : Component<Unit> {
                 flexBox({
                     height { Theme().appFrame.headerHeight }
                     Theme().appFrame.brand()
-                    this@AppFrameComponent.brand.first?.invoke()
-                }, prefix = "brand") {
-                    this@AppFrameComponent.brand.second?.invoke(this)
+                    this@AppFrameComponent.brand.styling?.invoke()
+                }, this@AppFrameComponent.brand.baseClass, this@AppFrameComponent.brand.id, "brand") {
+                    this@AppFrameComponent.brand.context(this)
                 }
             }
 
@@ -233,27 +238,27 @@ open class AppFrameComponent : Component<Unit> {
                 flexBox({
                     height { Theme().appFrame.headerHeight }
                     Theme().appFrame.header()
-                    this@AppFrameComponent.header.first?.invoke()
-                }, prefix = "header") {
+                    this@AppFrameComponent.header.styling?.invoke()
+                }, this@AppFrameComponent.header.baseClass, this@AppFrameComponent.header.id, "header") {
                     lineUp({
-                        alignItems { dev.fritz2.styling.params.AlignItemsValues.center }
+                        alignItems { center }
                     }) {
                         spacing { tiny }
                         items {
                             clickButton({
-                                display(md = { dev.fritz2.styling.params.DisplayValues.none })
+                                display(md = { none })
                                 padding { none }
                                 margins { left { "-.5rem" } }
                             }) {
-                                this@AppFrameComponent.sidebarToggle.value.invoke(this)
+                                this@AppFrameComponent.sidebarToggle.value(this)
                             } handledBy this@AppFrameComponent.toggleSidebar
-                            this@AppFrameComponent.header.second?.invoke(this)
+                            this@AppFrameComponent.header.context(this)
                         }
                     }
                     section({
-                        this@AppFrameComponent.actions.first?.invoke()
-                    }, prefix = "actions") {
-                        this@AppFrameComponent.actions.second?.invoke(this)
+                        this@AppFrameComponent.actions.styling?.invoke()
+                    }, this@AppFrameComponent.actions.baseClass, this@AppFrameComponent.actions.id, "actions") {
+                        this@AppFrameComponent.actions.context(this)
                     }
                 }
             }
@@ -277,20 +282,18 @@ open class AppFrameComponent : Component<Unit> {
                 }) {
                     section({
                         Theme().appFrame.navigation()
-                        this@AppFrameComponent.navigation.first?.invoke()
-                    }, prefix = "navigation", scope = {
-                        set(AppFrameScope.Navigation, true)
-                    }) {
-                        this@AppFrameComponent.navigation.second?.invoke(this)
+                        this@AppFrameComponent.navigation.styling?.invoke()
+                    }, this@AppFrameComponent.navigation.baseClass, this@AppFrameComponent.navigation.id,
+                        "navigation", { set(AppFrameScope.Navigation, true) }) {
+                        this@AppFrameComponent.navigation.context(this)
                     }
                     this@AppFrameComponent.complementary?.let { complementary ->
                         section({
                             Theme().appFrame.complementary()
-                            complementary.first?.invoke()
-                        }, scope = {
-                            set(AppFrameScope.Complementary, true)
-                        }) {
-                            complementary.second?.invoke(this)
+                            complementary.styling?.invoke()
+                        }, complementary.baseClass, complementary.id,
+                            "complementary", { set(AppFrameScope.Complementary, true) }) {
+                            complementary.context(this)
                         }
                     }
                 }
@@ -301,11 +304,12 @@ open class AppFrameComponent : Component<Unit> {
                 overflow { auto }
                 Theme().appFrame.content()
                 styling()
-                this@AppFrameComponent.content.first?.invoke()
-            }, styling, baseClass, id, prefix, {
+                this@AppFrameComponent.content.styling?.invoke()
+            }, this@AppFrameComponent.content.baseClass + baseClass,
+                this@AppFrameComponent.content.id ?: id, "content", {
                 set(AppFrameScope.Content, true)
             }) {
-                this@AppFrameComponent.content.second?.invoke(this)
+                this@AppFrameComponent.content.context(this)
             }
 
             this@AppFrameComponent.tablist?.let { tablist ->
@@ -315,11 +319,9 @@ open class AppFrameComponent : Component<Unit> {
                     alignItems { center }
                     justifyContent { spaceEvenly }
                     Theme().appFrame.tablist()
-                    tablist.first?.invoke()
-                }, prefix = "tablist", scope = {
-                    set(AppFrameScope.Tablist, true)
-                }) {
-                    tablist.second?.invoke(this)
+                    tablist.styling?.invoke()
+                }, tablist.baseClass, tablist.id, "tablist", { set(AppFrameScope.Tablist, true) }) {
+                    tablist.context(this)
                 }
             }
         }

--- a/components/src/jsMain/kotlin/dev/fritz2/components/appFrame/component.kt
+++ b/components/src/jsMain/kotlin/dev/fritz2/components/appFrame/component.kt
@@ -62,6 +62,7 @@ open class AppFrameComponent : Component<Unit>,
             staticStyle(
                 """
                 body {
+                    position: relative;
                     height: 100vh;
                     overflow: hidden;
                     max-height: -webkit-fill-available;
@@ -81,23 +82,37 @@ open class AppFrameComponent : Component<Unit>,
         }
     }
 
-    private var sidebarWith: Property? = null
+    private var sidebarWidth: Property? = null
 
     /**
      * sets the min-width of sidebar
      *
-     * @param value value between 0 - 100
+     * @param value percentage between 0 - 100
      */
-    fun sidebarWith(value: Int) { sidebarWith = "${value}vw"}
+    fun sidebarWidth(value: Int) { sidebarWidth = "${value}vw"}
 
-    private var mobileSidebarWith: Property? = null
+    /**
+     * sets the min-width of sidebar
+     *
+     * @param value some valid CSS length or percentage value
+     */
+    fun sidebarWidth(value: String) { sidebarWidth = value }
+
+    private var mobileSidebarWidth: Property? = null
 
     /**
      * sets the min-with of mobile sidebar
      *
-     * @param value value between 0 - 100
+     * @param value percentage between 0 - 100
      */
-    fun mobileSidebarWith(value: Int) { mobileSidebarWith = "${value}vw"}
+    fun mobileSidebarWidth(value: Int) { mobileSidebarWidth = "${value}vw"}
+
+    /**
+     * sets the min-width of sidebar
+     *
+     * @param value some valid CSS length or percentage value
+     */
+    fun mobileSidebarWidth(value: String) { mobileSidebarWidth = value }
 
     private val sidebarStatus = storeOf(false)
     private val toggleSidebar = sidebarStatus.handle { !it }
@@ -120,7 +135,7 @@ open class AppFrameComponent : Component<Unit>,
 
     private fun mobileSidebar(topPosition: Property): Style<BasicParams> = {
         zIndex { appFrame }
-        width(sm = { this@AppFrameComponent.mobileSidebarWith ?: Theme().appFrame.mobileSidebarWidth }, md = { unset })
+        width(sm = { this@AppFrameComponent.mobileSidebarWidth ?: Theme().appFrame.mobileSidebarWidth }, md = { unset })
         css(sm = "transform: translateX(-110vw);", md = "transform: unset;")
         position(sm = {
             fixed { top { topPosition } }
@@ -305,7 +320,7 @@ open class AppFrameComponent : Component<Unit>,
                 this@AppFrameComponent.mobileSidebar(Theme().appFrame.headerHeight)()
                 overflow { hidden }
                 height(sm = { "calc(100% - ${Theme().appFrame.headerHeight})" }, md = { unset })
-                minWidth { this@AppFrameComponent.sidebarWith ?: Theme().appFrame.sidebarWidth }
+                minWidth { this@AppFrameComponent.sidebarWidth ?: Theme().appFrame.sidebarWidth }
                 Theme().appFrame.sidebar()
             }) {
                 className(this@AppFrameComponent.openSideBar.whenever(this@AppFrameComponent.sidebarStatus.data).name)

--- a/components/src/jsMain/kotlin/dev/fritz2/components/appFrame/component.kt
+++ b/components/src/jsMain/kotlin/dev/fritz2/components/appFrame/component.kt
@@ -97,7 +97,7 @@ open class AppFrameComponent : Component<Unit>,
      *
      * @param value value between 0 - 100
      */
-    fun mobileSidebarWith(value: Int) { sidebarWith = "${value}vw"}
+    fun mobileSidebarWith(value: Int) { mobileSidebarWith = "${value}vw"}
 
     private val sidebarStatus = storeOf(false)
     private val toggleSidebar = sidebarStatus.handle { !it }

--- a/components/src/jsMain/kotlin/dev/fritz2/components/appFrame/component.kt
+++ b/components/src/jsMain/kotlin/dev/fritz2/components/appFrame/component.kt
@@ -18,7 +18,7 @@ import dev.fritz2.styling.theme.Theme
  * - brand
  * - header
  * - actions
- * - nav
+ * - navigation
  * - main
  * - complementary (only rendered if defined)
  * - tablist (only rendered if defined)
@@ -126,7 +126,7 @@ open class AppFrameComponent : Component<Unit> {
     }
 
     private var navigation = Pair<Style<BoxParams>?, (RenderContext.() -> Unit)?>(null, null)
-    fun navbar(styling: Style<BoxParams>? = null, context: RenderContext.() -> Unit) {
+    fun navigation(styling: Style<BoxParams>? = null, context: RenderContext.() -> Unit) {
         navigation = styling to context
     }
 
@@ -168,6 +168,8 @@ open class AppFrameComponent : Component<Unit> {
                 grid(sm = { area { "header" } }, md = { area { "brand" } })
                 this@AppFrameComponent.mobileSidebar("none")()
                 height(sm = { Theme().appFrame.headerHeight }, md = { unset })
+            }, scope = {
+                set(AppFrameScope.Brand, true)
             }) {
                 className(this@AppFrameComponent.openSideBar.whenever(this@AppFrameComponent.sidebarStatus.data).name)
                 flexBox({
@@ -181,6 +183,8 @@ open class AppFrameComponent : Component<Unit> {
 
             header({
                 grid { area { "header" } }
+            }, scope = {
+                set(AppFrameScope.Header, true)
             }) {
                 flexBox({
                     height { Theme().appFrame.headerHeight }
@@ -230,13 +234,17 @@ open class AppFrameComponent : Component<Unit> {
                     section({
                         Theme().appFrame.navigation()
                         this@AppFrameComponent.navigation.first?.invoke()
-                    }, prefix = "navigation") {
+                    }, prefix = "navigation", scope = {
+                        set(AppFrameScope.Navigation, true)
+                    }) {
                         this@AppFrameComponent.navigation.second?.invoke(this)
                     }
                     this@AppFrameComponent.complementary?.let { complementary ->
                         section({
                             Theme().appFrame.complementary()
                             complementary.first?.invoke()
+                        }, scope = {
+                            set(AppFrameScope.Complementary, true)
                         }) {
                             complementary.second?.invoke(this)
                         }
@@ -250,7 +258,9 @@ open class AppFrameComponent : Component<Unit> {
                 Theme().appFrame.main()
                 styling()
                 this@AppFrameComponent.main.first?.invoke()
-            }, styling, baseClass, id, prefix) {
+            }, styling, baseClass, id, prefix, {
+                set(AppFrameScope.Main, true)
+            }) {
                 this@AppFrameComponent.main.second?.invoke(this)
             }
 
@@ -262,7 +272,9 @@ open class AppFrameComponent : Component<Unit> {
                     justifyContent { spaceEvenly }
                     Theme().appFrame.tablist()
                     tablist.first?.invoke()
-                }, prefix = "tablist") {
+                }, prefix = "tablist", scope = {
+                    set(AppFrameScope.Tablist, true)
+                }) {
                     tablist.second?.invoke(this)
                 }
             }

--- a/components/src/jsMain/kotlin/dev/fritz2/components/appFrame/component.kt
+++ b/components/src/jsMain/kotlin/dev/fritz2/components/appFrame/component.kt
@@ -52,6 +52,7 @@ open class AppFrameComponent : Component<Unit> {
                 """
                 body {
                     height: 100vh;
+                    overflow: hidden;
                     max-height: -webkit-fill-available;
                     width: 100vw;
                     display: grid;

--- a/components/src/jsMain/kotlin/dev/fritz2/components/appFrame/component.kt
+++ b/components/src/jsMain/kotlin/dev/fritz2/components/appFrame/component.kt
@@ -5,6 +5,8 @@ import dev.fritz2.components.appFrame
 import dev.fritz2.components.buttons.PushButtonComponent
 import dev.fritz2.components.clickButton
 import dev.fritz2.components.flexBox
+import dev.fritz2.components.foundations.CloseButtonMixin
+import dev.fritz2.components.foundations.CloseButtonProperty
 import dev.fritz2.components.foundations.Component
 import dev.fritz2.components.foundations.ComponentProperty
 import dev.fritz2.components.lineUp
@@ -42,7 +44,12 @@ internal class AppFrameSection<S : BasicParams>(
  * The rendering function is used by the component factory functions [appFrame], so it is
  * not meant to be called directly unless you plan to implement your own appFrame.
  */
-open class AppFrameComponent : Component<Unit> {
+open class AppFrameComponent : Component<Unit>,
+    CloseButtonProperty by CloseButtonMixin("sidebar-close-button", {
+        margins { left { auto } }
+        display(sm = { unset }, md = { none })
+        Theme().appFrame.sidebarClose()
+    }) {
     companion object {
         init {
             // Needs to reference header height from Theme even though static style needs to be used to style the body.
@@ -228,6 +235,10 @@ open class AppFrameComponent : Component<Unit> {
                     this@AppFrameComponent.brand.styling?.invoke()
                 }, this@AppFrameComponent.brand.baseClass, this@AppFrameComponent.brand.id, "brand") {
                     this@AppFrameComponent.brand.context(this)
+                    if (this@AppFrameComponent.hasCloseButton.value) {
+                        this@AppFrameComponent.closeButtonRendering.value(this) handledBy
+                                this@AppFrameComponent.closeSidebar
+                    }
                 }
             }
 
@@ -308,8 +319,9 @@ open class AppFrameComponent : Component<Unit> {
                 this@AppFrameComponent.content.styling?.invoke()
             }, this@AppFrameComponent.content.baseClass + baseClass,
                 this@AppFrameComponent.content.id ?: id, "content", {
-                set(AppFrameScope.Content, true)
-            }) {
+                    set(AppFrameScope.Content, true)
+                }
+            ) {
                 this@AppFrameComponent.content.context(this)
             }
 

--- a/components/src/jsMain/kotlin/dev/fritz2/components/appFrame/component.kt
+++ b/components/src/jsMain/kotlin/dev/fritz2/components/appFrame/component.kt
@@ -17,6 +17,8 @@ import dev.fritz2.styling.params.Style
 import dev.fritz2.styling.theme.Property
 import dev.fritz2.styling.theme.Theme
 
+
+
 /**
  * This class combines the _configuration_ and the core rendering of the [appFrame].
  *
@@ -25,7 +27,7 @@ import dev.fritz2.styling.theme.Theme
  * - header
  * - actions
  * - navigation
- * - main
+ * - content
  * - complementary (only rendered if defined)
  * - tablist (only rendered if defined)
  *
@@ -50,7 +52,7 @@ open class AppFrameComponent : Component<Unit> {
                     display: grid;
                     grid-template-areas:
                         "brand header"
-                        "sidebar main"
+                        "sidebar content"
                         "sidebar tablist";
                     grid-template-rows: ${Theme().appFrame.headerHeight} 1fr min-content;
                     grid-auto-columns: min-content 1fr;
@@ -103,37 +105,72 @@ open class AppFrameComponent : Component<Unit> {
     }
 
     private var brand = Pair<Style<FlexParams>?, (RenderContext.() -> Unit)?>(null, null)
-    fun brand(styling: Style<FlexParams>? = null, context: RenderContext.() -> Unit) {
+    fun brand(
+        styling: Style<FlexParams>? = null,
+        baseClass: StyleClass = StyleClass.None,
+        id: String? = null,
+        context: RenderContext.() -> Unit
+    ) {
         brand = styling to context
     }
 
     private var header = Pair<Style<FlexParams>?, (RenderContext.() -> Unit)?>(null, null)
-    fun header(styling: Style<FlexParams>? = null, context: RenderContext.() -> Unit) {
+    fun header(
+        styling: Style<FlexParams>? = null,
+        baseClass: StyleClass = StyleClass.None,
+        id: String? = null,
+        context: RenderContext.() -> Unit
+    ) {
         header = styling to context
     }
 
     private var actions = Pair<Style<BoxParams>?, (RenderContext.() -> Unit)?>(null, null)
-    fun actions(styling: Style<BoxParams>? = null, context: RenderContext.() -> Unit) {
+    fun actions(
+        styling: Style<BoxParams>? = null,
+        baseClass: StyleClass = StyleClass.None,
+        id: String? = null,
+        context: RenderContext.() -> Unit
+    ) {
         actions = styling to context
     }
 
-    private var main = Pair<Style<BoxParams>?, (RenderContext.() -> Unit)?>(null, null)
-    fun main(styling: Style<BoxParams>? = null, context: RenderContext.() -> Unit) {
-        main = styling to context
+    private var content = Pair<Style<BoxParams>?, (RenderContext.() -> Unit)?>(null, null)
+    fun content(
+        styling: Style<BoxParams>? = null,
+        baseClass: StyleClass = StyleClass.None,
+        id: String? = null,
+        context: RenderContext.() -> Unit
+    ) {
+        content = styling to context
     }
 
     private var complementary: Pair<Style<BoxParams>?, (RenderContext.() -> Unit)?>? = null
-    fun complementary(styling: Style<BoxParams>? = null, context: RenderContext.() -> Unit) {
+    fun complementary(
+        styling: Style<BoxParams>? = null,
+        baseClass: StyleClass = StyleClass.None,
+        id: String? = null,
+        context: RenderContext.() -> Unit
+    ) {
         complementary = styling to context
     }
 
     private var tablist: Pair<Style<FlexParams>?, (RenderContext.() -> Unit)?>? = null
-    fun tablist(styling: Style<FlexParams>? = null, context: RenderContext.() -> Unit) {
+    fun tablist(
+        styling: Style<FlexParams>? = null,
+        baseClass: StyleClass = StyleClass.None,
+        id: String? = null,
+        context: RenderContext.() -> Unit
+    ) {
         tablist = styling to context
     }
 
     private var navigation = Pair<Style<BoxParams>?, (RenderContext.() -> Unit)?>(null, null)
-    fun navigation(styling: Style<BoxParams>? = null, context: RenderContext.() -> Unit) {
+    fun navigation(
+        styling: Style<BoxParams>? = null,
+        baseClass: StyleClass = StyleClass.None,
+        id: String? = null,
+        context: RenderContext.() -> Unit
+    ) {
         navigation = styling to context
     }
 
@@ -222,7 +259,7 @@ open class AppFrameComponent : Component<Unit> {
             }
 
             aside({
-                grid(sm = { area { "main" } }, md = { area { "sidebar" } })
+                grid(sm = { area { "content" } }, md = { area { "sidebar" } })
                 this@AppFrameComponent.mobileSidebar(Theme().appFrame.headerHeight)()
                 overflow { hidden }
                 height(sm = { "calc(100% - ${Theme().appFrame.headerHeight})" }, md = { unset })
@@ -260,15 +297,15 @@ open class AppFrameComponent : Component<Unit> {
             }
 
             main({
-                grid { area { "main" } }
+                grid { area { "content" } }
                 overflow { auto }
-                Theme().appFrame.main()
+                Theme().appFrame.content()
                 styling()
-                this@AppFrameComponent.main.first?.invoke()
+                this@AppFrameComponent.content.first?.invoke()
             }, styling, baseClass, id, prefix, {
-                set(AppFrameScope.Main, true)
+                set(AppFrameScope.Content, true)
             }) {
-                this@AppFrameComponent.main.second?.invoke(this)
+                this@AppFrameComponent.content.second?.invoke(this)
             }
 
             this@AppFrameComponent.tablist?.let { tablist ->

--- a/components/src/jsMain/kotlin/dev/fritz2/components/appFrame/component.kt
+++ b/components/src/jsMain/kotlin/dev/fritz2/components/appFrame/component.kt
@@ -1,13 +1,19 @@
 package dev.fritz2.components.appFrame
 
 import dev.fritz2.binding.storeOf
-import dev.fritz2.components.*
+import dev.fritz2.components.appFrame
 import dev.fritz2.components.buttons.PushButtonComponent
+import dev.fritz2.components.clickButton
+import dev.fritz2.components.flexBox
 import dev.fritz2.components.foundations.Component
 import dev.fritz2.components.foundations.ComponentProperty
+import dev.fritz2.components.lineUp
 import dev.fritz2.dom.html.RenderContext
 import dev.fritz2.styling.*
-import dev.fritz2.styling.params.*
+import dev.fritz2.styling.params.BasicParams
+import dev.fritz2.styling.params.BoxParams
+import dev.fritz2.styling.params.FlexParams
+import dev.fritz2.styling.params.Style
 import dev.fritz2.styling.theme.Property
 import dev.fritz2.styling.theme.Theme
 
@@ -58,6 +64,7 @@ open class AppFrameComponent : Component<Unit> {
 
     private val sidebarStatus = storeOf(false)
     private val toggleSidebar = sidebarStatus.handle { !it }
+    val closeSidebar = sidebarStatus.handle { false }
 
     private val openSideBar = staticStyle(
         "open-sidebar",

--- a/components/src/jsMain/kotlin/dev/fritz2/components/appFrame/component.kt
+++ b/components/src/jsMain/kotlin/dev/fritz2/components/appFrame/component.kt
@@ -312,6 +312,7 @@ open class AppFrameComponent : Component<Unit>,
             }
 
             main({
+                position { relative {  } }
                 grid { area { "content" } }
                 overflow { auto }
                 Theme().appFrame.content()

--- a/components/src/jsMain/kotlin/dev/fritz2/components/appFrame/component.kt
+++ b/components/src/jsMain/kotlin/dev/fritz2/components/appFrame/component.kt
@@ -72,10 +72,28 @@ open class AppFrameComponent : Component<Unit>,
                     padding: 0;
                     margin: 0; 
                 }
-             """.trimIndent()
+                """.trimIndent()
             )
         }
     }
+
+    private var sidebarWith: Property? = null
+
+    /**
+     * sets the min-width of sidebar
+     *
+     * @param value value between 0 - 100
+     */
+    fun sidebarWith(value: Int) { sidebarWith = "${value}vw"}
+
+    private var mobileSidebarWith: Property? = null
+
+    /**
+     * sets the min-with of mobile sidebar
+     *
+     * @param value value between 0 - 100
+     */
+    fun mobileSidebarWith(value: Int) { sidebarWith = "${value}vw"}
 
     private val sidebarStatus = storeOf(false)
     private val toggleSidebar = sidebarStatus.handle { !it }
@@ -98,7 +116,7 @@ open class AppFrameComponent : Component<Unit>,
 
     private fun mobileSidebar(topPosition: Property): Style<BasicParams> = {
         zIndex { appFrame }
-        width(sm = { Theme().appFrame.mobileSidebarWidth }, md = { unset })
+        width(sm = { this@AppFrameComponent.mobileSidebarWith ?: Theme().appFrame.mobileSidebarWidth }, md = { unset })
         css(sm = "transform: translateX(-110vw);", md = "transform: unset;")
         position(sm = {
             fixed { top { topPosition } }
@@ -280,6 +298,7 @@ open class AppFrameComponent : Component<Unit>,
                 this@AppFrameComponent.mobileSidebar(Theme().appFrame.headerHeight)()
                 overflow { hidden }
                 height(sm = { "calc(100% - ${Theme().appFrame.headerHeight})" }, md = { unset })
+                minWidth { this@AppFrameComponent.sidebarWith ?: Theme().appFrame.sidebarWidth }
                 Theme().appFrame.sidebar()
             }) {
                 className(this@AppFrameComponent.openSideBar.whenever(this@AppFrameComponent.sidebarStatus.data).name)

--- a/components/src/jsMain/kotlin/dev/fritz2/components/appFrame/component.kt
+++ b/components/src/jsMain/kotlin/dev/fritz2/components/appFrame/component.kt
@@ -1,6 +1,7 @@
 package dev.fritz2.components.appFrame
 
 import dev.fritz2.binding.storeOf
+import dev.fritz2.binding.watch
 import dev.fritz2.components.appFrame
 import dev.fritz2.components.buttons.PushButtonComponent
 import dev.fritz2.components.clickButton
@@ -10,6 +11,7 @@ import dev.fritz2.components.foundations.CloseButtonProperty
 import dev.fritz2.components.foundations.Component
 import dev.fritz2.components.foundations.ComponentProperty
 import dev.fritz2.components.lineUp
+import dev.fritz2.dom.Window
 import dev.fritz2.dom.html.RenderContext
 import dev.fritz2.styling.*
 import dev.fritz2.styling.params.BasicParams
@@ -18,6 +20,8 @@ import dev.fritz2.styling.params.FlexParams
 import dev.fritz2.styling.params.Style
 import dev.fritz2.styling.theme.Property
 import dev.fritz2.styling.theme.Theme
+import kotlinx.browser.document
+import kotlinx.coroutines.flow.onEach
 
 internal class AppFrameSection<S : BasicParams>(
     val styling: Style<S>? = null,
@@ -218,6 +222,9 @@ open class AppFrameComponent : Component<Unit>,
         id: String?,
         prefix: String
     ) {
+        Window.touchends.events
+            .onEach { document.documentElement?.scrollTo(0.0,0.0) }.watch()
+
         context.apply {
             div({
                 display(

--- a/components/src/jsMain/kotlin/dev/fritz2/components/appFrame/scope.kt
+++ b/components/src/jsMain/kotlin/dev/fritz2/components/appFrame/scope.kt
@@ -1,0 +1,13 @@
+package dev.fritz2.components.appFrame
+
+import dev.fritz2.dom.html.Scope
+
+sealed class AppFrameScope(name: String) : Scope.Key<Boolean>("appFrame-$name") {
+    object Header: AppFrameScope("header")
+    object Brand: AppFrameScope("brand")
+    object Actions: AppFrameScope("actions")
+    object Navigation: AppFrameScope("navigation")
+    object Main: AppFrameScope("main")
+    object Complementary: AppFrameScope("complementary")
+    object Tablist: AppFrameScope("tablist")
+}

--- a/components/src/jsMain/kotlin/dev/fritz2/components/appFrame/scope.kt
+++ b/components/src/jsMain/kotlin/dev/fritz2/components/appFrame/scope.kt
@@ -7,7 +7,7 @@ sealed class AppFrameScope(name: String) : Scope.Key<Boolean>("appFrame-$name") 
     object Brand: AppFrameScope("brand")
     object Actions: AppFrameScope("actions")
     object Navigation: AppFrameScope("navigation")
-    object Main: AppFrameScope("main")
+    object Content: AppFrameScope("content")
     object Complementary: AppFrameScope("complementary")
     object Tablist: AppFrameScope("tablist")
 }

--- a/components/src/jsMain/kotlin/dev/fritz2/components/appFrame/service.kt
+++ b/components/src/jsMain/kotlin/dev/fritz2/components/appFrame/service.kt
@@ -1,0 +1,14 @@
+package dev.fritz2.components.appFrame
+
+import kotlinx.browser.window
+
+fun registerServiceWorker(jsFileName: String = "serviceWorker.js") {
+    try {
+        window.addEventListener("load", {
+            window.navigator.serviceWorker.register(jsFileName)
+        })
+        console.log("ServiceWorker registered")
+    } catch (t: Throwable) {
+        console.log("Error registering ServiceWorker:", t)
+    }
+}

--- a/components/src/jsMain/kotlin/dev/fritz2/components/appFrame/service.kt
+++ b/components/src/jsMain/kotlin/dev/fritz2/components/appFrame/service.kt
@@ -1,7 +1,15 @@
 package dev.fritz2.components.appFrame
 
+import dev.fritz2.components.appFrame
 import kotlinx.browser.window
 
+/**
+ * Call this function at the beginning of your `main()` function to enable the
+ * [PWA](https://developer.mozilla.org/en-US/docs/Web/Progressive_web_apps) functionality of the [appFrame]
+ * component by registering your `serviceWorker.js` file.
+ *
+ * @param jsFileName path to your serviceWorker.js file to load
+ */
 fun registerServiceWorker(jsFileName: String = "serviceWorker.js") {
     try {
         window.addEventListener("load", {

--- a/components/src/jsMain/kotlin/dev/fritz2/components/box.kt
+++ b/components/src/jsMain/kotlin/dev/fritz2/components/box.kt
@@ -2,6 +2,7 @@ package dev.fritz2.components
 
 import dev.fritz2.dom.html.Div
 import dev.fritz2.dom.html.RenderContext
+import dev.fritz2.dom.html.ScopeContext
 import dev.fritz2.styling.StyleClass
 import dev.fritz2.styling.div
 import dev.fritz2.styling.params.FlexParams
@@ -76,8 +77,9 @@ fun RenderContext.flexBox(
     baseClass: StyleClass = StyleClass.None,
     id: String? = null,
     prefix: String = "flex-box",
+    scope: ScopeContext.() -> Unit = {},
     content: Div.() -> Unit
-): Div = div({ display { flex } }, styling, baseClass, id, prefix) { content() }
+): Div = div({ display { flex } }, styling, baseClass, id, prefix, scope) { content() }
 
 
 /**
@@ -117,7 +119,8 @@ fun RenderContext.gridBox(
     baseClass: StyleClass = StyleClass.None,
     id: String? = null,
     prefix: String = "grid-box",
+    scope: ScopeContext.() -> Unit = {},
     content: Div.() -> Unit
 ): Div =
-    div({ display { grid } }, styling, baseClass, id, prefix) { content() }
+    div({ display { grid } }, styling, baseClass, id, prefix, scope) { content() }
 

--- a/components/src/jsMain/kotlin/dev/fritz2/components/checkboxes/componentSingle.kt
+++ b/components/src/jsMain/kotlin/dev/fritz2/components/checkboxes/componentSingle.kt
@@ -119,6 +119,8 @@ open class CheckboxComponent(protected val value: Store<Boolean>?) :
     ): Label = with(context) {
         label({
             this@CheckboxComponent.size.value.invoke(Theme().checkbox.sizes)()
+            // to "capture" the invisible, absolute positioned `input`, see `checkboxInputStaticCss`
+            position { relative {  } }
         }, baseClass = baseClass, id = id, prefix = prefix) {
             val inputId = id?.let { "$it-input" }
             inputId?.let {

--- a/components/src/jsMain/kotlin/dev/fritz2/components/menu.kt
+++ b/components/src/jsMain/kotlin/dev/fritz2/components/menu.kt
@@ -51,6 +51,6 @@ fun RenderContext.menu(
     id: String? = null,
     prefix: String = "menu",
     build: MenuComponent.() -> Unit,
-) = MenuComponent()
+) = MenuComponent(scope)
     .apply(build)
     .render(this, styling, baseClass, id, prefix)

--- a/components/src/jsMain/kotlin/dev/fritz2/components/menu/component.kt
+++ b/components/src/jsMain/kotlin/dev/fritz2/components/menu/component.kt
@@ -1,15 +1,18 @@
 package dev.fritz2.components.menu
 
 import dev.fritz2.binding.storeOf
+import dev.fritz2.components.appFrame.AppFrameScope
 import dev.fritz2.components.foundations.*
 import dev.fritz2.components.icon
 import dev.fritz2.dom.html.RenderContext
+import dev.fritz2.dom.html.Scope
 import dev.fritz2.styling.*
 import dev.fritz2.styling.params.BoxParams
 import dev.fritz2.styling.params.Style
 import dev.fritz2.styling.params.plus
 import dev.fritz2.styling.theme.IconDefinition
 import dev.fritz2.styling.theme.Icons
+import dev.fritz2.styling.theme.MenuStyles
 import dev.fritz2.styling.theme.Theme
 import org.w3c.dom.HTMLButtonElement
 
@@ -48,7 +51,9 @@ import org.w3c.dom.HTMLButtonElement
  *      .run(::addChild)
  * ```
  */
-open class MenuComponent : Component<Unit>, MenuContext() {
+open class MenuComponent(scope: Scope) : Component<Unit>, MenuContext() {
+
+    val styles: MenuStyles = if(scope[AppFrameScope.Navigation] == true) Theme().appFrame.menu else Theme().menu
 
     override fun render(
         context: RenderContext,
@@ -58,9 +63,9 @@ open class MenuComponent : Component<Unit>, MenuContext() {
         prefix: String
     ) {
         context.apply {
-            div(Theme().menu.container + styling, baseClass, id, prefix) {
+            div(this@MenuComponent.styles.container + styling, baseClass, id, prefix) {
                 this@MenuComponent.children.forEach {
-                    it.render(this)
+                    it.render(this, this@MenuComponent.styles)
                 }
             }
         }
@@ -133,11 +138,11 @@ open class SubMenuComponent(
 
     private val hide = storeOf(true)
 
-    override fun render(context: RenderContext) {
+    override fun render(context: RenderContext, styles: MenuStyles) {
         context.apply {
-            button(Theme().menu.entry + this@SubMenuComponent.styling) {
+            button(styles.entry + this@SubMenuComponent.styling) {
                 this@SubMenuComponent.icon.value?.let {
-                    icon(Theme().menu.icon) { def(it(Theme().icons)) }
+                    icon(styles.icon) { def(it(Theme().icons)) }
                 }
                 this@SubMenuComponent.text.value?.let { span { +it } }
                 disabled(this@SubMenuComponent.disabled.values)
@@ -145,14 +150,14 @@ open class SubMenuComponent(
                 this@SubMenuComponent.events.value.invoke(this)
             }
             div(
-                Theme().menu.sub,
+                styles.sub,
                 this@SubMenuComponent.baseClass,
                 this@SubMenuComponent.id,
                 this@SubMenuComponent.prefix
             ) {
                 className(hidden.whenever(this@SubMenuComponent.hide.data).name)
                 this@SubMenuComponent.children.forEach {
-                    it.render(this)
+                    it.render(this, styles)
                 }
             }
         }

--- a/components/src/jsMain/kotlin/dev/fritz2/components/menu/context.kt
+++ b/components/src/jsMain/kotlin/dev/fritz2/components/menu/context.kt
@@ -28,9 +28,11 @@ open class MenuContext {
      * @param styling [Style] to be applied to the underlying component
      * @param text Text to be displayed in the header
      */
-    fun header(styling: Style<BoxParams>, text: String) = MenuHeader(styling)
-        .apply { text(text) }
-        .run(::addChild)
+    fun header(styling: Style<BoxParams>, text: String) {
+        MenuHeader(styling)
+            .apply { text(text) }
+            .run(::addChild)
+    }
 
     /**
      * Configures and adds a [MenuEntry] to the menu.
@@ -47,9 +49,11 @@ open class MenuContext {
      * @param styling [Style] to be applied to the component
      * @param build Lambda to configure the component itself
      */
-    fun entry(styling: Style<BoxParams>, build: MenuEntry.() -> Unit) = MenuEntry(styling)
-        .apply(build)
-        .run(::addChild)
+    fun entry(styling: Style<BoxParams>, build: MenuEntry.() -> Unit) {
+        MenuEntry(styling)
+            .apply(build)
+            .run(::addChild)
+    }
 
     /**
      * Configures and adds a [MenuLink] to the menu.
@@ -66,9 +70,11 @@ open class MenuContext {
      * @param styling [Style] to be applied to the component
      * @param build Lambda to configure the component itself
      */
-    fun link(styling: Style<BoxParams>, build: MenuLink.() -> Unit) = MenuLink(styling)
-        .apply(build)
-        .run(::addChild)
+    fun link(styling: Style<BoxParams>, build: MenuLink.() -> Unit) {
+        MenuLink(styling)
+            .apply(build)
+            .run(::addChild)
+    }
 
     /**
      * Adds a custom fritz2-component to the menu.
@@ -83,16 +89,18 @@ open class MenuContext {
      * @param styling [Style] to be applied to the component
      * @param build Lambda containing the layout to render
      */
-    fun custom(styling: Style<BoxParams>, build: RenderContext.() -> Unit) = CustomMenuEntry(styling)
-        .apply { content(build) }
-        .run(::addChild)
+    fun custom(styling: Style<BoxParams>, build: RenderContext.() -> Unit) {
+        CustomMenuEntry(styling)
+            .apply { content(build) }
+            .run(::addChild)
+    }
 
     /**
      * Adds a [MenuDivider] to the menu.
      *
      * @param styling optional [Style] to be applied to the underlying component
      */
-    fun divider(styling: Style<BoxParams> = {}) = addChild(MenuDivider(styling))
+    fun divider(styling: Style<BoxParams> = {}) { addChild(MenuDivider(styling)) }
 
     /**
      * Creates a [submenu].

--- a/components/src/jsMain/kotlin/dev/fritz2/components/menu/entries.kt
+++ b/components/src/jsMain/kotlin/dev/fritz2/components/menu/entries.kt
@@ -5,7 +5,10 @@ import dev.fritz2.components.icon
 import dev.fritz2.components.linkButton
 import dev.fritz2.dom.HtmlTagMarker
 import dev.fritz2.dom.html.RenderContext
-import dev.fritz2.styling.*
+import dev.fritz2.styling.a
+import dev.fritz2.styling.button
+import dev.fritz2.styling.div
+import dev.fritz2.styling.hr
 import dev.fritz2.styling.params.BoxParams
 import dev.fritz2.styling.params.Style
 import dev.fritz2.styling.params.plus
@@ -141,7 +144,7 @@ open class MenuDivider(private val styling: Style<BoxParams> = {}) : MenuChild {
 
     override fun render(context: RenderContext, styles: MenuStyles) {
         context.apply {
-            div(styles.divider + this@MenuDivider.styling) { }
+            hr(styles.divider + this@MenuDivider.styling) { }
         }
     }
 }

--- a/components/src/jsMain/kotlin/dev/fritz2/components/menu/entries.kt
+++ b/components/src/jsMain/kotlin/dev/fritz2/components/menu/entries.kt
@@ -4,6 +4,8 @@ import dev.fritz2.components.foundations.*
 import dev.fritz2.components.icon
 import dev.fritz2.components.linkButton
 import dev.fritz2.dom.HtmlTagMarker
+import dev.fritz2.dom.html.A
+import dev.fritz2.dom.html.Button
 import dev.fritz2.dom.html.RenderContext
 import dev.fritz2.styling.a
 import dev.fritz2.styling.button
@@ -40,6 +42,7 @@ interface MenuChild {
 open class MenuEntry(private val styling: Style<BoxParams> = {}) :
     MenuChild,
     EventProperties<HTMLButtonElement> by EventMixin(),
+    ElementProperties<Button> by ElementMixin(),
     FormProperties by FormMixin() {
     val icon = ComponentProperty<(Icons.() -> IconDefinition)?>(null)
     val text = ComponentProperty<String?>(null)
@@ -52,6 +55,7 @@ open class MenuEntry(private val styling: Style<BoxParams> = {}) :
                 }
                 this@MenuEntry.text.value?.let { span { +it } }
                 disabled(this@MenuEntry.disabled.values)
+                this@MenuEntry.element.value.invoke(this)
                 this@MenuEntry.events.value.invoke(this)
             }
         }
@@ -71,6 +75,7 @@ open class MenuEntry(private val styling: Style<BoxParams> = {}) :
 open class MenuLink(private val styling: Style<BoxParams> = {}) :
     MenuChild,
     EventProperties<HTMLAnchorElement> by EventMixin(),
+    ElementProperties<A> by ElementMixin(),
     FormProperties by FormMixin() {
     val icon = ComponentProperty<(Icons.() -> IconDefinition)?>(null)
     val text = ComponentProperty<String?>(null)
@@ -87,6 +92,7 @@ open class MenuLink(private val styling: Style<BoxParams> = {}) :
                 this@MenuLink.href.value?.let { href(it) }
                 this@MenuLink.target.value?.let { target(it) }
                 attr("disabled", this@MenuLink.disabled.values)
+                this@MenuLink.element.value.invoke(this)
                 this@MenuLink.events.value.invoke(this)
             }
         }

--- a/components/src/jsMain/kotlin/dev/fritz2/components/menu/entries.kt
+++ b/components/src/jsMain/kotlin/dev/fritz2/components/menu/entries.kt
@@ -11,6 +11,7 @@ import dev.fritz2.styling.params.Style
 import dev.fritz2.styling.params.plus
 import dev.fritz2.styling.theme.IconDefinition
 import dev.fritz2.styling.theme.Icons
+import dev.fritz2.styling.theme.MenuStyles
 import dev.fritz2.styling.theme.Theme
 import org.w3c.dom.HTMLAnchorElement
 import org.w3c.dom.HTMLButtonElement
@@ -20,7 +21,7 @@ import org.w3c.dom.HTMLButtonElement
  */
 @HtmlTagMarker
 interface MenuChild {
-    fun render(context: RenderContext)
+    fun render(context: RenderContext, styles: MenuStyles)
 }
 
 /**
@@ -40,11 +41,11 @@ open class MenuEntry(private val styling: Style<BoxParams> = {}) :
     val icon = ComponentProperty<(Icons.() -> IconDefinition)?>(null)
     val text = ComponentProperty<String?>(null)
 
-    override fun render(context: RenderContext) {
+    override fun render(context: RenderContext, styles: MenuStyles) {
         context.apply {
-            button(Theme().menu.entry + this@MenuEntry.styling) {
+            button(styles.entry + this@MenuEntry.styling) {
                 this@MenuEntry.icon.value?.let {
-                    icon(Theme().menu.icon) { def(it(Theme().icons)) }
+                    icon(styles.icon) { def(it(Theme().icons)) }
                 }
                 this@MenuEntry.text.value?.let { span { +it } }
                 disabled(this@MenuEntry.disabled.values)
@@ -73,11 +74,11 @@ open class MenuLink(private val styling: Style<BoxParams> = {}) :
     val href = ComponentProperty<String?>(null)
     val target = ComponentProperty<String?>(null)
 
-    override fun render(context: RenderContext) {
+    override fun render(context: RenderContext, styles: MenuStyles) {
         context.apply {
-            a(Theme().menu.entry + this@MenuLink.styling) {
+            a(styles.entry + this@MenuLink.styling) {
                 this@MenuLink.icon.value?.let {
-                    icon(Theme().menu.icon) { def(it(Theme().icons)) }
+                    icon(styles.icon) { def(it(Theme().icons)) }
                 }
                 this@MenuLink.text.value?.let { span { +it } }
                 this@MenuLink.href.value?.let { href(it) }
@@ -98,9 +99,9 @@ open class MenuLink(private val styling: Style<BoxParams> = {}) :
 open class CustomMenuEntry(private val styling: Style<BoxParams> = {}) : MenuChild {
     val content = ComponentProperty<RenderContext.() -> Unit> { }
 
-    override fun render(context: RenderContext) {
+    override fun render(context: RenderContext, styles: MenuStyles) {
         context.apply {
-            div(Theme().menu.custom + this@CustomMenuEntry.styling) {
+            div(styles.custom + this@CustomMenuEntry.styling) {
                 this@CustomMenuEntry.content.value(this)
             }
         }
@@ -119,9 +120,9 @@ open class MenuHeader(private val styling: Style<BoxParams> = {}) : MenuChild {
 
     val text = ComponentProperty("")
 
-    override fun render(context: RenderContext) {
+    override fun render(context: RenderContext, styles: MenuStyles) {
         context.apply {
-            div(Theme().menu.header + this@MenuHeader.styling) {
+            div(styles.header + this@MenuHeader.styling) {
                 +this@MenuHeader.text.value
             }
         }
@@ -138,9 +139,9 @@ open class MenuHeader(private val styling: Style<BoxParams> = {}) : MenuChild {
  */
 open class MenuDivider(private val styling: Style<BoxParams> = {}) : MenuChild {
 
-    override fun render(context: RenderContext) {
+    override fun render(context: RenderContext, styles: MenuStyles) {
         context.apply {
-            div(Theme().menu.divider + this@MenuDivider.styling) { }
+            div(styles.divider + this@MenuDivider.styling) { }
         }
     }
 }

--- a/components/src/jsMain/kotlin/dev/fritz2/components/radios/componentSingle.kt
+++ b/components/src/jsMain/kotlin/dev/fritz2/components/radios/componentSingle.kt
@@ -138,6 +138,8 @@ open class RadioComponent(protected val value: Store<Boolean>? = null) :
         return with(context) {
             label({
                 this@RadioComponent.size.value.invoke(Theme().radio.sizes)()
+                // to "capture" the invisible, absolute positioned `input`, see `radioInputStaticCss`
+                position { relative {  } }
             }, baseClass = baseClass, id = id, prefix = prefix) {
                 inputId?.let {
                     `for`(inputId)

--- a/components/src/jsMain/kotlin/dev/fritz2/components/switch/component.kt
+++ b/components/src/jsMain/kotlin/dev/fritz2/components/switch/component.kt
@@ -120,6 +120,8 @@ open class SwitchComponent(protected val value: Store<Boolean>? = null) :
         return with(context) {
             label({
                 this@SwitchComponent.size.value.invoke(Theme().switch.sizes)()
+                // to "capture" the invisible, absolute positioned `input`, see `switchInputStaticCss`
+                position { relative {  } }
             }, baseClass = baseClass, id = id, prefix = prefix) {
                 `for`(inputId)
                 input({

--- a/components/src/jsMain/kotlin/dev/fritz2/components/toast/component.kt
+++ b/components/src/jsMain/kotlin/dev/fritz2/components/toast/component.kt
@@ -345,7 +345,8 @@ open class AlertToastComponent : ToastComponentBase() {
                     stacking { toast }
                 }
 
-            this@AlertToastComponent.closeButtonStyle(Theme().toast.closeButton.close + {
+            this@AlertToastComponent.closeButtonStyle {
+                Theme().toast.closeButton.close
                 color {
                     val colorScheme = alertComponent.severity.value(Theme().alert.severities).colorScheme
                     when (alertComponent.variant.value(AlertComponent.VariantContext)) {
@@ -355,7 +356,7 @@ open class AlertToastComponent : ToastComponentBase() {
                         else -> colorScheme.mainContrast
                     }
                 }
-            })
+            }
 
             alertComponent.render(this, styling, baseClass, id, prefix)
         }

--- a/core/src/jsMain/kotlin/dev/fritz2/binding/store.kt
+++ b/core/src/jsMain/kotlin/dev/fritz2/binding/store.kt
@@ -1,5 +1,6 @@
 package dev.fritz2.binding
 
+import dev.fritz2.dom.html.WithJob
 import dev.fritz2.identification.RootInspector
 import dev.fritz2.lenses.Lens
 import dev.fritz2.lenses.Lenses

--- a/styling/src/jsMain/kotlin/dev/fritz2/styling/theme/default.kt
+++ b/styling/src/jsMain/kotlin/dev/fritz2/styling/theme/default.kt
@@ -2199,7 +2199,6 @@ open class DefaultTheme : Theme {
         override val menu: MenuStyles = object : MenuStyles {
             // base css for all menu children ('entry' uses special styling though)
             private val base: Style<BasicParams> = {
-                width { "calc(100% - ${sizes.normal} * 2)" }
                 margins {
                     horizontal { normal }
                     vertical { smaller }
@@ -2207,35 +2206,35 @@ open class DefaultTheme : Theme {
             }
 
             override val container: Style<BasicParams> = {
-                minWidth { "50px" }
-                maxWidth { maxContent }
+                color { sidebarColor.mainContrast }
                 paddings {
                     vertical { smaller }
                 }
-                background { color { "red" } }
             }
 
             override val sub: Style<BoxParams> = {
-                paddings {
-                    left { normal }
+                children("*") {
+                    paddings {
+                        left { normal }
+                    }
                 }
             }
 
             override val entry: Style<BoxParams> = {
-                width { full }
                 display { flex }
-                justifyContent { start }
-                margin { auto }
+                width { full }
+                alignItems { center }
+                textAlign { "start" }
                 paddings {
-                    horizontal { normal }
+                    horizontal { small }
                     vertical { smaller }
                 }
-                radius { "6px" }
+                radius { normal }
                 css("transition: 0.4s")
                 css("user-select: none")
 
                 hover {
-                    background { color { primary.highlight } }
+                    background { color { sidebarColor.highlight } }
                 }
 
                 disabled {
@@ -2246,7 +2245,7 @@ open class DefaultTheme : Theme {
 
             override val header: Style<BasicParams> = {
                 base()
-                color { secondary.main }
+                color { headerColor.main }
                 fontWeight { bold }
                 css("white-space: nowrap")
             }
@@ -2254,7 +2253,7 @@ open class DefaultTheme : Theme {
             override val divider: Style<BasicParams> = {
                 base()
                 height { "1px" }
-                background { color { gray300 } }
+                background { color { sidebarColor.highlightContrast } }
             }
 
             override val custom: Style<BasicParams> = {

--- a/styling/src/jsMain/kotlin/dev/fritz2/styling/theme/default.kt
+++ b/styling/src/jsMain/kotlin/dev/fritz2/styling/theme/default.kt
@@ -2105,7 +2105,7 @@ open class DefaultTheme : Theme {
         val sidebarColor: ColorScheme
             get() = colors.tertiary
 
-        val mainColor: ColorScheme
+        val contentColor: ColorScheme
             get() = colors.neutral
 
         val tabsColor: ColorScheme
@@ -2155,10 +2155,10 @@ open class DefaultTheme : Theme {
             background { color { headerColor.main } }
         }
 
-        override val main: Style<BasicParams> = {
+        override val content: Style<BasicParams> = {
             padding { normal }
-            background { color { mainColor.main } }
-            color { mainColor.mainContrast }
+            background { color { contentColor.main } }
+            color { contentColor.mainContrast }
         }
 
         override val tablist: Style<FlexParams> = {

--- a/styling/src/jsMain/kotlin/dev/fritz2/styling/theme/default.kt
+++ b/styling/src/jsMain/kotlin/dev/fritz2/styling/theme/default.kt
@@ -2111,7 +2111,7 @@ open class DefaultTheme : Theme {
 
         override val headerHeight: Property = "3.6rem"
         override val complementaryMinHeight: Property = "2.8rem"
-        override val sidebarWidth: Property = "22vw"
+        override val sidebarWidth: Property = "15vw"
         override val mobileSidebarWidth: Property = "85vw"
 
         override val brand: Style<FlexParams> = {

--- a/styling/src/jsMain/kotlin/dev/fritz2/styling/theme/default.kt
+++ b/styling/src/jsMain/kotlin/dev/fritz2/styling/theme/default.kt
@@ -2131,6 +2131,10 @@ open class DefaultTheme : Theme {
             minWidth { "22vw" }
         }
 
+        override val sidebarClose: Style<BasicParams> = {
+            color { brandColor.mainContrast }
+        }
+
         override val navigation: Style<BasicParams> = {
             width { full }
             paddings {

--- a/styling/src/jsMain/kotlin/dev/fritz2/styling/theme/default.kt
+++ b/styling/src/jsMain/kotlin/dev/fritz2/styling/theme/default.kt
@@ -2195,6 +2195,76 @@ open class DefaultTheme : Theme {
             background { color { "rgba(0,0,0,0.8)" } }
             css("transition: opacity .3s ease-in;")
         }
+
+        override val menu: MenuStyles = object : MenuStyles {
+            // base css for all menu children ('entry' uses special styling though)
+            private val base: Style<BasicParams> = {
+                width { "calc(100% - ${sizes.normal} * 2)" }
+                margins {
+                    horizontal { normal }
+                    vertical { smaller }
+                }
+            }
+
+            override val container: Style<BasicParams> = {
+                minWidth { "50px" }
+                maxWidth { maxContent }
+                paddings {
+                    vertical { smaller }
+                }
+                background { color { "red" } }
+            }
+
+            override val sub: Style<BoxParams> = {
+                paddings {
+                    left { normal }
+                }
+            }
+
+            override val entry: Style<BoxParams> = {
+                width { full }
+                display { flex }
+                justifyContent { start }
+                margin { auto }
+                paddings {
+                    horizontal { normal }
+                    vertical { smaller }
+                }
+                radius { "6px" }
+                css("transition: 0.4s")
+                css("user-select: none")
+
+                hover {
+                    background { color { primary.highlight } }
+                }
+
+                disabled {
+                    opacity { "0.4" }
+                    css("cursor: not-allowed")
+                }
+            }
+
+            override val header: Style<BasicParams> = {
+                base()
+                color { secondary.main }
+                fontWeight { bold }
+                css("white-space: nowrap")
+            }
+
+            override val divider: Style<BasicParams> = {
+                base()
+                height { "1px" }
+                background { color { gray300 } }
+            }
+
+            override val custom: Style<BasicParams> = {
+                base()
+            }
+
+            override val icon: Style<BasicParams> = {
+                margins { right { smaller } }
+            }
+        }
     }
 
 

--- a/styling/src/jsMain/kotlin/dev/fritz2/styling/theme/default.kt
+++ b/styling/src/jsMain/kotlin/dev/fritz2/styling/theme/default.kt
@@ -2111,6 +2111,7 @@ open class DefaultTheme : Theme {
 
         override val headerHeight: Property = "3.6rem"
         override val complementaryMinHeight: Property = "2.8rem"
+        override val sidebarWidth: Property = "22vw"
         override val mobileSidebarWidth: Property = "85vw"
 
         override val brand: Style<FlexParams> = {
@@ -2126,7 +2127,6 @@ open class DefaultTheme : Theme {
         override val sidebar: Style<BasicParams> = {
             background { color { sidebarColor.main } }
             color { sidebarColor.mainContrast }
-            minWidth { "22vw" }
         }
 
         override val sidebarClose: Style<BasicParams> = {

--- a/styling/src/jsMain/kotlin/dev/fritz2/styling/theme/default.kt
+++ b/styling/src/jsMain/kotlin/dev/fritz2/styling/theme/default.kt
@@ -2052,8 +2052,7 @@ open class DefaultTheme : Theme {
 
         override val divider: Style<BasicParams> = {
             base()
-            height { "1px" }
-            background { color { gray300 } }
+            opacity { "0.6" }
         }
 
         override val custom: Style<BasicParams> = {
@@ -2061,7 +2060,10 @@ open class DefaultTheme : Theme {
         }
 
         override val icon: Style<BasicParams> = {
-            margins { right { smaller } }
+            margins {
+                right { smaller }
+                top { "1px" }
+            }
         }
     }
 
@@ -2199,8 +2201,8 @@ open class DefaultTheme : Theme {
         override val menu: MenuStyles = object : MenuStyles {
             // base css for all menu children ('entry' uses special styling though)
             private val base: Style<BasicParams> = {
-                margins {
-                    horizontal { normal }
+                paddings {
+                    horizontal { small }
                     vertical { smaller }
                 }
             }
@@ -2218,17 +2220,19 @@ open class DefaultTheme : Theme {
                         left { normal }
                     }
                 }
+                children("hr") {
+                    margins {
+                        left { large }
+                    }
+                }
             }
 
             override val entry: Style<BoxParams> = {
+                base()
                 display { flex }
                 width { full }
                 alignItems { center }
                 textAlign { "start" }
-                paddings {
-                    horizontal { small }
-                    vertical { smaller }
-                }
                 radius { normal }
                 css("transition: 0.4s")
                 css("user-select: none")
@@ -2244,16 +2248,24 @@ open class DefaultTheme : Theme {
             }
 
             override val header: Style<BasicParams> = {
-                base()
+                margins {
+                    horizontal { smaller }
+                    vertical { small }
+                }
                 color { headerColor.main }
                 fontWeight { bold }
                 css("white-space: nowrap")
             }
 
             override val divider: Style<BasicParams> = {
-                base()
-                height { "1px" }
-                background { color { sidebarColor.highlightContrast } }
+                margins {
+                    horizontal { smaller }
+                    vertical { smaller }
+                }
+                border {
+                    color { colors.gray500 }
+                }
+                opacity { "0.6" }
             }
 
             override val custom: Style<BasicParams> = {

--- a/styling/src/jsMain/kotlin/dev/fritz2/styling/theme/default.kt
+++ b/styling/src/jsMain/kotlin/dev/fritz2/styling/theme/default.kt
@@ -2250,6 +2250,9 @@ open class DefaultTheme : Theme {
             }
 
             override val header: Style<BasicParams> = {
+                not(":first-child") {
+                    paddings { top { huge } }
+                }
                 margins {
                     horizontal { smaller }
                     vertical { small }

--- a/styling/src/jsMain/kotlin/dev/fritz2/styling/theme/default.kt
+++ b/styling/src/jsMain/kotlin/dev/fritz2/styling/theme/default.kt
@@ -2034,6 +2034,7 @@ open class DefaultTheme : Theme {
             css("user-select: none")
 
             hover {
+                color { primary.highlightContrast }
                 background { color { primary.highlight } }
             }
 
@@ -2238,6 +2239,7 @@ open class DefaultTheme : Theme {
                 css("user-select: none")
 
                 hover {
+                    color { sidebarColor.highlightContrast }
                     background { color { sidebarColor.highlight } }
                 }
 
@@ -2252,7 +2254,7 @@ open class DefaultTheme : Theme {
                     horizontal { smaller }
                     vertical { small }
                 }
-                color { headerColor.main }
+                color { sidebarColor.highlightContrast }
                 fontWeight { bold }
                 css("white-space: nowrap")
             }

--- a/styling/src/jsMain/kotlin/dev/fritz2/styling/theme/definitions.kt
+++ b/styling/src/jsMain/kotlin/dev/fritz2/styling/theme/definitions.kt
@@ -749,6 +749,7 @@ interface AppFrameStyles {
     val main: Style<BasicParams>
     val tablist: Style<FlexParams>
     val backdrop: Style<BasicParams>
+    val menu: MenuStyles
 }
 
 interface DataTableStyles {

--- a/styling/src/jsMain/kotlin/dev/fritz2/styling/theme/definitions.kt
+++ b/styling/src/jsMain/kotlin/dev/fritz2/styling/theme/definitions.kt
@@ -739,6 +739,7 @@ interface AppFrameStyles {
     val mobileSidebarWidth: Property
     val brand: Style<FlexParams>
     val sidebar: Style<BasicParams>
+    val sidebarClose: Style<BasicParams>
     val navigation: Style<BasicParams>
     val complementary: Style<BasicParams>
     val header: Style<FlexParams>

--- a/styling/src/jsMain/kotlin/dev/fritz2/styling/theme/definitions.kt
+++ b/styling/src/jsMain/kotlin/dev/fritz2/styling/theme/definitions.kt
@@ -736,6 +736,7 @@ interface NavBarStyles {
 interface AppFrameStyles {
     val headerHeight: Property
     val complementaryMinHeight: Property
+    val sidebarWidth: Property
     val mobileSidebarWidth: Property
     val brand: Style<FlexParams>
     val sidebar: Style<BasicParams>

--- a/styling/src/jsMain/kotlin/dev/fritz2/styling/theme/definitions.kt
+++ b/styling/src/jsMain/kotlin/dev/fritz2/styling/theme/definitions.kt
@@ -742,7 +742,7 @@ interface AppFrameStyles {
     val navigation: Style<BasicParams>
     val complementary: Style<BasicParams>
     val header: Style<FlexParams>
-    val main: Style<BasicParams>
+    val content: Style<BasicParams>
     val tablist: Style<FlexParams>
     val backdrop: Style<BasicParams>
     val menu: MenuStyles


### PR DESCRIPTION
The `appFrame` component uses now different `ColorScheme`s to coloring itself.

The `menu` component can now contain `submenu`s:
```kotlin
menu {
    header("Entries")
    entry {
        text("Basic entry")
    }
    divider()
    custom {
        pushButton {
            text("I'm a custom entry")
        }
    }
    submenu {
        icon { menu }
        text("Sub Menu")
        entry {
            icon { sun }
            text("Entry with icon")
        }
        entry {
            icon { ban }
            text("Disabled entry")
            disabled(true)
        }
    }
}
```