### PR TITLE
chausknecht/dynamicSubmenuIcons

### DIFF
--- a/components/src/jsMain/kotlin/dev/fritz2/components/menu/component.kt
+++ b/components/src/jsMain/kotlin/dev/fritz2/components/menu/component.kt
@@ -15,6 +15,8 @@ import dev.fritz2.styling.theme.IconDefinition
 import dev.fritz2.styling.theme.Icons
 import dev.fritz2.styling.theme.MenuStyles
 import dev.fritz2.styling.theme.Theme
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.map
 import org.w3c.dom.HTMLButtonElement
 
@@ -55,7 +57,7 @@ import org.w3c.dom.HTMLButtonElement
  */
 open class MenuComponent(scope: Scope) : Component<Unit>, MenuContext() {
 
-    val styles: MenuStyles = if(scope[AppFrameScope.Navigation] == true) Theme().appFrame.menu else Theme().menu
+    val styles: MenuStyles = if (scope[AppFrameScope.Navigation] == true) Theme().appFrame.menu else Theme().menu
 
     override fun render(
         context: RenderContext,
@@ -136,7 +138,16 @@ open class SubMenuComponent(
         val hidden = staticStyle("hidden", "display: none")
     }
 
-    val icon = ComponentProperty<(Icons.() -> IconDefinition)?>(null)
+    fun icon(def: Icons.() -> IconDefinition) {
+        icon = flowOf(def(Theme().icons))
+    }
+
+    fun icon(def: Flow<IconDefinition>) {
+        icon = def
+    }
+
+    var icon: Flow<IconDefinition>? = null
+
     val text = ComponentProperty<String?>(null)
 
     private val visible = value ?: storeOf(false)
@@ -144,8 +155,8 @@ open class SubMenuComponent(
     override fun render(context: RenderContext, styles: MenuStyles) {
         context.apply {
             button(styles.entry + this@SubMenuComponent.styling) {
-                this@SubMenuComponent.icon.value?.let {
-                    icon(styles.icon) { def(it(Theme().icons)) }
+                this@SubMenuComponent.icon?.render {
+                     icon(styles.icon) { def(it) }
                 }
                 this@SubMenuComponent.text.value?.let { span { +it } }
                 disabled(this@SubMenuComponent.disabled.values)


### PR DESCRIPTION
This PR enhances the API of the `submenu` component's icon defintion. Instead of just apssing some static `IconDefinition` it is now possible to pass some `Flow<IconDefinition>`too. This enables one to realize an "accordeon style" menu, where the icon reflects the open / close state of the submenu:

```kotlin
// some store to hold the open/close state of a submenu
val toggle = storeOf(false)

menu {
    header("Entries")
    entry {
        text("Basic entry")
    }
    submenu(value=toggle) {
        text("Sub")
        // use the state to select the appropriate sub-menu icon
        icon(toggle.data.map { if (it) Theme().icons.chevronDown else Theme().icons.chevronLeft })
        entry {
            text("A")
        }
        entry {
            text("B")
        }
        entry {
            text("C")
        }
    }
}
```

![2021-09-28 14_59_24-KitchenSink - fritz2 components demo](https://user-images.githubusercontent.com/70946811/135092057-1a867761-a307-437f-848f-b9a22a015e6c.png)


fixes #527 