### PR TITLE
fix modal close handler

### DIFF
--- a/components/src/jsMain/kotlin/dev/fritz2/components/modal/component.kt
+++ b/components/src/jsMain/kotlin/dev/fritz2/components/modal/component.kt
@@ -3,7 +3,6 @@ package dev.fritz2.components.modal
 import dev.fritz2.binding.RootStore
 import dev.fritz2.binding.SimpleHandler
 import dev.fritz2.binding.storeOf
-import dev.fritz2.binding.watch
 import dev.fritz2.components.flexBox
 import dev.fritz2.components.foundations.*
 import dev.fritz2.dom.html.Div
@@ -20,7 +19,6 @@ import dev.fritz2.styling.staticStyle
 import dev.fritz2.styling.theme.*
 import kotlinx.browser.document
 import kotlinx.coroutines.Job
-import kotlinx.coroutines.flow.map
 import org.w3c.dom.get
 
 /**
@@ -155,8 +153,8 @@ open class ModalComponent :
             stack + dialog
         }
 
-        val pop = handle { stack ->
-            stack.dropLast(1)
+        fun pop(dialog: ModalRenderContext) = handle { stack ->
+            stack - dialog
         }
     }
 
@@ -256,7 +254,7 @@ open class ModalComponent :
         id: String?,
         prefix: String
     ): SimpleHandler<Unit> {
-        val close = stack.pop
+        lateinit var close: SimpleHandler<Unit>
 
         val modal: ModalRenderContext = { level ->
             flexBox({
@@ -305,6 +303,8 @@ open class ModalComponent :
                 }
             }
         }
+
+        close = stack.pop(modal)
 
         return stack.push(modal)
     }


### PR DESCRIPTION
the close handler in the modal does not always close the correct modal, it does actually only close the modal, which is on top at that moment.

For example triggerring the handler more than once also closes the modal below. When closing a modal and opening another modal simultaneously it is also possible that the wrong modal gets closed .

Instead of closing the modal on top, this pull request removes the explicit modal from the stack to fix these issues.