### PR TITLE
Rework `ToastComponent`

### DIFF
--- a/components/src/jsMain/kotlin/dev/fritz2/components/toast.kt
+++ b/components/src/jsMain/kotlin/dev/fritz2/components/toast.kt
@@ -220,7 +220,7 @@ abstract class ToastComponentBase : ManagedComponent<Unit>,
                 )
             }, baseClass, id, prefix) {
                 div({
-                    Theme().toast.toast()
+                    Theme().toast.body()
                     background { color(this@ToastComponentBase.background.value) }
                     styling()
                 }) {

--- a/components/src/jsMain/kotlin/dev/fritz2/components/toast.kt
+++ b/components/src/jsMain/kotlin/dev/fritz2/components/toast.kt
@@ -160,7 +160,8 @@ abstract class ToastComponentBase : ManagedComponent<Unit>,
                         ToastStore.data
                             .map { toasts ->
                                 toasts.filter { toast -> toast.placement == it }
-                            }.map { toasts ->
+                            }
+                            .map { toasts ->
                                 /*
                                 New toasts should always be stacked on existing ones, which naturally depends on the
                                 basic placement:
@@ -168,8 +169,7 @@ abstract class ToastComponentBase : ManagedComponent<Unit>,
                                 - bottom: the new toast must be rendered *above* the existing ones (reverse order
                                           needed)
                                  */
-                                if (Placement.appearsFromBottom(toasts)
-                                ) {
+                                if (Placement.appearsFromBottom(toasts)) {
                                     toasts.asReversed()
                                 } else {
                                     toasts
@@ -226,9 +226,8 @@ abstract class ToastComponentBase : ManagedComponent<Unit>,
                 }) {
                     this@ToastComponentBase.renderContent(this, styling, baseClass, id, prefix)
                     if (this@ToastComponentBase.hasCloseButton.value) {
-                        this@ToastComponentBase.closeButtonRendering.value(this).map {
-                            localId
-                        } handledBy ToastStore.remove
+                        this@ToastComponentBase.closeButtonRendering.value(this)
+                            .map { localId } handledBy ToastStore.remove
                     }
                 }
             }
@@ -280,13 +279,7 @@ open class ToastComponent : ToastComponentBase() {
         prefix: String
     ) {
         context.apply {
-            this@ToastComponent.content.value?.let {
-                div({
-                    css("flex: 1 1 0%;")
-                }) {
-                    it.invoke(this)
-                }
-            }
+            this@ToastComponent.content.value?.invoke(this)
         }
     }
 }
@@ -389,9 +382,7 @@ fun showToast(
     id: String? = null,
     prefix: String = "toast",
     build: ToastComponent.() -> Unit
-) {
-    ToastComponent().apply(build).render(styling, baseClass, id, prefix)
-}
+) = ToastComponent().apply(build).render(styling, baseClass, id, prefix)
 
 /**
  * This factory method creates a toast that will be shown when the returned handler is triggered, eg. on a button press.
@@ -467,9 +458,7 @@ fun showAlertToast(
     id: String? = null,
     prefix: String = "toast-alert",
     build: AlertToastComponent.() -> Unit
-) {
-    AlertToastComponent().apply(build).render(styling, baseClass, id, prefix)
-}
+) = AlertToastComponent().apply(build).render(styling, baseClass, id, prefix)
 
 /**
  * This factory method creates a toast with an alert as it's content that will be shown when the returned handler is

--- a/components/src/jsMain/kotlin/dev/fritz2/components/toast.kt
+++ b/components/src/jsMain/kotlin/dev/fritz2/components/toast.kt
@@ -2,15 +2,14 @@ package dev.fritz2.components
 
 import dev.fritz2.binding.RootStore
 import dev.fritz2.binding.SimpleHandler
-import dev.fritz2.components.ToastComponent.Companion.closeAllToasts
-import dev.fritz2.components.ToastComponent.Companion.closeLastToast
-import dev.fritz2.components.ToastComponentBase.Companion.closeAllToasts
-import dev.fritz2.components.ToastComponentBase.Companion.closeLastToast
 import dev.fritz2.dom.html.Li
 import dev.fritz2.dom.html.RenderContext
 import dev.fritz2.identification.uniqueId
 import dev.fritz2.styling.*
-import dev.fritz2.styling.params.*
+import dev.fritz2.styling.params.BasicParams
+import dev.fritz2.styling.params.BoxParams
+import dev.fritz2.styling.params.ColorProperty
+import dev.fritz2.styling.params.plus
 import dev.fritz2.styling.theme.Colors
 import dev.fritz2.styling.theme.Theme
 import kotlinx.coroutines.*
@@ -42,7 +41,6 @@ abstract class ToastComponentBase : ManagedComponent<Unit>,
     )
 
     object Placement {
-
         const val bottom = "bottom"
         const val bottomLeft = "bottomLeft"
         const val bottomRight = "bottomRight"
@@ -73,7 +71,6 @@ abstract class ToastComponentBase : ManagedComponent<Unit>,
     }
 
     object ToastStore : RootStore<List<ToastFragment>>(listOf(), id = "toast-store") {
-
         val add = handle<ToastFragment> { allToasts, newToast ->
             allToasts + newToast
         }
@@ -128,9 +125,7 @@ abstract class ToastComponentBase : ManagedComponent<Unit>,
         }
     }
 
-
     companion object : CloseMethodCompanion() {
-
         private val toastContainerStaticCss = staticStyle(
             "toastContainer",
             """
@@ -140,33 +135,6 @@ abstract class ToastComponentBase : ManagedComponent<Unit>,
                flex-direction: column;
                """
         )
-
-        private val listStyle: Style<BasicParams> = {
-            display { flex }
-            css("transform-origin: 50% 50% 0px;")
-            css("flex-direction: column;")
-            opacity { "1" }
-            css("transition: opacity 1s ease-in-out;")
-            overflow { auto }
-        }
-
-        private val toastStyle: Style<BasicParams> = {
-            display { flex }
-            css("flex-direction: row")
-            position { relative { } }
-            overflow { hidden }
-
-            maxWidth { "560px" }
-            minWidth { "300px" }
-
-            margin { "0.5rem" }
-            radius { "0.375rem" }
-
-            css("pointer-events: auto;")
-            css("-webkit-box-align: start;")
-            css("align-items: start;")
-            css("box-shadow: rgba(0, 0, 0, 0.1) 0px 10px 15px -3px, rgba(0, 0, 0, 0.05) 0px 4px 6px -2px;")
-        }
 
         private val job = Job()
         private val globalId = "f2c-toasts-${randomId()}"
@@ -245,17 +213,15 @@ abstract class ToastComponentBase : ManagedComponent<Unit>,
             placement.value(Placement)
         ) {
             li({
-                listStyle()
+                Theme().toast.list()
                 Theme().toast.alignment(
                     this,
                     Placement.alignmentOf(this@ToastComponentBase.placement.value(Placement))
                 )
             }, baseClass, id, prefix) {
                 div({
-                    Theme().toast.base()
-                    toastStyle()
+                    Theme().toast.toast()
                     background { color(this@ToastComponentBase.background.value) }
-                    alignItems { center }
                     styling()
                 }) {
                     this@ToastComponentBase.renderContent(this, styling, baseClass, id, prefix)

--- a/styling/src/jsMain/kotlin/dev/fritz2/styling/theme/default.kt
+++ b/styling/src/jsMain/kotlin/dev/fritz2/styling/theme/default.kt
@@ -1578,9 +1578,32 @@ open class DefaultTheme : Theme {
     }
 
     override val toast = object : ToastStyles {
-        override val base: Style<BasicParams> = {
+        override val toast: Style<BoxParams> = {
+            position { relative { } }
+            display { flex }
+            direction { row }
+            alignItems { center }
+
+            maxWidth { "560px" }
+            minWidth { giant }
             minHeight { giant }
+            overflow { hidden }
+            margin { smaller }
+            radius { normal }
+            boxShadow { raised }
+
+            css("pointer-events: auto;")
+            css("-webkit-box-align: start;")
         }
+
+        override val list: Style<BoxParams> = {
+            display { flex }
+            direction { column }
+            overflow { visible }
+
+            css("transform-origin: 50% 50% 0px;")
+        }
+
         override val placement = object : ToastPlacement {
             override val top: Style<BasicParams> = {
                 css("top:0px")
@@ -1639,6 +1662,7 @@ open class DefaultTheme : Theme {
             }
 
         }
+
         override val closeButton = object : ToastButton {
             override val close: Style<BasicParams> = {
                 position {

--- a/styling/src/jsMain/kotlin/dev/fritz2/styling/theme/default.kt
+++ b/styling/src/jsMain/kotlin/dev/fritz2/styling/theme/default.kt
@@ -1578,7 +1578,7 @@ open class DefaultTheme : Theme {
     }
 
     override val toast = object : ToastStyles {
-        override val toast: Style<BoxParams> = {
+        override val body: Style<BoxParams> = {
             position { relative { } }
             display { flex }
             direction { row }

--- a/styling/src/jsMain/kotlin/dev/fritz2/styling/theme/definitions.kt
+++ b/styling/src/jsMain/kotlin/dev/fritz2/styling/theme/definitions.kt
@@ -653,9 +653,10 @@ interface AlertVariants {
  * definition of the theme's toasts
  */
 interface ToastStyles {
-    val base: Style<BasicParams>
-    val placement: ToastPlacement
+    val toast: Style<BoxParams>
+    val list: Style<BoxParams>
 
+    val placement: ToastPlacement
     /**
      * Styling to align the messages according to their horizontal position.
      * Possible values to react are `left`, `center` and `right`.

--- a/styling/src/jsMain/kotlin/dev/fritz2/styling/theme/definitions.kt
+++ b/styling/src/jsMain/kotlin/dev/fritz2/styling/theme/definitions.kt
@@ -653,7 +653,7 @@ interface AlertVariants {
  * definition of the theme's toasts
  */
 interface ToastStyles {
-    val toast: Style<BoxParams>
+    val body: Style<BoxParams>
     val list: Style<BoxParams>
 
     val placement: ToastPlacement


### PR DESCRIPTION
### Changes

This PR cleans up the `ToastComponent` code. This includes:
- Adding styling-options to the theme
- Use correct z-indizes
- General code-cleanup

---

### What's API breaking?

- `Theme().toast.base` has been renamed to `Theme().toast.body` and might break themes that have custom toast-styles

---

Closes #388 .
Closes #396 .