### PR TITLE
Adding new Adhoc-Handler

### DIFF
--- a/core/src/jsMain/kotlin/dev/fritz2/binding/utils.kt
+++ b/core/src/jsMain/kotlin/dev/fritz2/binding/utils.kt
@@ -9,9 +9,11 @@ import kotlinx.coroutines.flow.launchIn
 /**
  * If a data-[Flow] is never mounted, use this method to start the updating of derived values.
  */
+@Deprecated("use handledBy function with lambda expression instead of onEach{}.watch().")
 fun <T> Flow<T>.watch(scope: CoroutineScope = MainScope()) { this.catch {}.launchIn(scope) }
 
 /**
  * If a [Store]'s data-[Flow] is never mounted, use this method to start the updating of derived values.
  */
+@Deprecated("use handledBy function with lambda expression instead of onEach{}.watch().")
 fun <T> Store<T>.watch(scope: CoroutineScope = MainScope()): Store<T> = this.also { data.catch {}.launchIn(scope) }

--- a/core/src/jsMain/kotlin/dev/fritz2/dom/html/job.kt
+++ b/core/src/jsMain/kotlin/dev/fritz2/dom/html/job.kt
@@ -4,8 +4,9 @@ import dev.fritz2.binding.Handler
 import dev.fritz2.dom.DomListener
 import dev.fritz2.dom.WindowListener
 import kotlinx.coroutines.Job
-import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.MainScope
+import kotlinx.coroutines.flow.*
+import kotlinx.coroutines.plus
 import org.w3c.dom.Element
 import org.w3c.dom.events.Event
 
@@ -16,12 +17,31 @@ interface WithJob {
     val job: Job
 
     /**
+     * Default error handler printing the error to console.
+     *
+     * @param exception Exception to handle
+     */
+    private fun errorHandler(exception: Throwable) {
+        console.error("ERROR: ${exception.message}", exception)
+    }
+
+    /**
      * Connects a [Flow] to a [Handler].
      *
      * @param handler [Handler] that will be called for each action/event on the [Flow]
      * @receiver [Flow] of action/events to bind to an [Handler]
      */
     infix fun <A> Flow<A>.handledBy(handler: Handler<A>) = handler.collect(this, job)
+
+    /**
+     * Connects a [Flow] to a [Handler].
+     *
+     * @param execute function that will be called for each action/event on the [Flow]
+     * @receiver [Flow] of action/events to bind to an [Handler]
+     */
+    infix fun <A> Flow<A>.handledBy(execute: suspend (A) -> Unit) =
+        this.catch { errorHandler(it) }.onEach { execute(it) }.launchIn(MainScope() + job)
+
 
     /**
      * Connects [Event]s to a [Handler].
@@ -35,9 +55,39 @@ interface WithJob {
     /**
      * Connects [Event]s to a [Handler].
      *
+     * @receiver [DomListener] which contains the [Event]
+     * @param execute function that will handle the fired [Event]
+     */
+    infix fun <E : Event, X : Element> DomListener<E, X>.handledBy(execute: suspend (E) -> Unit) =
+        this.events.catch { errorHandler(it) }.onEach { execute(it) }.launchIn(MainScope() + job)
+
+
+    /**
+     * Connects [Event]s to a [Handler].
+     *
      * @receiver [WindowListener] which contains the [Event]
      * @param handler that will handle the fired [Event]
      */
     infix fun <E : Event> WindowListener<E>.handledBy(handler: Handler<Unit>) =
         handler.collect(this.events.map { }, job)
+
+    /**
+     * Connects [Event]s to a [Handler].
+     *
+     * @receiver [WindowListener] which contains the [Event]
+     * @param execute function that will handle the fired [Event]
+     */
+    infix fun <E : Event> WindowListener<E>.handledBy(execute: suspend (E) -> Unit) =
+        this.events.catch { errorHandler(it) }.onEach { execute(it) }.launchIn(MainScope() + job)
+
 }
+
+/**
+ * Connects a [Flow] to a [Handler].
+ *
+ * @param execute function that will be called for each action/event on the [Flow]
+ * @receiver [Flow] of action/events to bind to an [Handler]
+ */
+infix fun <A> Flow<A>.handledBy(execute: suspend (A) -> Unit) =
+    this.catch { console.error("ERROR: ${it.message}", it) }
+        .onEach { execute(it) }.launchIn(MainScope())


### PR DESCRIPTION
Added new easy to use `handleBy` functions which have a lambda parameter. Anytime a new value on the `Flow` occurs the given function gets called.
```kotlin
render {
   button {
       +"Click me!"
       clicks handledBy {
           window.alert("Clicked!")
       }
   }
}
```
Outside the HTML DSL you can do the same:
```kotlin
flowOf("Hello World!") handledBy {
    window.alert(it)
}
```
That is why the `watch()` function at the end of a `Flow` is not needed anymore and is now deprecated.
```kotlin
// before    
flowOf("Hello World!").onEach {
    window.alert(it)
}.watch()
    
// now
flowOf("Hello World!") handledBy {
    window.alert(it)
}
```
This way the handling of data in fritz2 (using `Flows`s) gets more consistent.