### PR TITLE
Move Modal's close handler into content property

### DIFF
--- a/components/src/jsMain/kotlin/dev/fritz2/components/modal.kt
+++ b/components/src/jsMain/kotlin/dev/fritz2/components/modal.kt
@@ -43,5 +43,5 @@ fun modal(
     baseClass: StyleClass = StyleClass.None,
     id: String? = null,
     prefix: String = "modal",
-    build: ModalComponent.(SimpleHandler<Unit>) -> Unit
-): SimpleHandler<Unit> = ModalComponent(build).render(styling, baseClass, id, prefix)
+    build: ModalComponent.() -> Unit
+): SimpleHandler<Unit> = ModalComponent().apply(build).render(styling, baseClass, id, prefix)

--- a/components/src/jsMain/kotlin/dev/fritz2/components/modal/component.kt
+++ b/components/src/jsMain/kotlin/dev/fritz2/components/modal/component.kt
@@ -85,7 +85,7 @@ class DefaultOverlay(
  * The content and structure within the modal are completely free to model. Further more there are predefined styles
  * to easily choose a fitting size or to choose some other variants of appearance. Last but not least there is a simple
  * closeButton predefined that automatically closes the modal. Of course the closing mechanism is free to be applied
- * with a custom solution, as a [SimpleHandler<Unit>] is injected as parameter into the [build] expression.
+ * with a custom solution, as a [SimpleHandler<Unit>] is injected as parameter into the [content] property.
  *
  * The modal can be configured for the following aspects:
  *
@@ -109,9 +109,9 @@ class DefaultOverlay(
  * // apply custom close button
  * clickButton {
  *     text("Open")
- * } handledBy modal { closeHandler -> // SimpleHandler<Unit> is injected by default
+ * } handledBy modal {
  *     hasCloseButton(false) // disable the integrated close button
- *     content {
+ *     content { closeHandler -> // SimpleHandler<Unit> is injected by default
  *         p { +"Hello world from a modal!" }
  *         p { +"Please click the X to close this..." }
  *         clickButton { text("Close") } handledBy closeHandler // define a custom button that uses the close handler
@@ -135,7 +135,7 @@ class DefaultOverlay(
  *
  * For a detailed understanding have a look the ``ModalComponent.Companion.init`` block.
  */
-open class ModalComponent(protected val build: ModalComponent.(SimpleHandler<Unit>) -> Unit) :
+open class ModalComponent :
     ManagedComponent<SimpleHandler<Unit>>,
     CloseButtonProperty by CloseButtonMixin("modal-close-button", {
         position {
@@ -199,7 +199,7 @@ open class ModalComponent(protected val build: ModalComponent.(SimpleHandler<Uni
 
     }
 
-    val content = ComponentProperty<(RenderContext.() -> Unit)?>(null)
+    val content = ComponentProperty<(RenderContext.(SimpleHandler<Unit>) -> Unit)?>(null)
 
     @Deprecated(message = "Use width property instead.")
     val size = ComponentProperty<(ModalSizes.() -> Style<BasicParams>)?>(null)
@@ -253,7 +253,6 @@ open class ModalComponent(protected val build: ModalComponent.(SimpleHandler<Uni
         prefix: String
     ): SimpleHandler<Unit> {
         val close = stack.pop
-        val component = this.apply { build(close) }
 
         val modal: ModalRenderContext = { level ->
             flexBox({
@@ -266,36 +265,39 @@ open class ModalComponent(protected val build: ModalComponent.(SimpleHandler<Uni
                 }
                 width { "100vw" }
                 height { "100vh" }
-                if (PlacementContext.externalScrollingPossible(component.placement.value(PlacementContext))) {
+                if (PlacementContext.externalScrollingPossible(this@ModalComponent.placement.value(PlacementContext))) {
                     overflow { auto }
                 }
                 justifyContent { center }
-                alignItems { PlacementContext.flexValueOf(component.placement.value(PlacementContext)) }
+                alignItems { PlacementContext.flexValueOf(this@ModalComponent.placement.value(PlacementContext)) }
             }) {
                 div({
                     css("--modal-level: ${level}rem;")
                     zIndex { modal(level, 1) }
                     position { relative { } }
                     Theme().modal.base()
-                    if (component.size.value != null) {
+                    if (this@ModalComponent.size.value != null) {
                         // TODO: remove if-branch when ``size`` gets removed; keep only else body!
-                        component.size.value!!.invoke(Theme().modal.sizes)()
+                        this@ModalComponent.size.value!!.invoke(Theme().modal.sizes)()
                     } else {
                         Theme().modal.width(
                             this,
-                            component.width.value(WidthContext),
-                            WidthContext.asCssWidthExpression(component.width.value(WidthContext))
+                            this@ModalComponent.width.value(WidthContext),
+                            WidthContext.asCssWidthExpression(this@ModalComponent.width.value(WidthContext))
                         )
                     }
-                    if (!PlacementContext.externalScrollingPossible(component.placement.value(PlacementContext))) {
+                    if (!PlacementContext.externalScrollingPossible(
+                            this@ModalComponent.placement.value(PlacementContext)
+                        )
+                    ) {
                         Theme().modal.internalScrolling()
                     }
                     styling(this)
                 }, baseClass, id, prefix) {
-                    if (component.hasCloseButton.value) {
-                        component.closeButtonRendering.value(this) handledBy close
+                    if (this@ModalComponent.hasCloseButton.value) {
+                        this@ModalComponent.closeButtonRendering.value(this) handledBy close
                     }
-                    component.content.value?.let { it() }
+                    this@ModalComponent.content.value?.let { it(close) }
                 }
             }
         }


### PR DESCRIPTION
Until now the `close` handler was injected directly into the main configuration scope of a modal. With repsect to [EfC 416]((#item-416-never-provide-parameters-within-components-main-context)) this is now changed. The handler only gets injected into the `content` property, where it is considered to be used.

## Migration Guide
Just move the handler parameter from the `build` expression of modal into the `content` property:
```kotlin
// old
clickButton {
    text("Custom Close Button")
} handledBy modal { close -> // injected at top level
    content { 
        clickButton {icon { logOut } } handledBy close
    }
}

// new
clickButton {
    text("Custom Close Button")
} handledBy modal {
    content { close -> // injected only within content
        clickButton {icon { logOut } } handledBy close
    }
}
```

fixes #482