### PR TITLE
Remove deprecated `direction`-api from `RadioGroupComponent` and `CheckboxGroupComponent`

### DIFF
--- a/components/src/jsMain/kotlin/dev/fritz2/components/checkboxes/componentGroup.kt
+++ b/components/src/jsMain/kotlin/dev/fritz2/components/checkboxes/componentGroup.kt
@@ -104,12 +104,9 @@ open class CheckboxGroupComponent<T>(
     OrientationProperty by OrientationMixin(Orientation.VERTICAL) {
 
     companion object {
-        // TODO: Remove ``direction`` part and therefore ``if`` branch
-        fun layoutOf(orientation: Orientation, direction: Direction): Style<BasicParams> = {
+        fun layoutOf(orientation: Orientation): Style<BasicParams> = {
             display {
-                if (direction == Direction.ROW) {
-                    inlineFlex
-                } else when (orientation) {
+                when (orientation) {
                     Orientation.HORIZONTAL -> inlineFlex
                     Orientation.VERTICAL -> inlineGrid
                 }
@@ -125,21 +122,6 @@ open class CheckboxGroupComponent<T>(
         }
     }
     val size = ComponentProperty<FormSizes.() -> Style<BasicParams>> { Theme().checkbox.sizes.normal }
-
-    enum class Direction {
-        COLUMN, ROW
-    }
-
-    object DirectionContext {
-        @Deprecated("Use orientation { vertical } instead", ReplaceWith("vertical"))
-        val column: Direction = Direction.COLUMN
-
-        @Deprecated("Use orientation { horizontal } instead", ReplaceWith("horizontal"))
-        val row: Direction = Direction.ROW
-    }
-
-    @Deprecated("Use orientation instead", ReplaceWith("orientation"))
-    val direction = ComponentProperty<DirectionContext.() -> Direction> { column }
 
     val itemStyle = ComponentProperty(Theme().checkbox.default)
     var labelStyle = ComponentProperty(Theme().checkbox.label)
@@ -164,10 +146,7 @@ open class CheckboxGroupComponent<T>(
 
         context.apply {
             div({
-                layoutOf(
-                    this@CheckboxGroupComponent.orientation.value(OrientationContext),
-                    this@CheckboxGroupComponent.direction.value(DirectionContext)
-                )()
+                layoutOf(this@CheckboxGroupComponent.orientation.value(OrientationContext))()
             }, styling, baseClass, id, prefix) {
                 (this@CheckboxGroupComponent.values?.data
                     ?: this@CheckboxGroupComponent.selectedItems.values) handledBy multiSelectionStore.update

--- a/components/src/jsMain/kotlin/dev/fritz2/components/radios/componentGroup.kt
+++ b/components/src/jsMain/kotlin/dev/fritz2/components/radios/componentGroup.kt
@@ -92,12 +92,9 @@ open class RadioGroupComponent<T>(protected val items: List<T>, protected val va
     OrientationProperty by OrientationMixin(Orientation.VERTICAL) {
 
     companion object {
-        // TODO: Remove `direction` part and therefore `if` branch
-        fun layoutOf(orientation: Orientation, direction: Direction): Style<BasicParams> = {
+        fun layoutOf(orientation: Orientation): Style<BasicParams> = {
             display {
-                if (direction == Direction.ROW) {
-                    inlineFlex
-                } else when (orientation) {
+                when (orientation) {
                     Orientation.HORIZONTAL -> inlineFlex
                     Orientation.VERTICAL -> inlineGrid
                 }
@@ -108,21 +105,6 @@ open class RadioGroupComponent<T>(protected val items: List<T>, protected val va
     val label = ComponentProperty<(item: T) -> String> { it.toString() }
     val labelRendering = ComponentProperty<Div.(item: T) -> Unit> { +this@RadioGroupComponent.label.value(it) }
     val size = ComponentProperty<FormSizes.() -> Style<BasicParams>> { Theme().radio.sizes.normal }
-
-    enum class Direction {
-        COLUMN, ROW
-    }
-
-    object DirectionContext {
-        @Deprecated("Use orientation { vertical } instead", ReplaceWith("vertical"))
-        val column: Direction = Direction.COLUMN
-
-        @Deprecated("Use orientation { horizontal } instead", ReplaceWith("horizontal"))
-        val row: Direction = Direction.ROW
-    }
-
-    @Deprecated("Use orientation instead", ReplaceWith("orientation"))
-    val direction = ComponentProperty<DirectionContext.() -> Direction> { column }
 
     val itemStyle = ComponentProperty(Theme().radio.default)
     val labelStyle = ComponentProperty(Theme().radio.label)
@@ -147,10 +129,7 @@ open class RadioGroupComponent<T>(protected val items: List<T>, protected val va
 
         context.apply {
             div({
-                RadioGroupComponent.layoutOf(
-                    this@RadioGroupComponent.orientation.value(OrientationContext),
-                    this@RadioGroupComponent.direction.value(DirectionContext)
-                )()
+                layoutOf(this@RadioGroupComponent.orientation.value(OrientationContext))()
             }, styling, baseClass, id, prefix) {
                 (this@RadioGroupComponent.value?.data ?: this@RadioGroupComponent.selectedItem.values)
                     .map { selectedItem ->


### PR DESCRIPTION
This PR removes the deprecated `direction `-api from `RadioGroupComponent` and `CheckboxGroupComponent`.
Use `orientation instead`.

---

Closes #418 .