### PR TITLE
Improve null value handling for attribute setting

### DIFF
--- a/core/src/jsMain/kotlin/dev/fritz2/dom/tag.kt
+++ b/core/src/jsMain/kotlin/dev/fritz2/dom/tag.kt
@@ -403,7 +403,10 @@ open class Tag<out E : Element>(
      * @param value to use
      */
     fun attr(name: String, value: Flow<String?>) {
-        mountSingle(job, value) { v, _ -> attr(name, v) }
+        mountSingle(job, value) { v, _ ->
+            if (v != null) attr(name, v)
+            else domNode.removeAttribute(name)
+        }
     }
 
     /**
@@ -423,7 +426,10 @@ open class Tag<out E : Element>(
      * @param value to use
      */
     fun <T> attr(name: String, value: Flow<T>) {
-        mountSingle(job, value.mapNotNull { it?.toString() }) { v, _ -> attr(name, v) }
+        mountSingle(job, value.map { it?.toString() }) { v, _ ->
+            if (v != null) attr(name, v)
+            else domNode.removeAttribute(name)
+        }
     }
 
     /**

--- a/core/src/jsMain/kotlin/dev/fritz2/dom/tag.kt
+++ b/core/src/jsMain/kotlin/dev/fritz2/dom/tag.kt
@@ -377,6 +377,16 @@ open class Tag<out E : Element>(
     }
 
     /**
+     * Sets an attribute only if its [value] is not null.
+     *
+     * @param name to use
+     * @param value to use
+     */
+    fun attr(name: String, value: String?) {
+        value?.let { domNode.setAttribute(name, it) }
+    }
+
+    /**
      * Sets an attribute.
      *
      * @param name to use
@@ -387,13 +397,23 @@ open class Tag<out E : Element>(
     }
 
     /**
+     * Sets an attribute only for all none null values of the flow.
+     *
+     * @param name to use
+     * @param value to use
+     */
+    fun attr(name: String, value: Flow<String?>) {
+        mountSingle(job, value) { v, _ -> attr(name, v) }
+    }
+
+    /**
      * Sets an attribute.
      *
      * @param name to use
      * @param value to use
      */
     fun <T> attr(name: String, value: T) {
-        domNode.setAttribute(name, value.toString())
+        value?.let { domNode.setAttribute(name, it.toString()) }
     }
 
     /**
@@ -403,11 +423,11 @@ open class Tag<out E : Element>(
      * @param value to use
      */
     fun <T> attr(name: String, value: Flow<T>) {
-        mountSingle(job, value.map { it.toString() }) { v, _ -> attr(name, v) }
+        mountSingle(job, value.mapNotNull { it?.toString() }) { v, _ -> attr(name, v) }
     }
 
     /**
-     * Sets an attribute when [value] is true other removes it.
+     * Sets an attribute when [value] is true otherwise removes it.
      *
      * @param name to use
      * @param value for decision
@@ -419,13 +439,38 @@ open class Tag<out E : Element>(
     }
 
     /**
-     * Sets an attribute when [value] is true other removes it.
+     * Sets an attribute when [value] is true otherwise removes it.
+     *
+     * @param name to use
+     * @param value for decision
+     * @param trueValue value to use if attribute is set (default "")
+     */
+    fun attr(name: String, value: Boolean?, trueValue: String = "") {
+        value?.let {
+            if (it) domNode.setAttribute(name, trueValue)
+            else domNode.removeAttribute(name)
+        }
+    }
+
+    /**
+     * Sets an attribute when [value] is true otherwise removes it.
      *
      * @param name to use
      * @param value for decision
      * @param trueValue value to use if attribute is set (default "")
      */
     fun attr(name: String, value: Flow<Boolean>, trueValue: String = "") {
+        mountSingle(job, value) { v, _ -> attr(name, v, trueValue) }
+    }
+
+    /**
+     * Sets an attribute when [value] is true otherwise removes it.
+     *
+     * @param name to use
+     * @param value for decision
+     * @param trueValue value to use if attribute is set (default "")
+     */
+    fun attr(name: String, value: Flow<Boolean?>, trueValue: String = "") {
         mountSingle(job, value) { v, _ -> attr(name, v, trueValue) }
     }
 
@@ -602,7 +647,7 @@ open class Tag<out E : Element>(
      * Sets all scope-entries as data-attributes to the element.
      */
     fun Scope.asDataAttr() {
-        for((k, v) in this) {
+        for ((k, v) in this) {
             attr("data-${k.name}", v.toString())
         }
     }
@@ -613,7 +658,7 @@ open class Tag<out E : Element>(
      *
      * @param key key of scope-entry to look for in scope
      */
-    fun <T: Any> Scope.asDataAttr(key: Scope.Key<T>) {
+    fun <T : Any> Scope.asDataAttr(key: Scope.Key<T>) {
         this[key]?.let {
             attr("data-${key.name}", it.toString())
         }

--- a/core/src/jsTest/kotlin/dev/fritz2/dom/attributes.kt
+++ b/core/src/jsTest/kotlin/dev/fritz2/dom/attributes.kt
@@ -1,5 +1,6 @@
 package dev.fritz2.dom
 
+import dev.fritz2.binding.storeOf
 import dev.fritz2.dom.html.render
 import dev.fritz2.identification.Id
 import dev.fritz2.test.initDocument
@@ -83,7 +84,7 @@ class AttributeTests {
                 attr("nullableT", null as Int?)
                 attr("nullableFlowOfT", flowOf(null as Int?))
                 attr("nullableBoolean", null as Boolean?, "nullableBoolean")
-                attr("nullableFlowOfBoolean", null as Boolean?, "nullableFlowOfBoolean")
+                attr("nullableFlowOfBoolean", flowOf(null as Boolean?), "nullableFlowOfBoolean")
             }
         }
 
@@ -96,5 +97,68 @@ class AttributeTests {
         assertFalse(element.hasAttribute("nullableFlowOfT"))
         assertFalse(element.hasAttribute("nullableBoolean"))
         assertFalse(element.hasAttribute("nullableFlowOfBoolean"))
+    }
+
+    @Test
+    fun testAlternatingNullableStringFlows() = runTest {
+        initDocument()
+        val testId = Id.next()
+
+        val nullableFlow = storeOf<String?>("a")
+
+        render {
+            div(id = testId) {
+                attr("test", nullableFlow.data)
+            }
+        }
+
+        delay(50)
+        val element = document.getElementById(testId).unsafeCast<HTMLDivElement>()
+
+        assertTrue(element.hasAttribute("test"))
+        assertEquals("a", element.getAttribute("test"))
+
+        nullableFlow.update(null)
+        delay(50)
+
+        assertFalse(element.hasAttribute("test"))
+
+        nullableFlow.update("c")
+        delay(50)
+
+        assertTrue(element.hasAttribute("test"))
+        assertEquals("c", element.getAttribute("test"))
+    }
+
+
+    @Test
+    fun testAlternatingNullableTFlows() = runTest {
+        initDocument()
+        val testId = Id.next()
+
+        val nullableFlow = storeOf<Int?>(42)
+
+        render {
+            div(id = testId) {
+                attr("test", nullableFlow.data)
+            }
+        }
+
+        delay(50)
+        val element = document.getElementById(testId).unsafeCast<HTMLDivElement>()
+
+        assertTrue(element.hasAttribute("test"))
+        assertEquals("42", element.getAttribute("test"))
+
+        nullableFlow.update(null)
+        delay(50)
+
+        assertFalse(element.hasAttribute("test"))
+
+        nullableFlow.update(99)
+        delay(50)
+
+        assertTrue(element.hasAttribute("test"))
+        assertEquals("99", element.getAttribute("test"))
     }
 }

--- a/core/src/jsTest/kotlin/dev/fritz2/dom/attributes.kt
+++ b/core/src/jsTest/kotlin/dev/fritz2/dom/attributes.kt
@@ -70,4 +70,31 @@ class AttributeTests {
         assertTrue(element.hasAttribute("test6"))
         assertEquals("foo", element.getAttribute("test6"))
     }
+
+    @Test
+    fun testNullableAttributes() = runTest {
+        initDocument()
+        val testId = Id.next()
+
+        render {
+            div(id = testId) {
+                attr("nullableString", null as String?)
+                attr("nullableFlowOfString", flowOf(null as String?))
+                attr("nullableT", null as Int?)
+                attr("nullableFlowOfT", flowOf(null as Int?))
+                attr("nullableBoolean", null as Boolean?, "nullableBoolean")
+                attr("nullableFlowOfBoolean", null as Boolean?, "nullableFlowOfBoolean")
+            }
+        }
+
+        delay(200)
+        val element = document.getElementById(testId).unsafeCast<HTMLDivElement>()
+
+        assertFalse(element.hasAttribute("nullableString"))
+        assertFalse(element.hasAttribute("nullableFlowOfString"))
+        assertFalse(element.hasAttribute("nullableT"))
+        assertFalse(element.hasAttribute("nullableFlowOfT"))
+        assertFalse(element.hasAttribute("nullableBoolean"))
+        assertFalse(element.hasAttribute("nullableFlowOfBoolean"))
+    }
 }


### PR DESCRIPTION
Null values will now prohibit the setting of an attribute with String `null` as value; instead no attribute will be set at all.