### PR TITLE
Use a SharedFlow for Web Component attribute changes

### DIFF
--- a/core/src/jsMain/kotlin/dev/fritz2/webcomponents/webcomponents.kt
+++ b/core/src/jsMain/kotlin/dev/fritz2/webcomponents/webcomponents.kt
@@ -83,7 +83,8 @@ abstract class WebComponent<T : Element>(observeAttributes: Boolean = true) {
      * this callback is used, when building the component in native-js (since ES2015-classes are not supported by Kotlin/JS by now)
      */
     //cannot be private or internal because it is used in native js
-    val attributeChangedCallback: (name: String, value: String) -> Unit = { name, value ->
+    @JsName("attributeChangedCallback")
+    fun attributeChangedCallback(name: String, value: String) {
         _attributeChanges.tryEmit(Pair(name, value))
     }
 

--- a/core/src/jsMain/kotlin/dev/fritz2/webcomponents/webcomponents.kt
+++ b/core/src/jsMain/kotlin/dev/fritz2/webcomponents/webcomponents.kt
@@ -6,7 +6,7 @@ import dev.fritz2.dom.html.Scope
 import dev.fritz2.dom.html.TagContext
 import kotlinx.browser.window
 import kotlinx.coroutines.Job
-import kotlinx.coroutines.channels.awaitClose
+import kotlinx.coroutines.channels.BufferOverflow
 import kotlinx.coroutines.flow.*
 import org.w3c.dom.*
 import kotlin.reflect.KClass
@@ -76,23 +76,22 @@ abstract class WebComponent<T : Element>(observeAttributes: Boolean = true) {
         }.init(element, shadowRoot)
     }
 
+    private val _attributeChanges: MutableSharedFlow<Pair<String, String>> =
+        MutableSharedFlow(replay = 10, onBufferOverflow = BufferOverflow.DROP_OLDEST)
+
     /**
      * this callback is used, when building the component in native-js (since ES2015-classes are not supported by Kotlin/JS by now)
      */
     //cannot be private or internal because it is used in native js
-    lateinit var attributeChangedCallback: (name: String, value: String) -> Unit
+    val attributeChangedCallback: (name: String, value: String) -> Unit = { name, value ->
+        _attributeChanges.tryEmit(Pair(name, value))
+    }
 
     /**
      * a [Flow] of all changes made to observed attributes.
      */
     val attributeChanges: Flow<Pair<String, String>> = if (observeAttributes) {
-        callbackFlow {
-            attributeChangedCallback = { name, value ->
-                trySend(Pair(name, value))
-            }
-            awaitClose {}
-        }.distinctUntilChanged()
-        //TODO: sharedFlow
+        _attributeChanges.distinctUntilChanged()
     } else {
         flowOf()
     }

--- a/core/src/jsTest/kotlin/dev/fritz2/webcomponents/webcomponent.kt
+++ b/core/src/jsTest/kotlin/dev/fritz2/webcomponents/webcomponent.kt
@@ -1,5 +1,7 @@
 package dev.fritz2.webcomponents
 
+import dev.fritz2.binding.storeOf
+import dev.fritz2.dom.Tag
 import dev.fritz2.dom.html.TagContext
 import dev.fritz2.test.initDocument
 import dev.fritz2.test.runTest
@@ -37,5 +39,43 @@ class WebComponentTests {
         }
 
         assertEquals("I am a WebComponent", content?.textContent?.trim())
+    }
+
+    object AttributeComponent : WebComponent<HTMLElement>() {
+        override fun TagContext.init(element: HTMLElement, shadowRoot: ShadowRoot): Tag<HTMLElement> {
+            val store = storeOf("Initial")
+            attributeChanges("test") handledBy { store.update(it) }
+
+            return div(id = "contents") {
+                store.data.asText()
+            }
+        }
+    }
+
+    @Test
+    fun testAttributeChanges() = runTest {
+        initDocument()
+
+        delay(250)
+
+        val body = document.body.unsafeCast<HTMLBodyElement>()
+        val attrComponent = document.createElement("attr-component", ElementCreationOptions("attr-component"))
+        attrComponent.setAttribute("test", "New")
+
+        // This is only called down here in order to replicate https://github.com/jwstegemann/fritz2/issues/83.
+        registerWebComponent("attr-component", AttributeComponent, "test")
+
+        body.appendChild(attrComponent)
+
+        delay(250)
+
+        val content = attrComponent.shadowRoot?.getElementById("contents")
+
+        assertEquals("New", content?.textContent?.trim())
+
+        attrComponent.setAttribute("test", "Newer")
+        delay(250)
+
+        assertEquals("Newer", content?.textContent?.trim())
     }
 }


### PR DESCRIPTION
I was running into a similar issue to what is described in Issue #83, and while investigating the codebase to see what might be causing it, I saw that you were planning to move to using a `SharedFlow` for Web Component attribtues anyway. I believe that this will solve the issue, because `SharedFlow` is a hot flow, so we wouldn't need to wait for someone to consume the flow in order to give `attributeChangedCallback` a value. Hope this helps!