### PR TITLE
Optimize DataTable's reactive rendering

### DIFF
--- a/components/src/jsMain/kotlin/dev/fritz2/components/datatable/component.kt
+++ b/components/src/jsMain/kotlin/dev/fritz2/components/datatable/component.kt
@@ -410,7 +410,7 @@ open class DataTableComponent<T, I>(val dataStore: RootStore<List<T>>, protected
             }) {
                 this@DataTableComponent.stateStore
                     .renderingRowsData(this@DataTableComponent, rowIdProvider).let { renderingData ->
-                        renderingData.map { it.first }.renderEach(indexedRowIdProvider) { (index, rowData) ->
+                        renderingData.map { it.first }.renderEach(indexedRowIdProvider) { (_, rowData) ->
                             val rowStore = this@DataTableComponent.dataStore.sub(rowData, rowIdProvider)
                             tr {
                                 this@DataTableComponent.selection.value.strategy.value
@@ -420,17 +420,20 @@ open class DataTableComponent<T, I>(val dataStore: RootStore<List<T>>, protected
                                 } handledBy this@DataTableComponent.selectionStore.dbClickedRow
 
                                 renderingData.mapNotNull { it.second[rowIdProvider(rowData)] }
+                                    // provide data structure that only relies on String representation of the
+                                    // column for `equals`. This way we can still provide the whole `T` for the styling
+                                    // and content, but also able to render only cells, which content has changed!
                                     .renderEach { (column, statefulIndex) ->
-                                        console.log(column.title, statefulIndex.index, statefulIndex.value.item)
+                                        val (index, stateful) = statefulIndex
+                                        console.log(column.title, index, stateful.item)
                                         td({
-                                            Sorting.sorted(statefulIndex.value.sorting)
                                             Theme().dataTableStyles.cellStyle(
                                                 this,
                                                 IndexedValue(
                                                     index,
-                                                    rowData as Any, // cast necessary, as theme can't depend on ``T``!
+                                                    stateful.item as Any, // cast necessary, as theme can't depend on ``T``!
                                                 ),
-                                                statefulIndex.value.selected,
+                                                stateful.selected,
                                                 Sorting.sorted(statefulIndex.value.sorting)
                                             )
                                             this@DataTableComponent.columns.value.styling.value(this, statefulIndex)
@@ -441,7 +444,7 @@ open class DataTableComponent<T, I>(val dataStore: RootStore<List<T>>, protected
                                                 this,
                                                 statefulIndex.value.selected,
                                                 index,
-                                                rowData
+                                                stateful.item
                                             )
                                             column.content(
                                                 this,

--- a/components/src/jsMain/kotlin/dev/fritz2/components/datatable/component.kt
+++ b/components/src/jsMain/kotlin/dev/fritz2/components/datatable/component.kt
@@ -420,12 +420,8 @@ open class DataTableComponent<T, I>(val dataStore: RootStore<List<T>>, protected
                                 } handledBy this@DataTableComponent.selectionStore.dbClickedRow
 
                                 renderingData.mapNotNull { it.second[rowIdProvider(rowData)] }
-                                    // provide data structure that only relies on String representation of the
-                                    // column for `equals`. This way we can still provide the whole `T` for the styling
-                                    // and content, but also able to render only cells, which content has changed!
-                                    .renderEach { (column, statefulIndex) ->
+                                    .renderEach({ columnIdProvider(it) }) { (column, statefulIndex) ->
                                         val (index, stateful) = statefulIndex
-                                        console.log(column.title, index, stateful.item)
                                         td({
                                             Theme().dataTableStyles.cellStyle(
                                                 this,
@@ -439,10 +435,9 @@ open class DataTableComponent<T, I>(val dataStore: RootStore<List<T>>, protected
                                             this@DataTableComponent.columns.value.styling.value(this, statefulIndex)
                                             column.styling(this, statefulIndex)
                                         }) {
-                                            console.log("rendere neu: ", column.title)
                                             this@DataTableComponent.applySelectionStyle(
-                                                this,
-                                                statefulIndex.value.selected,
+                                                this@tr,
+                                                stateful.selected,
                                                 index,
                                                 stateful.item
                                             )
@@ -461,12 +456,12 @@ open class DataTableComponent<T, I>(val dataStore: RootStore<List<T>>, protected
         }
     }
 
-    private fun applySelectionStyle(renderContext: Td, isSelected: Boolean, index: Int, rowData: T) {
+    private fun applySelectionStyle(renderContext: Tr, isSelected: Boolean, index: Int, rowData: T) {
         renderContext.apply {
             if (this@DataTableComponent.options.value.hovering.value.active.value) {
                 className(
                     style {
-                        hover {
+                        children("&:hover td") {
                             Theme().dataTableStyles.hoveringStyle(
                                 this,
                                 IndexedValue(

--- a/components/src/jsMain/kotlin/dev/fritz2/components/datatable/foundation.kt
+++ b/components/src/jsMain/kotlin/dev/fritz2/components/datatable/foundation.kt
@@ -69,6 +69,18 @@ data class Column<T>(
 )
 
 /**
+ * This helper function determines for the inner rendering loop of the cells (`td`), which cell really needs to
+ * be re-rendered! Only changes to the column itself, that is its [String] representation or its state, requires such
+ * a new rendering process.
+ */
+fun <T> columnIdProvider(param: Pair<Column<T>, IndexedValue<StatefulItem<T>>>) =
+    param.first.lens?.get(param.second.value.item).hashCode() * 31 +
+            param.second.index * 31 +
+            param.second.value.selected.hashCode() * 31 +
+            param.second.value.sorting.hashCode() * 31
+
+
+/**
  * Wrapping class to group the id of a [Column] with the sorting strategy.
  * This is the base for the type ``T`` independent [SortingPlan] which itself is necessary for the *internal*
  * [State].

--- a/styling/src/jsMain/kotlin/dev/fritz2/styling/theme/default.kt
+++ b/styling/src/jsMain/kotlin/dev/fritz2/styling/theme/default.kt
@@ -2294,13 +2294,12 @@ open class DefaultTheme : Theme {
             selected: Boolean,
             sorted: Boolean
         ) -> Unit
-            get() = { _, _, _ ->
+            get() = { value, _, _ ->
                 color { hoveringColors.mainContrast }
-                borders {
-                    horizontal {
-                        color { hoveringColors.mainContrast }
-                        width { thin }
-                        style { solid }
+                boxShadow {
+                    with(columnColors[(value.index + 1) % 2].mainContrast) {
+                        shadow("0px", "1px", color = this@with, inset = true) and
+                        shadow("0px", "-1px", color = this@with, inset = true)
                     }
                 }
             }


### PR DESCRIPTION
The DataTable now reacts much smoother to changes of its content, so that:
- a row itself (the `tr` tag) is not deleted until the `id` of its row disappears
- a cell (the `td` tag) is only rendered if its `String` represenatation via its `Lens` changes or some of the state related properties like the selection state or the sorting

This improves the handling of editable cells, as one can now *tab* through a row without rerendering it and therefore keeping the focus stable so it advances by default to the next column.

Be aware that you must adapt to those changes, if your editable DataTable relies on changes to one arbitrary (maybe not rendered property!) field of a model. This will not work any longer and must be solved otherwise.

fixes #404
fixes #509