### PR TITLE
fix registering mount points

### DIFF
--- a/core/src/jsMain/kotlin/dev/fritz2/dom/tag.kt
+++ b/core/src/jsMain/kotlin/dev/fritz2/dom/tag.kt
@@ -156,12 +156,12 @@ open class Tag<out E : Element>(
      */
     fun <V> Flow<V>.render(content: RenderContext.(V) -> Unit) {
         val newJob = Job(job)
-        mountDomNodeList(job, domNode, this.onEach { console.log("before map: $it\n") }.map { data ->
+        mountDomNodeList(job, domNode, this.map { data ->
             newJob.cancelChildren()
             registerMulti(newJob, this@Tag.unsafeCast<RenderContext>()) {
                 content(data)
             }
-        }.onEach { console.log("new Value: ${it.map { it.domNode.textContent }}\n") })
+        })
     }
 
     /**

--- a/core/src/jsMain/kotlin/dev/fritz2/dom/tag.kt
+++ b/core/src/jsMain/kotlin/dev/fritz2/dom/tag.kt
@@ -67,7 +67,7 @@ open class Tag<out E : Element>(
                     job, parent.scope, parent.domNode.unsafeCast<HTMLElement>()
                 ) {
                     override fun <E : Element, W : WithDomNode<E>> register(element: W, content: (W) -> Unit): W {
-                        parent.register(element, content)
+                        content(element)
                         add(element.unsafeCast<WithDomNode<HTMLElement>>())
                         return element
                     }
@@ -88,7 +88,8 @@ open class Tag<out E : Element>(
                     if (alreadyRegistered) {
                         throw MultipleRootElementsException("You can have only one root-tag per html-context!")
                     } else {
-                        parent.register(element, content)
+                        content(element)
+                        //parent.register(element, content)
                         alreadyRegistered = true
                         return element
                     }

--- a/core/src/jsMain/kotlin/dev/fritz2/dom/tag.kt
+++ b/core/src/jsMain/kotlin/dev/fritz2/dom/tag.kt
@@ -106,24 +106,6 @@ open class Tag<out E : Element>(
             return content(targetContext)
         }
 
-//            content(object : RenderContext(
-//                "", parent.id, parent.baseClass,
-//                job, parent.scope, parent.domNode.unsafeCast<HTMLElement>()
-//            ) {
-//                var alreadyRegistered: Boolean = false
-//
-//                override fun <E : Element, W : WithDomNode<E>> register(element: W, content: (W) -> Unit): W {
-//                    if (alreadyRegistered) {
-//                        throw MultipleRootElementsException("You can have only one root-tag per html-context!")
-//                    } else {
-//                        content(element)
-////                        parent.register(element, content)
-//                        alreadyRegistered = true
-//                        return element
-//                    }
-//                }
-//            })
-
         /**
          * Accumulates a [Pair] and a [List] to a new [Pair] of [List]s
          *


### PR DESCRIPTION
fixes two problems:

1.  child elements were already appended by mount-points to the parent element during the mapping. The mount-method late only moved them to their right position when calling replace element. not the child - elements are not connect to their parent until the mount-function
2.  a mount point has to forward its parent to its children as context if this parent is another mount point. Only if it is a regular tag it has to create a new "virtual" RenderContext