### PR TITLE
Add `TooltipComponent`

### DIFF
--- a/components/src/jsMain/kotlin/dev/fritz2/components/popup.kt
+++ b/components/src/jsMain/kotlin/dev/fritz2/components/popup.kt
@@ -11,7 +11,6 @@ import dev.fritz2.styling.params.BasicParams
  *
  * @see PopupComponent
  * @param styling a lambda expression for declaring the styling of the actual dropdown as fritz2's styling DSL
- * @param styling a lambda expression for declaring the styling of the actual dropdown as fritz2's styling DSL
  * @param baseClass optional CSS class that should be applied to the element
  * @param id the ID of element
  * @param prefix the prefix for the generated CSS class resulting in the form `$prefix-$hash`

--- a/components/src/jsMain/kotlin/dev/fritz2/components/popup/component.kt
+++ b/components/src/jsMain/kotlin/dev/fritz2/components/popup/component.kt
@@ -19,6 +19,28 @@ import org.w3c.dom.HTMLInputElement
 import org.w3c.dom.events.EventTarget
 
 /**
+ * This object offers some values for setting up the placement of some popup.
+ *
+ * Should be also used as context for custom popup based components as context for some placement property.
+ *
+ * @see [Placement]
+ */
+object PlacementContext {
+    val top = Placement.Top
+    val topStart = Placement.TopStart
+    val topEnd = Placement.TopEnd
+    val bottom = Placement.Bottom
+    val bottomStart = Placement.BottomStart
+    val bottomEnd = Placement.BottomEnd
+    val left = Placement.Left
+    val leftStart = Placement.LeftStart
+    val leftEnd = Placement.LeftEnd
+    val right = Placement.Right
+    val rightStart = Placement.RightStart
+    val rightEnd = Placement.RightEnd
+}
+
+/**
  * This component creates a popup.
  *
  * A popup should be used to position `content` like `tooltip` or `popover` automatically
@@ -102,20 +124,6 @@ open class PopupComponent :
     val content = ComponentProperty<(RenderContext.(SimpleHandler<Unit>) -> Unit)?>(null)
     val trigger = ComponentProperty<(RenderContext.(SimpleHandler<EventTarget?>, SimpleHandler<Unit>) -> Unit)?>(null)
 
-    object PlacementContext {
-        val top = Placement.Top
-        val topStart = Placement.TopStart
-        val topEnd = Placement.TopEnd
-        val bottom = Placement.Bottom
-        val bottomStart = Placement.BottomStart
-        val bottomEnd = Placement.BottomEnd
-        val left = Placement.Left
-        val leftStart = Placement.LeftStart
-        val leftEnd = Placement.LeftEnd
-        val right = Placement.Right
-        val rightStart = Placement.RightStart
-        val rightEnd = Placement.RightEnd
-    }
     val placement = ComponentProperty<PlacementContext.() -> Placement> { Placement.Top }
 
     private val popupStore = object : RootStore<TriggerInformation>(TriggerInformation()) {

--- a/components/src/jsMain/kotlin/dev/fritz2/components/tooltip.kt
+++ b/components/src/jsMain/kotlin/dev/fritz2/components/tooltip.kt
@@ -1,12 +1,49 @@
 package dev.fritz2.components
 
+import dev.fritz2.components.foundations.randomId
+import dev.fritz2.components.popper.Placement
+import dev.fritz2.components.popper.PopperComponent
+import dev.fritz2.components.tooltip.TooltipComponent
+import dev.fritz2.dom.html.RenderContext
+import dev.fritz2.styling.StyleClass
 import dev.fritz2.styling.params.BasicParams
 import dev.fritz2.styling.params.Style
 import dev.fritz2.styling.params.StyleParams
 import dev.fritz2.styling.theme.Theme
 import dev.fritz2.styling.theme.TooltipPlacements
 
+@Deprecated("since 0.12 - please use TooltipComponent")
 fun StyleParams.tooltip(vararg text: String) = Theme().tooltip.write(*text)
 
+@Deprecated("since 0.12 - please use TooltipComponent")
 fun StyleParams.tooltip(vararg text: String, tooltipPlacement: TooltipPlacements.() -> Style<BasicParams>) =
     Theme().tooltip.write(*text, tooltipPlacement = tooltipPlacement)
+
+fun RenderContext.tooltip(
+    styling: BasicParams.() -> Unit = {},
+    baseClass: StyleClass = StyleClass.None,
+    id: String = "fc2-tooltip-${randomId()}",
+    prefix: String = "tooltip",
+    build: TooltipComponent.() -> Unit
+) = TooltipComponent().apply(build).render(this, styling, baseClass, id, prefix)
+
+fun RenderContext.tooltip(
+    text: String,
+    placement: TooltipComponent.PlacementContext.() -> Placement = { Placement.Top }
+) {
+    tooltip({}) {
+        text(text)
+        placement { placement.invoke(TooltipComponent.PlacementContext) }
+    }
+}
+
+fun RenderContext.tooltip(
+    vararg text: String,
+    placement: TooltipComponent.PlacementContext.() -> Placement = { Placement.Top }
+) {
+    tooltip({}) {
+        text(*text)
+        placement { placement.invoke(TooltipComponent.PlacementContext) }
+    }
+
+}

--- a/components/src/jsMain/kotlin/dev/fritz2/components/tooltip.kt
+++ b/components/src/jsMain/kotlin/dev/fritz2/components/tooltip.kt
@@ -18,6 +18,28 @@ fun StyleParams.tooltip(vararg text: String) = Theme().tooltip.write(*text)
 fun StyleParams.tooltip(vararg text: String, tooltipPlacement: TooltipPlacements.() -> Style<BasicParams>) =
     Theme().tooltip.write(*text, tooltipPlacement = tooltipPlacement)
 
+/**
+ * This component creates a Tooltip
+ * A `tooltip` should be used to display fast information for the user.
+ * The individual `text` will be shown on hover the `RenderContext` in which be called.
+ *
+ * Example usage:
+ * ```
+ *   tooltip(text = "my Tooltip") { }
+ *
+ *   tooltip({
+ *       color { danger.mainContrast }
+ *       background {
+ *           color { danger.main }
+ *       }
+ *   }) {
+ *       text(listOf("first line, second line"))
+ *       placement { TooltipComponent.PlacementContext.bottomEnd }
+ *   }
+ * ```
+ *
+ * @see TooltipComponent
+ */
 fun RenderContext.tooltip(
     styling: BasicParams.() -> Unit = {},
     text: String? = null,
@@ -27,6 +49,17 @@ fun RenderContext.tooltip(
     build: TooltipComponent.() -> Unit
 ) = TooltipComponent(text).apply(build).render(this, styling, baseClass, id, prefix)
 
+
+/**
+ * `tooltip` convenience function
+ *
+ * Example usage:
+ * ```
+ *   tooltip("my Tooltip") { }
+ * ```
+ *
+ * @see TooltipComponent
+ */
 fun RenderContext.tooltip(
     text: String,
     build: TooltipComponent.() -> Unit
@@ -36,6 +69,16 @@ fun RenderContext.tooltip(
     }
 }
 
+/**
+ * `tooltip` convenience function
+ *
+ * Example usage:
+ * ```
+ *   tooltip("my Tooltip", "second tooltip line") { }
+ * ```
+ *
+ *  @see TooltipComponent
+ */
 fun RenderContext.tooltip(
     vararg text: String,
     build: TooltipComponent.() -> Unit

--- a/components/src/jsMain/kotlin/dev/fritz2/components/tooltip.kt
+++ b/components/src/jsMain/kotlin/dev/fritz2/components/tooltip.kt
@@ -24,8 +24,13 @@ fun StyleParams.tooltip(vararg text: String, tooltipPlacement: TooltipPlacements
  *
  * Example usage:
  * ```
- *   tooltip(text = "my Tooltip") { }
+ *   span {
+ *      +"hover me"
+ *      tooltip(text = "my Tooltip") { }
+ *   }
  *
+ *   span {
+ *   +"hover me"
  *   tooltip({
  *       color { danger.mainContrast }
  *       background {
@@ -54,8 +59,15 @@ fun RenderContext.tooltip(
  *
  * Example usage:
  * ```
- *   tooltip("my Tooltip") { }
- *   tooltip("my Tooltip") { placement { bottom } }
+ *   span {
+ *      +"hover me"
+ *      tooltip("my Tooltip") { }
+ *   }
+ *
+ *   span {
+ *      +"hover me"
+ *      tooltip("my Tooltip") { placement { bottom } }
+ *   }
  * ```
  *
  * @see TooltipComponent
@@ -74,7 +86,10 @@ fun RenderContext.tooltip(
  *
  * Example usage:
  * ```
- *   tooltip("my Tooltip", "second tooltip line") { }
+ *  span {
+ *      +"hover me"
+ *      tooltip("my Tooltip", "second tooltip line") { }
+ *  }
  * ```
  *
  *  @see TooltipComponent

--- a/components/src/jsMain/kotlin/dev/fritz2/components/tooltip.kt
+++ b/components/src/jsMain/kotlin/dev/fritz2/components/tooltip.kt
@@ -18,29 +18,25 @@ fun StyleParams.tooltip(vararg text: String, tooltipPlacement: TooltipPlacements
     Theme().tooltip.write(*text, tooltipPlacement = tooltipPlacement)
 
 /**
- * This component creates a Tooltip
+ * This factory function creates a Tooltip.
+ *
  * A `tooltip` should be used to display fast information for the user.
- * The individual `text` will be shown on hover the `RenderContext` in which be called.
+ * The individual `text` will be shown on hovering the `RenderContext`'s element in which it is called.
  *
  * Example usage:
  * ```
  *   span {
- *      +"hover me"
- *      tooltip(text = "my Tooltip") { }
- *   }
- *
- *   span {
  *   +"hover me"
- *   tooltip({
- *       color { danger.mainContrast }
- *       background {
- *           color { danger.main }
- *       }
- *   }) {
- *       text(listOf("first line, second line"))
+ *   tooltip {
+ *       text("some tooltip text")
  *       placement { bottomEnd }
  *   }
  * ```
+ *
+ * There exist also one convenience functions, that allow a terser creation! This one offers the whole freedom
+ * to provide the common component's parameters though.
+ *
+ * Especially dynamic text content (`Flow<String>`) is only possible to set up within the context itself.
  *
  * @see TooltipComponent
  */
@@ -53,9 +49,8 @@ fun RenderContext.tooltip(
     build: TooltipComponent.() -> Unit
 ) = TooltipComponent(text).apply(build).render(this, styling, baseClass, id, prefix)
 
-
 /**
- * `tooltip` convenience function
+ * `tooltip` factory function that allow a terser creation for just static text as tooltip's content.
  *
  * Example usage:
  * ```
@@ -63,36 +58,28 @@ fun RenderContext.tooltip(
  *      +"hover me"
  *      tooltip("my Tooltip") { }
  *   }
+ * ```
  *
+ * One can configure the placement too:
+ * ```
  *   span {
  *      +"hover me"
  *      tooltip("my Tooltip") { placement { bottom } }
  *   }
  * ```
  *
- * @see TooltipComponent
- */
-fun RenderContext.tooltip(
-    text: String,
-    build: TooltipComponent.() -> Unit
-) {
-    tooltip({}, text) {
-        build()
-    }
-}
-
-/**
- * `tooltip` convenience function
- *
- * Example usage:
+ * One can pass multiple text values as parameters, which will result in multi line tooltip:
  * ```
- *  span {
+ *   span {
  *      +"hover me"
- *      tooltip("my Tooltip", "second tooltip line") { }
- *  }
+ *      tooltip("first line", "second line") { }
+ *   }
  * ```
  *
- *  @see TooltipComponent
+ * @see TooltipComponent
+ *
+ * @param text the content of the tooltip; pass multiple text parameters to create multi line content
+ * @param build a lambda expression for setting up the component itself
  */
 fun RenderContext.tooltip(
     vararg text: String,

--- a/components/src/jsMain/kotlin/dev/fritz2/components/tooltip.kt
+++ b/components/src/jsMain/kotlin/dev/fritz2/components/tooltip.kt
@@ -1,8 +1,7 @@
 package dev.fritz2.components
 
 import dev.fritz2.components.foundations.randomId
-import dev.fritz2.components.popper.Placement
-import dev.fritz2.components.popper.PopperComponent
+import dev.fritz2.components.popup.Placement
 import dev.fritz2.components.tooltip.TooltipComponent
 import dev.fritz2.dom.html.RenderContext
 import dev.fritz2.styling.StyleClass
@@ -21,29 +20,28 @@ fun StyleParams.tooltip(vararg text: String, tooltipPlacement: TooltipPlacements
 
 fun RenderContext.tooltip(
     styling: BasicParams.() -> Unit = {},
+    text: String? = null,
     baseClass: StyleClass = StyleClass.None,
     id: String = "fc2-tooltip-${randomId()}",
     prefix: String = "tooltip",
     build: TooltipComponent.() -> Unit
-) = TooltipComponent().apply(build).render(this, styling, baseClass, id, prefix)
+) = TooltipComponent(text).apply(build).render(this, styling, baseClass, id, prefix)
 
 fun RenderContext.tooltip(
     text: String,
-    placement: TooltipComponent.PlacementContext.() -> Placement = { Placement.Top }
+    build: TooltipComponent.() -> Unit
 ) {
-    tooltip({}) {
-        text(text)
-        placement { placement.invoke(TooltipComponent.PlacementContext) }
+    tooltip({}, text) {
+        build()
     }
 }
 
 fun RenderContext.tooltip(
     vararg text: String,
-    placement: TooltipComponent.PlacementContext.() -> Placement = { Placement.Top }
+    build: TooltipComponent.() -> Unit
 ) {
     tooltip({}) {
+        build()
         text(*text)
-        placement { placement.invoke(TooltipComponent.PlacementContext) }
     }
-
 }

--- a/components/src/jsMain/kotlin/dev/fritz2/components/tooltip.kt
+++ b/components/src/jsMain/kotlin/dev/fritz2/components/tooltip.kt
@@ -1,7 +1,6 @@
 package dev.fritz2.components
 
 import dev.fritz2.components.foundations.randomId
-import dev.fritz2.components.popup.Placement
 import dev.fritz2.components.tooltip.TooltipComponent
 import dev.fritz2.dom.html.RenderContext
 import dev.fritz2.styling.StyleClass

--- a/components/src/jsMain/kotlin/dev/fritz2/components/tooltip.kt
+++ b/components/src/jsMain/kotlin/dev/fritz2/components/tooltip.kt
@@ -34,7 +34,7 @@ fun StyleParams.tooltip(vararg text: String, tooltipPlacement: TooltipPlacements
  *       }
  *   }) {
  *       text(listOf("first line, second line"))
- *       placement { TooltipComponent.PlacementContext.bottomEnd }
+ *       placement { bottomEnd }
  *   }
  * ```
  *
@@ -56,6 +56,7 @@ fun RenderContext.tooltip(
  * Example usage:
  * ```
  *   tooltip("my Tooltip") { }
+ *   tooltip("my Tooltip") { placement { bottom } }
  * ```
  *
  * @see TooltipComponent

--- a/components/src/jsMain/kotlin/dev/fritz2/components/tooltip/component.kt
+++ b/components/src/jsMain/kotlin/dev/fritz2/components/tooltip/component.kt
@@ -31,20 +31,29 @@ import org.w3c.dom.HTMLInputElement
  *
  * Example usage:
  * ```
- *   tooltip("my Tooltip") {
- *       placement { right }
+ *   span {
+ *       +"hover me"
+ *       tooltip("my Tooltip on right side") {
+ *           placement { right }
+ *       }
  *   }
  *
- *   tooltip("first line, second line"){}
+ *   span {
+ *       +"hover me for see a multiline tooltip"
+ *       tooltip("first line, second line"){}
+ *   }
  *
- *   tooltip({
- *       color { danger.mainContrast }
- *       background {
- *           color { danger.main }
+ *   span {
+ *       +"hover me for custom colored tooltip"
+ *       tooltip({
+ *           color { danger.mainContrast }
+ *           background {
+ *               color { danger.main }
+ *           }
+ *       }) {
+ *           text(listOf("first line, second line"))
+ *           placement { TooltipComponent.PlacementContext.bottomEnd }
  *       }
- *   }) {
- *       text(listOf("first line, second line"))
- *       placement { TooltipComponent.PlacementContext.bottomEnd }
  *   }
  * ```
  *

--- a/components/src/jsMain/kotlin/dev/fritz2/components/tooltip/component.kt
+++ b/components/src/jsMain/kotlin/dev/fritz2/components/tooltip/component.kt
@@ -6,6 +6,7 @@ import dev.fritz2.components.foundations.EventMixin
 import dev.fritz2.components.foundations.EventProperties
 import dev.fritz2.components.popup
 import dev.fritz2.components.popup.Placement
+import dev.fritz2.dom.html.Div
 import dev.fritz2.dom.html.RenderContext
 import dev.fritz2.styling.StyleClass
 import dev.fritz2.styling.params.BoxParams
@@ -13,10 +14,47 @@ import dev.fritz2.styling.theme.Theme
 import kotlinx.coroutines.flow.*
 import org.w3c.dom.HTMLInputElement
 
+/**
+ * This component creates a Tooltip
+ *
+ * A `tooltip` should be used to display fast information for the user.
+ * The individual `text` will be shown on hover the `RenderContext` in which be called.
+ *
+ * This class offers the following _configuration_ features:
+ * [text] can be a `vararg`, a flow, a list, a flow of list of String or a simple string,
+ * optional can be use the @property textFromParam.
+ * [placement] of the [text] around the `RenderContext`in which be called.
+ * Available placements are `top`, `topStart`, `topEnd`, `bottom`, `bottomStart`, `bottomEnd`, `left`, `leftStart`,
+ * `leftEnd`, `right`, `rightStart`, `rightEnd`.
+ *
+ * The `render` function of [TooltipComponent] uses the fritz2 [dev.fritz2.components.popup.PopupComponent]
+ *
+ * Example usage:
+ * ```
+ *   tooltip("my Tooltip") {
+ *       placement { right }
+ *   }
+ *
+ *   tooltip("first line, second line"){}
+ *
+ *   tooltip({
+ *       color { danger.mainContrast }
+ *       background {
+ *           color { danger.main }
+ *       }
+ *   }) {
+ *       text(listOf("first line, second line"))
+ *       placement { TooltipComponent.PlacementContext.bottomEnd }
+ *   }
+ * ```
+ *
+ * @see [Placement]
+ *
+ */
 
 open class TooltipComponent(private val textFromParam: String?) :
     EventProperties<HTMLInputElement> by EventMixin(),
-    Component<Unit> {
+    Component<Div> {
 
     private var textFromContext: Flow<List<String>> = emptyFlow()
     fun text(vararg value: String) {
@@ -43,7 +81,7 @@ open class TooltipComponent(private val textFromParam: String?) :
 
     /**
      * PlacementContext
-     * uses the [Placement] of [dev.fritz2.components.popup.PopupComponent]
+     * uses [Placement] of [dev.fritz2.components.popup.PopupComponent]
      */
     object PlacementContext {
         val top = Placement.Top
@@ -68,27 +106,25 @@ open class TooltipComponent(private val textFromParam: String?) :
         baseClass: StyleClass,
         id: String?,
         prefix: String
-    ) {
-        context.apply {
-            popup({
-                this as BoxParams
-                Theme().tooltip.base.invoke()
-                styling.invoke()
-            }, id = id ?: "") {
-                placement { this@TooltipComponent.placement.value.invoke(PlacementContext) }
-                offset(5.0)
-                trigger { toggle, close ->
-                    context.domNode.apply {
-                        mouseenters.events.map {
-                            it.currentTarget
-                        } handledBy toggle
-                        mouseleaves.events.map { } handledBy close
-                    }
+    ): Div = with(context) {
+        popup({
+            this as BoxParams
+            Theme().tooltip.base.invoke()
+            styling.invoke()
+        }, id = id ?: "") {
+            placement { this@TooltipComponent.placement.value.invoke(PlacementContext) }
+            offset(5.0)
+            trigger { toggle, close ->
+                context.domNode.apply {
+                    mouseenters.events.map {
+                        it.currentTarget
+                    } handledBy toggle
+                    mouseleaves.events.map { } handledBy close
                 }
-                content {
-                    this@TooltipComponent.content().renderEach { text ->
-                        span { +text }
-                    }
+            }
+            content {
+                this@TooltipComponent.content().renderEach { text ->
+                    span { +text }
                 }
             }
         }

--- a/components/src/jsMain/kotlin/dev/fritz2/components/tooltip/component.kt
+++ b/components/src/jsMain/kotlin/dev/fritz2/components/tooltip/component.kt
@@ -40,7 +40,7 @@ import org.w3c.dom.HTMLInputElement
  *
  *   span {
  *       +"hover me for see a multiline tooltip"
- *       tooltip("first line, second line"){}
+ *       tooltip("first line", "second line"){}
  *   }
  *
  *   span {
@@ -51,7 +51,7 @@ import org.w3c.dom.HTMLInputElement
  *               color { danger.main }
  *           }
  *       }) {
- *           text(listOf("first line, second line"))
+ *           text(listOf("first line", "second line"))
  *           placement { TooltipComponent.PlacementContext.bottomEnd }
  *       }
  *   }

--- a/components/src/jsMain/kotlin/dev/fritz2/components/tooltip/component.kt
+++ b/components/src/jsMain/kotlin/dev/fritz2/components/tooltip/component.kt
@@ -1,0 +1,101 @@
+package dev.fritz2.components.tooltip
+
+import dev.fritz2.components.foundations.Component
+import dev.fritz2.components.foundations.ComponentProperty
+import dev.fritz2.components.foundations.EventMixin
+import dev.fritz2.components.foundations.EventProperties
+import dev.fritz2.components.popper
+import dev.fritz2.components.popper.Placement
+import dev.fritz2.dom.html.Div
+import dev.fritz2.dom.html.RenderContext
+import dev.fritz2.styling.StyleClass
+import dev.fritz2.styling.params.BasicParams
+import dev.fritz2.styling.params.BoxParams
+import dev.fritz2.styling.span
+import dev.fritz2.styling.theme.Theme
+import kotlinx.coroutines.flow.*
+import org.w3c.dom.HTMLInputElement
+
+
+
+open class TooltipComponent :
+    EventProperties<HTMLInputElement> by EventMixin(),
+    Component<Unit> {
+
+    /**
+     * TODO to be discussed
+     */
+    private var text: Flow<List<String>> = emptyFlow()
+    fun text(vararg value: String) {
+        text = flowOf(value.asList())
+    }
+
+    fun text(value: String) {
+        text = flowOf(listOf(value))
+    }
+
+    fun text(value: Flow<String>) {
+        text = value.map { listOf(it) }
+    }
+
+    fun text(value: List<String>) {
+        text = flowOf(value)
+    }
+
+    fun text(value: Flow<List<String>>) {
+        text = value
+    }
+
+    /**
+     * PlacementContext
+     * uses the [Placement] of [dev.fritz2.components.popper.PopperComponent]
+     */
+    object PlacementContext {
+        val top = Placement.Top
+        val topStart = Placement.TopStart
+        val topEnd = Placement.TopEnd
+        val bottom = Placement.Bottom
+        val bottomStart = Placement.BottomStart
+        val bottomEnd = Placement.BottomEnd
+        val left = Placement.Left
+        val leftStart = Placement.LeftStart
+        val leftEnd = Placement.LeftEnd
+        val right = Placement.Right
+        val rightStart = Placement.RightStart
+        val rightEnd = Placement.RightEnd
+    }
+
+    val placement = ComponentProperty<PlacementContext.() -> Placement> { Placement.Top }
+
+    override fun render(
+        context: RenderContext,
+        styling: BoxParams.() -> Unit,
+        baseClass: StyleClass,
+        id: String?,
+        prefix: String
+    ) {
+        context.apply {
+            popper({
+                this as BoxParams
+                Theme().tooltip.base.invoke()
+                styling.invoke()
+            }, id = id ?: "") {
+                placement { this@TooltipComponent.placement.value.invoke(PlacementContext) }
+                offset(5.0)
+                trigger { toggle, close ->
+                    context.domNode.apply {
+                        mouseenters.events.map {
+                            it.currentTarget
+                        } handledBy toggle
+                        mouseleaves.events.map { } handledBy close
+                    }
+                }
+                content {
+                    this@TooltipComponent.text.renderEach { text ->
+                        span { +text }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/components/src/jsMain/kotlin/dev/fritz2/components/tooltip/component.kt
+++ b/components/src/jsMain/kotlin/dev/fritz2/components/tooltip/component.kt
@@ -4,51 +4,46 @@ import dev.fritz2.components.foundations.Component
 import dev.fritz2.components.foundations.ComponentProperty
 import dev.fritz2.components.foundations.EventMixin
 import dev.fritz2.components.foundations.EventProperties
-import dev.fritz2.components.popper
-import dev.fritz2.components.popper.Placement
-import dev.fritz2.dom.html.Div
+import dev.fritz2.components.popup
+import dev.fritz2.components.popup.Placement
 import dev.fritz2.dom.html.RenderContext
 import dev.fritz2.styling.StyleClass
-import dev.fritz2.styling.params.BasicParams
 import dev.fritz2.styling.params.BoxParams
-import dev.fritz2.styling.span
 import dev.fritz2.styling.theme.Theme
 import kotlinx.coroutines.flow.*
 import org.w3c.dom.HTMLInputElement
 
 
-
-open class TooltipComponent :
+open class TooltipComponent(private val textFromParam: String?) :
     EventProperties<HTMLInputElement> by EventMixin(),
     Component<Unit> {
 
-    /**
-     * TODO to be discussed
-     */
-    private var text: Flow<List<String>> = emptyFlow()
+    private var textFromContext: Flow<List<String>> = emptyFlow()
     fun text(vararg value: String) {
-        text = flowOf(value.asList())
+        textFromContext = flowOf(value.asList())
     }
 
     fun text(value: String) {
-        text = flowOf(listOf(value))
+        textFromContext = flowOf(listOf(value))
     }
 
     fun text(value: Flow<String>) {
-        text = value.map { listOf(it) }
+        textFromContext = value.map { listOf(it) }
     }
 
     fun text(value: List<String>) {
-        text = flowOf(value)
+        textFromContext = flowOf(value)
     }
 
     fun text(value: Flow<List<String>>) {
-        text = value
+        textFromContext = value
     }
+
+    private fun content() = if (textFromParam != null) flowOf(listOf(textFromParam)) else textFromContext
 
     /**
      * PlacementContext
-     * uses the [Placement] of [dev.fritz2.components.popper.PopperComponent]
+     * uses the [Placement] of [dev.fritz2.components.popup.PopupComponent]
      */
     object PlacementContext {
         val top = Placement.Top
@@ -75,7 +70,7 @@ open class TooltipComponent :
         prefix: String
     ) {
         context.apply {
-            popper({
+            popup({
                 this as BoxParams
                 Theme().tooltip.base.invoke()
                 styling.invoke()
@@ -91,7 +86,7 @@ open class TooltipComponent :
                     }
                 }
                 content {
-                    this@TooltipComponent.text.renderEach { text ->
+                    this@TooltipComponent.content().renderEach { text ->
                         span { +text }
                     }
                 }

--- a/components/src/jsMain/kotlin/dev/fritz2/components/tooltip/component.kt
+++ b/components/src/jsMain/kotlin/dev/fritz2/components/tooltip/component.kt
@@ -6,6 +6,7 @@ import dev.fritz2.components.foundations.EventMixin
 import dev.fritz2.components.foundations.EventProperties
 import dev.fritz2.components.popup
 import dev.fritz2.components.popup.Placement
+import dev.fritz2.components.popup.PlacementContext
 import dev.fritz2.dom.html.Div
 import dev.fritz2.dom.html.RenderContext
 import dev.fritz2.styling.StyleClass
@@ -18,14 +19,14 @@ import org.w3c.dom.HTMLInputElement
  * This component creates a Tooltip
  *
  * A `tooltip` should be used to display fast information for the user.
- * The individual `text` will be shown on hover the `RenderContext` in which be called.
+ * The individual `text` will be shown on hovering the `RenderContext`' element in which it is called.
  *
  * This class offers the following _configuration_ features:
- * [text] can be a `vararg`, a flow, a list, a flow of list of String or a simple string,
- * optional can be use the @property textFromParam.
- * [placement] of the [text] around the `RenderContext`in which be called.
- * Available placements are `top`, `topStart`, `topEnd`, `bottom`, `bottomStart`, `bottomEnd`, `left`, `leftStart`,
- * `leftEnd`, `right`, `rightStart`, `rightEnd`.
+ * - [text] can be a `vararg`, a flow, a list, a flow of list of String or a simple string,
+ *   optional can be use the @property textFromParam.
+ * - [placement] of the [text] around the `RenderContext`in which be called.
+ *   Available placements are `top`, `topStart`, `topEnd`, `bottom`, `bottomStart`, `bottomEnd`, `left`, `leftStart`,
+ *   `leftEnd`, `right`, `rightStart`, `rightEnd`.
  *
  * The `render` function of [TooltipComponent] uses the fritz2 [dev.fritz2.components.popup.PopupComponent]
  *
@@ -39,7 +40,7 @@ import org.w3c.dom.HTMLInputElement
  *   }
  *
  *   span {
- *       +"hover me for see a multiline tooltip"
+ *       +"hover me to see a multiline tooltip"
  *       tooltip("first line", "second line"){}
  *   }
  *
@@ -52,15 +53,15 @@ import org.w3c.dom.HTMLInputElement
  *           }
  *       }) {
  *           text(listOf("first line", "second line"))
- *           placement { TooltipComponent.PlacementContext.bottomEnd }
+ *           placement { bottomEnd }
  *       }
  *   }
  * ```
  *
  * @see [Placement]
+ * @see [PopupComponent]
  *
  */
-
 open class TooltipComponent(private val textFromParam: String?) :
     EventProperties<HTMLInputElement> by EventMixin(),
     Component<Div> {
@@ -87,25 +88,6 @@ open class TooltipComponent(private val textFromParam: String?) :
     }
 
     private fun content() = if (textFromParam != null) flowOf(listOf(textFromParam)) else textFromContext
-
-    /**
-     * PlacementContext
-     * uses [Placement] of [dev.fritz2.components.popup.PopupComponent]
-     */
-    object PlacementContext {
-        val top = Placement.Top
-        val topStart = Placement.TopStart
-        val topEnd = Placement.TopEnd
-        val bottom = Placement.Bottom
-        val bottomStart = Placement.BottomStart
-        val bottomEnd = Placement.BottomEnd
-        val left = Placement.Left
-        val leftStart = Placement.LeftStart
-        val leftEnd = Placement.LeftEnd
-        val right = Placement.Right
-        val rightStart = Placement.RightStart
-        val rightEnd = Placement.RightEnd
-    }
 
     val placement = ComponentProperty<PlacementContext.() -> Placement> { Placement.Top }
 

--- a/styling/src/jsMain/kotlin/dev/fritz2/styling/theme/default.kt
+++ b/styling/src/jsMain/kotlin/dev/fritz2/styling/theme/default.kt
@@ -1376,6 +1376,18 @@ open class DefaultTheme : Theme {
                 }
             }
         }
+
+        override val base: Style<BoxParams> = {
+            display { flex }
+            direction { column }
+            background { color { gray700 } }
+            radius { small }
+            color { gray300 }
+            zIndex { tooltip }
+            padding { tiny }
+            fontSize { smaller }
+            lineHeight { smaller }
+        }
     }
 
     override val textArea = object : TextAreaStyles {
@@ -2513,7 +2525,7 @@ open class DefaultTheme : Theme {
             position {
                 absolute {
                     top { "0" }
-                    left {"-${leftPosition}px"}
+                    left { "-${leftPosition}px" }
                 }
             }
             opacity { "0" }

--- a/styling/src/jsMain/kotlin/dev/fritz2/styling/theme/definitions.kt
+++ b/styling/src/jsMain/kotlin/dev/fritz2/styling/theme/definitions.kt
@@ -527,11 +527,16 @@ interface PopoverSizes {
  * definition of the theme's tooltip
  */
 interface TooltipStyles {
+    @Deprecated("since 0.12 - please use TooltipComponent")
     fun write(vararg value: String): Style<BasicParams>
+    @Deprecated("since 0.12 - please use TooltipComponent")
     fun write(vararg value: String, tooltipPlacement: TooltipPlacements.() -> Style<BasicParams>): Style<BasicParams>
+    @Deprecated("since 0.12 - please use TooltipComponent")
     val placement: TooltipPlacements
+    val base: Style<BoxParams>
 }
 
+@Deprecated("since 0.12 - please use TooltipComponent")
 interface TooltipPlacements {
     val top: Style<BasicParams>
     val right: Style<BasicParams>


### PR DESCRIPTION
This PR deals with the new `TooltipComponent`

A `tooltip` should be used to display fast information for the user.
The individual `text` will be shown on hover the `RenderContext` in which be called.
 
This class offers the following _configuration_ features:
- `text` can be a `vararg`, a flow, a list, a flow of list of String or a simple string, optional can be use the @property `textFromParam`.
- `placement` of the `text` around the `RenderContext`in which be called. Available placements are `top`, `topStart`, `topEnd`, `bottom`, `bottomStart`, `bottomEnd`, `left`, `leftStart`, `leftEnd`, `right`, `rightStart`, `rightEnd`.
 
Example usage:
```kotlin
span {
   +"hover me"
   tooltip("my Tooltip on right side") {
      placement { right }
    }
}
 
span {
   +"hover me to see a multiline tooltip"
   tooltip("first line", "second line"){}
}

span {
   +"hover me for custom colored tooltip"
   tooltip({
        color { danger.mainContrast }
        background {
            color { danger.main }
        }
   }) {
        text(listOf("first line", "second line"))
        placement { TooltipComponent.PlacementContext.bottomEnd }
    }
}
```

## Migration

## Notes
- The olf tooltip component remains as deprecated for the next releases, so clients have time to migrate.
- For using this component in our `components` we need a new mixin interface. (PR #507)
- this PR needs  PR #493 before it can be merged .

## Motivation

The *old* Tooltip component is based upon pure CSS. This is fine for basic usage, but it fails when it comes to advanced features like automatic positioning. Also the API does not fit into the "fritz2 component style". That's why there is the need to rework the tooltip.