### PR TITLE
Allow `sub()` on all `Store´s

### DIFF
--- a/components/src/jsMain/kotlin/dev/fritz2/components/datatable/context.kt
+++ b/components/src/jsMain/kotlin/dev/fritz2/components/datatable/context.kt
@@ -267,7 +267,7 @@ class ColumnsContext<T> {
             ComponentProperty<Td.(
                 value: IndexedValue<StatefulItem<T>>,
                 cellStore: Store<String>?,
-                rowStore: SubStore<List<T>, List<T>, T>
+                rowStore: SubStore<List<T>, T>
             ) -> Unit>
             { _, store, _ -> store?.data?.asText() }
     }

--- a/components/src/jsMain/kotlin/dev/fritz2/components/datatable/foundation.kt
+++ b/components/src/jsMain/kotlin/dev/fritz2/components/datatable/foundation.kt
@@ -62,7 +62,7 @@ data class Column<T>(
     val content: Td.(
         value: IndexedValue<StatefulItem<T>>,
         cellStore: Store<String>?,
-        rowStore: SubStore<List<T>, List<T>, T>
+        rowStore: SubStore<List<T>, T>
     ) -> Unit,
     val headerStyling: BasicParams.(sorting: Sorting) -> Unit = {},
     val headerContent: Div.(column: Column<T>) -> Unit

--- a/components/src/jsMain/kotlin/dev/fritz2/components/datatable/selection.kt
+++ b/components/src/jsMain/kotlin/dev/fritz2/components/datatable/selection.kt
@@ -84,7 +84,7 @@ class RowSelectionStore<T, I>(private val rowIdProvider: (T) -> I) : RootStore<L
 interface SelectionStrategy<T, I> {
     fun manageSelectionByExtraColumn(component: DataTableComponent<T, I>)
     fun manageSelectionByRowEvents(
-        component: DataTableComponent<T, I>, rowStore: SubStore<List<T>, List<T>, T>,
+        component: DataTableComponent<T, I>, rowStore: SubStore<List<T>, T>,
         renderContext: Tr
     )
 }
@@ -103,7 +103,7 @@ class NoSelection<T, I> : SelectionStrategy<T, I> {
 
     override fun manageSelectionByRowEvents(
         component: DataTableComponent<T, I>,
-        rowStore: SubStore<List<T>, List<T>, T>,
+        rowStore: SubStore<List<T>, T>,
         renderContext: Tr
     ) {
         // don't wire events -> nothing should get selected!
@@ -197,7 +197,7 @@ class SelectionByCheckBox<T, I> : SelectionStrategy<T, I> {
 
     override fun manageSelectionByRowEvents(
         component: DataTableComponent<T, I>,
-        rowStore: SubStore<List<T>, List<T>, T>,
+        rowStore: SubStore<List<T>, T>,
         renderContext: Tr
     ) {
         // don't wire events -> extra column with checkbox handles everything!
@@ -216,7 +216,7 @@ class SelectionByClick<T, I> : SelectionStrategy<T, I> {
 
     override fun manageSelectionByRowEvents(
         component: DataTableComponent<T, I>,
-        rowStore: SubStore<List<T>, List<T>, T>,
+        rowStore: SubStore<List<T>, T>,
         renderContext: Tr
     ) {
         renderContext.apply {

--- a/components/src/jsMain/kotlin/dev/fritz2/components/validation/validation.kt
+++ b/components/src/jsMain/kotlin/dev/fritz2/components/validation/validation.kt
@@ -53,8 +53,8 @@ fun <D> Store<D>.validationMessage(): Flow<ComponentValidationMessage?>? = when 
             null
         }
     }
-    is SubStore<*, *, *> -> {
-        val root = this.root
+    is SubStore<*, *> -> {
+        val root = this.findRootStore()
         if (root is WithValidator<*, *>) {
             root.validator.find { it.id == this@validationMessage.id }
         } else null
@@ -76,11 +76,23 @@ fun <D> Store<D>.validationMessages(): Flow<List<ComponentValidationMessage>>? =
             null
         }
     }
-    is SubStore<*, *, *> -> {
-        val root = this.root
+    is SubStore<*, *> -> {
+        val root = this.findRootStore()
         if (root is WithValidator<*, *>) {
             root.validator.filter { it.id == this@validationMessages.id }
         } else null
     }
     else -> null
+}
+
+/**
+ * recursively get root store of [SubStore]s
+ * @return [Store] which is the root of the [SubStore]
+ */
+private fun <P, T> SubStore<P, T>.findRootStore(): Store<*> {
+    var store: Store<*> = this
+    while (store is SubStore<*, *>) {
+        store = store.parent
+    }
+    return store
 }

--- a/core/src/jsMain/kotlin/dev/fritz2/binding/store.kt
+++ b/core/src/jsMain/kotlin/dev/fritz2/binding/store.kt
@@ -162,6 +162,16 @@ interface Store<T> : WithJob {
             if (last != it) session.send(resource.serialize(it))
         }.watch()
     }
+
+    /**
+     * create a [SubStore] that represents a certain part of your data model.
+     *
+     * @param lens: a [Lens] describing, which part of your data model you will create [SubStore] for.
+     * Use @[Lenses] annotation to let your compiler
+     * create the lenses for you or use the buildLens-factory-method.
+     */
+    fun <X> sub(lens: Lens<T, X>): SubStore<T, X> =
+        SubStore(this, lens)
 }
 
 /**
@@ -237,16 +247,6 @@ open class RootStore<T>(
      * a simple [SimpleHandler] that just takes the given action-value as the new value for the [Store].
      */
     override val update = this.handle<T> { _, newValue -> newValue }
-
-    /**
-     * create a [SubStore] that represents a certain part of your data model.
-     *
-     * @param lens: a [Lens] describing, which part of your data model you will create [SubStore] for.
-     * Use @[Lenses] annotation to let your compiler
-     * create the lenses for you or use the buildLens-factory-method.
-     */
-    fun <X> sub(lens: Lens<T, X>): SubStore<T, T, X> =
-        SubStore(this, lens, this, lens)
 }
 
 /**

--- a/core/src/jsMain/kotlin/dev/fritz2/binding/substores.kt
+++ b/core/src/jsMain/kotlin/dev/fritz2/binding/substores.kt
@@ -59,17 +59,6 @@ class SubStore<P, T>(
         lens.get(it)
     }.distinctUntilChanged()
 
-    //TODO: sharedFlow
-
-    /**
-     * the current value of the [SubStore] is derived from the data of it's parent using the given [Lens].
-     */
-//    override val value : T
-//        get() = parent.data.map {
-//        lens.get(it)
-//    }.distinctUntilChanged()
-
-
 }
 
 

--- a/core/src/jsMain/kotlin/dev/fritz2/binding/substores.kt
+++ b/core/src/jsMain/kotlin/dev/fritz2/binding/substores.kt
@@ -13,11 +13,9 @@ import kotlinx.coroutines.flow.map
  * A [Store] that is derived from your [RootStore] or another [SubStore] that represents a part of the data-model of it's parent.
  * Use the .sub-factory-method on the parent [Store] to create it.
  */
-class SubStore<R, P, T>(
-    private val parent: Store<P>,
-    private val lens: Lens<P, T>,
-    val root: Store<R>,
-    internal val rootLens: Lens<R, T>
+class SubStore<P, T>(
+    val parent: Store<P>,
+    private val lens: Lens<P, T>
 ) : Store<T> {
     /**
      * [Job] used as parent job on all coroutines started in [Handler]s in the scope of this [Store]
@@ -40,13 +38,13 @@ class SubStore<R, P, T>(
      * Since a [SubStore] is just a view on a [RootStore] holding the real value, it forwards the [Update] to it, using it's [Lens] to transform it.
      */
     override suspend fun enqueue(update: QueuedUpdate<T>) {
-        root.enqueue(QueuedUpdate({
+        parent.enqueue(QueuedUpdate({
             try {
-                rootLens.apply(it, update.update)
+                lens.apply(it, update.update)
             } catch (e: Throwable) {
-                rootLens.apply(it, { oldValue -> update.errorHandler(e, oldValue) })
+                lens.apply(it) { oldValue -> update.errorHandler(e, oldValue) }
             }
-        }, root::errorHandler))
+        }, parent::errorHandler))
     }
 
     /**
@@ -60,6 +58,7 @@ class SubStore<R, P, T>(
     override val data: Flow<T> = parent.data.map {
         lens.get(it)
     }.distinctUntilChanged()
+
     //TODO: sharedFlow
 
     /**
@@ -70,14 +69,9 @@ class SubStore<R, P, T>(
 //        lens.get(it)
 //    }.distinctUntilChanged()
 
-    /**
-     * creates a new [SubStore] using this one as it's parent.
-     *
-     * @param lens a [Lens] describing which part to create the [SubStore] for
-     */
-    fun <X> sub(lens: Lens<T, X>): SubStore<R, T, X> =
-        SubStore(this, lens, root, rootLens + lens)
+
 }
+
 
 /**
  * creates a [SubStore] using a [RootStore] as parent using a given [IdProvider].
@@ -85,9 +79,9 @@ class SubStore<R, P, T>(
  * @param element current instance of the entity to focus on
  * @param id to identify the same entity (i.e. when it's content changed)
  */
-fun <T, I> RootStore<List<T>>.sub(element: T, id: IdProvider<T, I>): SubStore<List<T>, List<T>, T> {
+fun <T, I> Store<List<T>>.sub(element: T, id: IdProvider<T, I>): SubStore<List<T>, T> {
     val lens = elementLens(element, id)
-    return SubStore(this, lens, this, lens)
+    return SubStore(this, lens)
 }
 
 /**
@@ -96,29 +90,7 @@ fun <T, I> RootStore<List<T>>.sub(element: T, id: IdProvider<T, I>): SubStore<Li
  *
  * @param index position in the list to point to
  */
-fun <T> RootStore<List<T>>.sub(index: Int): SubStore<List<T>, List<T>, T> {
+fun <T> Store<List<T>>.sub(index: Int): SubStore<List<T>, T> {
     val lens = positionLens<T>(index)
-    return SubStore(this, lens, this, lens)
-}
-
-/**
- * creates a [SubStore] using another [SubStore] as parent using a given [IdProvider].
- *
- * @param element current instance of the entity to focus on
- * @param idProvider to identify the same entity (i.e. when it's content changed)
- */
-fun <R, P, T, I> SubStore<R, P, List<T>>.sub(element: T, idProvider: IdProvider<T, I>): SubStore<R, List<T>, T> {
-    val lens = elementLens(element, idProvider)
-    return SubStore(this, lens, root, rootLens + lens)
-}
-
-/**
- * creates a [SubStore] using a [SubStore] as parent using the index in the list
- * (do not use this, if you want to manipulate the list itself (add or move elements, filter, etc.).
- *
- * @param index position in the list to point to
- */
-fun <R, P, T> SubStore<R, P, List<T>>.sub(index: Int): SubStore<R, List<T>, T> {
-    val lens = positionLens<T>(index)
-    return SubStore(this, lens, root, rootLens + lens)
+    return SubStore(this, lens)
 }

--- a/core/src/jsMain/kotlin/dev/fritz2/dom/tag.kt
+++ b/core/src/jsMain/kotlin/dev/fritz2/dom/tag.kt
@@ -233,7 +233,7 @@ open class Tag<out E : Element>(
      */
     fun <V, I> RootStore<List<V>>.renderEach(
         idProvider: IdProvider<V, I>,
-        content: RenderContext.(SubStore<List<V>, List<V>, V>) -> RenderContext
+        content: RenderContext.(SubStore<List<V>, V>) -> RenderContext
     ) {
         val jobs = mutableMapOf<Node, Job>()
 
@@ -263,7 +263,7 @@ open class Tag<out E : Element>(
      * @param content [RenderContext] for rendering the data to the DOM given a [Store] of the list's item-type
      */
     fun <V> RootStore<List<V>>.renderEach(
-        content: RenderContext.(SubStore<List<V>, List<V>, V>) -> RenderContext
+        content: RenderContext.(SubStore<List<V>, V>) -> RenderContext
     ) {
         val jobs = mutableMapOf<Node, Job>()
         mountDomNodePatch(job, domNode,
@@ -291,9 +291,9 @@ open class Tag<out E : Element>(
      * @param idProvider function to identify a unique entity in the list
      * @param content [RenderContext] for rendering the data to the DOM given a [Store] of the list's item-type
      */
-    fun <R, P, V, I> SubStore<R, P, List<V>>.renderEach(
+    fun <P, V, I> SubStore<P, List<V>>.renderEach(
         idProvider: IdProvider<V, I>,
-        content: RenderContext.(SubStore<R, List<V>, V>) -> RenderContext
+        content: RenderContext.(SubStore<List<V>, V>) -> RenderContext
     ) {
         val jobs = mutableMapOf<Node, Job>()
         mountDomNodePatch(job, domNode,
@@ -321,8 +321,8 @@ open class Tag<out E : Element>(
      *
      * @param content [RenderContext] for rendering the data to the DOM given a [Store] of the list's item-type
      */
-    fun <R, P, V> SubStore<R, P, List<V>>.renderEach(
-        content: RenderContext.(SubStore<R, List<V>, V>) -> RenderContext
+    fun <P, V> SubStore<P, List<V>>.renderEach(
+        content: RenderContext.(SubStore<List<V>, V>) -> RenderContext
     ) {
         val jobs = mutableMapOf<Node, Job>()
         mountDomNodePatch(job, domNode,

--- a/core/src/jsTest/kotlin/dev/fritz2/binding/substores.kt
+++ b/core/src/jsTest/kotlin/dev/fritz2/binding/substores.kt
@@ -32,7 +32,7 @@ class SubStoreTests {
         val store = object : RootStore<Person>(person) {}
 
         val nameSub = store.sub(nameLens)
-        val addressSub: SubStore<Person, Address> = store.sub(addressLens)
+        val addressSub = store.sub(addressLens)
         val streetSub = addressSub.sub(streetLens)
         val postalCodeSub = addressSub.sub(postalCodeLens)
         val codeSub = postalCodeSub.sub(codeLens)

--- a/core/src/jsTest/kotlin/dev/fritz2/binding/substores.kt
+++ b/core/src/jsTest/kotlin/dev/fritz2/binding/substores.kt
@@ -32,7 +32,7 @@ class SubStoreTests {
         val store = object : RootStore<Person>(person) {}
 
         val nameSub = store.sub(nameLens)
-        val addressSub: SubStore<Person, Person, Address> = store.sub(addressLens)
+        val addressSub: SubStore<Person, Address> = store.sub(addressLens)
         val streetSub = addressSub.sub(streetLens)
         val postalCodeSub = addressSub.sub(postalCodeLens)
         val codeSub = postalCodeSub.sub(codeLens)


### PR DESCRIPTION
Removes the `RootStore` dependency in the `SubStore`, so that `SubStore`s can be created by calling `sub()` function implemented in `Store` interface. Therefore it is now possible to create a `SubStore` from every `Store` object.

Because one `SubStore` generic type gets obsolete, it will break existing code, but it is easy to fix that. Just remove the first not type parameter.
```kotlin
// before
class SubStore<R, P, T> {}
// now
class SubStore<P, T> {}
```

```kotlin
// before
val addressSub: SubStore<Person, Person, Address> = store.sub(addressLens)
// now
val addressSub: SubStore<Person, Address> = store.sub(addressLens)
```