### PR TITLE
fix type of InputEvent

### DIFF
--- a/core/src/jsMain/kotlin/dev/fritz2/dom/events.kt
+++ b/core/src/jsMain/kotlin/dev/fritz2/dom/events.kt
@@ -17,7 +17,6 @@ interface EventContext<out T : Element> : WithJob, WithEvents<T>
  * Offers [DomListener]s for all DOM-events available.
  */
 interface WithEvents<out T : Element> : WithDomNode<T> {
-
     /**
      * Creates a [DomListener] on a DOM-element.
      *

--- a/core/src/jsMain/kotlin/dev/fritz2/dom/html/events.kt
+++ b/core/src/jsMain/kotlin/dev/fritz2/dom/html/events.kt
@@ -13,6 +13,10 @@ class EventType<T : Event>(val name: String)
 /**
  * Contains all javascript event types.
  * Take a look [here](https://www.w3schools.com/jsref/dom_obj_event.asp).
+ *
+ * Sometimes it is necessary to use a more generic type (like UIEvent or even Event)
+ * because the type that is offered to the listener is not always consistent
+ * (on different browsers, different actions, etc.)
  */
 object Events {
 
@@ -101,7 +105,8 @@ object Events {
     val hashchange = EventType<HashChangeEvent>("hashchange")
 
     // The event occurs when an element gets user input
-    val input = EventType<InputEvent>("input")
+    // has to use Event as type because Chrome and Safari offer Events instead of InputEvents when selecting from a datalist
+    val input = EventType<Event>("input")
 
     // The event occurs when an element is invalid
     val invalid = EventType<Event>("invalid")


### PR DESCRIPTION
because Chrome and Safari sometimes offer instances of `Event` and not(!) `InputEvent` to a listener on "input", we have to change the type of an `InputEvent` to just `Event`.
For example this is the case when selecting an entry from a datalist.