### PR TITLE
Improve Key API and keys event handling

### DIFF
--- a/components/src/jsMain/kotlin/dev/fritz2/components/popover.kt
+++ b/components/src/jsMain/kotlin/dev/fritz2/components/popover.kt
@@ -9,7 +9,7 @@ import dev.fritz2.dom.Window
 import dev.fritz2.dom.html.Key
 import dev.fritz2.dom.html.Keys
 import dev.fritz2.dom.html.RenderContext
-import dev.fritz2.dom.key
+import dev.fritz2.dom.keys
 import dev.fritz2.styling.*
 import dev.fritz2.styling.params.BasicParams
 import dev.fritz2.styling.params.BoxParams
@@ -20,7 +20,6 @@ import dev.fritz2.styling.theme.PopoverSizes
 import dev.fritz2.styling.theme.Theme
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.debounce
-import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.flow.flowOf
 import org.w3c.dom.HTMLElement
 
@@ -167,7 +166,7 @@ open class PopoverComponent : Component<Unit>,
         context.apply {
 
             if (this@PopoverComponent.closeOnEscape.value) {
-                Window.keyups.key().filter { it == Keys.Escape } handledBy this@PopoverComponent.visible.closeOnKey
+                Window.keyups.keys(Keys.Escape) handledBy this@PopoverComponent.visible.closeOnKey
             }
 
             div(staticCss.name, id) {

--- a/components/src/jsMain/kotlin/dev/fritz2/components/popover.kt
+++ b/components/src/jsMain/kotlin/dev/fritz2/components/popover.kt
@@ -21,6 +21,7 @@ import dev.fritz2.styling.theme.Theme
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.debounce
 import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.flow.map
 import org.w3c.dom.HTMLElement
 
 /**
@@ -153,7 +154,7 @@ open class PopoverComponent : Component<Unit>,
 
     private val visible = object : RootStore<Boolean>(false) {
         val toggle = handle { !it }
-        val closeOnKey = handle<Key> { _, _ -> false }
+        val closeOnKey = handle<Unit> { _, _ -> false }
     }
 
     override fun render(
@@ -166,7 +167,7 @@ open class PopoverComponent : Component<Unit>,
         context.apply {
 
             if (this@PopoverComponent.closeOnEscape.value) {
-                Window.keyups.keys(Keys.Escape) handledBy this@PopoverComponent.visible.closeOnKey
+                Window.keyups.keys(Keys.Escape).map { } handledBy this@PopoverComponent.visible.closeOnKey
             }
 
             div(staticCss.name, id) {

--- a/components/src/jsMain/kotlin/dev/fritz2/components/slider/component.kt
+++ b/components/src/jsMain/kotlin/dev/fritz2/components/slider/component.kt
@@ -13,6 +13,7 @@ import dev.fritz2.dom.html.Div
 import dev.fritz2.dom.html.Key
 import dev.fritz2.dom.html.Keys
 import dev.fritz2.dom.html.RenderContext
+import dev.fritz2.dom.keys
 import dev.fritz2.styling.StyleClass
 import dev.fritz2.styling.div
 import dev.fritz2.styling.name
@@ -362,16 +363,11 @@ open class SliderComponent(protected val store: Store<Int>? = null) :
                     clicks.events handledBy internalStore.updateByClick
                     Window.mousemoves.events handledBy internalStore.updateByMovement
                     Window.mouseups.events.map { false } handledBy internalStore.updateMovementTracking
-                    keydowns.events.mapNotNull {
-                        when (Key(it)) {
-                            Keys.ArrowDown, Keys.ArrowLeft -> {
-                                it.preventDefault()
-                                Direction.DOWN
-                            }
-                            Keys.ArrowUp, Keys.ArrowRight -> {
-                                it.preventDefault()
-                                Direction.UP
-                            }
+                    keydowns.keys(Keys.ArrowDown, Keys.ArrowUp, Keys.ArrowLeft, Keys.ArrowRight).mapNotNull {
+                        it.event.preventDefault()
+                        when(it.key) {
+                            Keys.ArrowDown, Keys.ArrowLeft -> Direction.DOWN
+                            Keys.ArrowUp, Keys.ArrowRight -> Direction.UP
                             else -> null
                         }
                     } handledBy internalStore.updateByKeystroke

--- a/components/src/jsMain/kotlin/dev/fritz2/components/slider/component.kt
+++ b/components/src/jsMain/kotlin/dev/fritz2/components/slider/component.kt
@@ -10,7 +10,6 @@ import dev.fritz2.dom.EventContext
 import dev.fritz2.dom.Tag
 import dev.fritz2.dom.Window
 import dev.fritz2.dom.html.Div
-import dev.fritz2.dom.html.Key
 import dev.fritz2.dom.html.Keys
 import dev.fritz2.dom.html.RenderContext
 import dev.fritz2.dom.keys
@@ -363,14 +362,15 @@ open class SliderComponent(protected val store: Store<Int>? = null) :
                     clicks.events handledBy internalStore.updateByClick
                     Window.mousemoves.events handledBy internalStore.updateByMovement
                     Window.mouseups.events.map { false } handledBy internalStore.updateMovementTracking
-                    keydowns.keys(Keys.ArrowDown, Keys.ArrowUp, Keys.ArrowLeft, Keys.ArrowRight).mapNotNull {
-                        it.event.preventDefault()
-                        when(it.key) {
-                            Keys.ArrowDown, Keys.ArrowLeft -> Direction.DOWN
-                            Keys.ArrowUp, Keys.ArrowRight -> Direction.UP
-                            else -> null
-                        }
-                    } handledBy internalStore.updateByKeystroke
+                    keydowns.keys(Keys.ArrowDown, Keys.ArrowUp, Keys.ArrowLeft, Keys.ArrowRight)
+                        .mapNotNull { (key, event) ->
+                            event.preventDefault()
+                            when (key) {
+                                Keys.ArrowDown, Keys.ArrowLeft -> Direction.DOWN
+                                Keys.ArrowUp, Keys.ArrowRight -> Direction.UP
+                                else -> null
+                            }
+                        } handledBy internalStore.updateByKeystroke
 
                     internalStore.data.render { state ->
                         div({

--- a/core/src/jsMain/kotlin/dev/fritz2/dom/html/events.kt
+++ b/core/src/jsMain/kotlin/dev/fritz2/dom/html/events.kt
@@ -385,10 +385,10 @@ data class Key(
      * @see ExtraKey
      */
     operator fun plus(other: ExtraKey): Key = copy(
-        ctrl = other.ctrl,
-        alt = other.alt,
-        shift = other.shift,
-        meta = other.meta
+        ctrl = ctrl || other.ctrl,
+        alt = alt || other.alt,
+        shift = shift || other.shift,
+        meta = meta || other.meta
     )
 }
 

--- a/core/src/jsMain/kotlin/dev/fritz2/dom/html/events.kt
+++ b/core/src/jsMain/kotlin/dev/fritz2/dom/html/events.kt
@@ -376,10 +376,10 @@ data class Key(
      * This operator function enables the concatenation with additional extra keys:
      * ```
      * Key("F") + Keys.Alt
-     * // of even
-     * val searchKey = Key("F") + Keys.Alt + Keys.Shift
-     * //              ^^^^^^^^^^^^^^^^^^^
-     * //              will already result in a `Key`
+     * // or even
+     * Key("F") + Keys.Alt + Keys.Shift
+     * ^^^^^^^^^^^^^^^^^^^
+     * will already result in a `Key`
      * ```
      *
      * @see ExtraKey
@@ -400,7 +400,7 @@ data class Key(
  * // define a commonly used combination
  * val searchKey = Keys.Shift + Keys.Alt + "F"
  *
- * // react only to a set of Keys to enable keyboard navigation of some component
+ * // react only to a set of Keys e.g. to enable keyboard navigation of some component
  * div {
  *     keydowns.keys(Keys.Space, Keys.Enter).map { } handledBy selectItem
  * }

--- a/core/src/jsMain/kotlin/dev/fritz2/dom/html/events.kt
+++ b/core/src/jsMain/kotlin/dev/fritz2/dom/html/events.kt
@@ -265,16 +265,16 @@ object Events {
  *
  * More info [here](https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/key/Key_Values)
  */
-class Key(
-    val code: String,
+data class Key(
     val key: String,
-    val ctrl: Boolean = false,
-    val alt: Boolean = false,
-    val shift: Boolean = false,
-    val meta: Boolean = false
+    val event: KeyboardEvent
 ) {
-    constructor(key: String) : this(key, key)
-    constructor(e: KeyboardEvent) : this(e.code, e.key, e.ctrlKey, e.altKey, e.shiftKey, e.metaKey)
+    constructor(event: KeyboardEvent) : this(event.key, event)
+
+    val ctrl: Boolean = event.ctrlKey
+    val alt: Boolean = event.altKey
+    val shift: Boolean = event.shiftKey
+    val meta: Boolean = event.metaKey
 
     override fun equals(other: Any?): Boolean =
         if (other is Key) key == other.key else super.equals(other)
@@ -285,80 +285,80 @@ class Key(
 }
 
 object Keys {
-    val Unidentified = Key("Unidentified")
-    val Alt = Key("Alt")
-    val AltGraph = Key("AltGraph")
-    val CapsLock = Key("CapsLock")
-    val Control = Key("Control")
-    val Fn = Key("Fn")
-    val FnLock = Key("FnLock")
-    val Hyper = Key("Hyper")
-    val Meta = Key("Meta")
-    val NumLock = Key("NumLock")
-    val ScrollLock = Key("ScrollLock")
-    val Shift = Key("Shift")
-    val Super = Key("Super")
-    val Symbol = Key("Symbol")
-    val SymbolLock = Key("SymbolLock")
-    val Enter = Key("Enter")
-    val Tab = Key("Tab")
-    val Space = Key(" ")
-    val ArrowDown = Key("ArrowDown")
-    val ArrowLeft = Key("ArrowLeft")
-    val ArrowRight = Key("ArrowRight")
-    val ArrowUp = Key("ArrowUp")
-    val End = Key("End")
-    val Home = Key("Home")
-    val PageDown = Key("PageDown")
-    val PageUp = Key("PageUp")
-    val Backspace = Key("Backspace")
-    val Clear = Key("Clear")
-    val Copy = Key("Copy")
-    val CrSel = Key("CrSel")
-    val Cut = Key("Cut")
-    val Delete = Key("Delete")
-    val EraseEof = Key("EraseEof")
-    val ExSel = Key("ExSel")
-    val Insert = Key("Insert")
-    val Paste = Key("Paste")
-    val Redo = Key("Redo")
-    val Undo = Key("Undo")
-    val Accept = Key("Accept")
-    val Again = Key("Again")
-    val Attn = Key("Attn")
-    val Cancel = Key("Cancel")
-    val ContextMenu = Key("ContextMenu")
-    val Escape = Key("Escape")
-    val Execute = Key("Execute")
-    val Find = Key("Find")
-    val Help = Key("Help")
-    val Pause = Key("Pause")
-    val Play = Key("Play")
-    val Props = Key("Props")
-    val Select = Key("Select")
-    val ZoomIn = Key("ZoomIn")
-    val ZoomOut = Key("ZoomOut")
-    val F1 = Key("F1")
-    val F2 = Key("F2")
-    val F3 = Key("F3")
-    val F4 = Key("F4")
-    val F5 = Key("F5")
-    val F6 = Key("F6")
-    val F7 = Key("F7")
-    val F8 = Key("F8")
-    val F9 = Key("F9")
-    val F10 = Key("F10")
-    val F11 = Key("F11")
-    val F12 = Key("F12")
-    val Num0 = Key("0")
-    val Num1 = Key("1")
-    val Num2 = Key("2")
-    val Num3 = Key("3")
-    val Num4 = Key("4")
-    val Num5 = Key("5")
-    val Num6 = Key("6")
-    val Num7 = Key("7")
-    val Num8 = Key("8")
-    val Num9 = Key("9")
-    val Separator = Key("Separator")
+    const val Unidentified = "Unidentified"
+    const val Alt = "Alt"
+    const val AltGraph = "AltGraph"
+    const val CapsLock = "CapsLock"
+    const val Control = "Control"
+    const val Fn = "Fn"
+    const val FnLock = "FnLock"
+    const val Hyper = "Hyper"
+    const val Meta = "Meta"
+    const val NumLock = "NumLock"
+    const val ScrollLock = "ScrollLock"
+    const val Shift = "Shift"
+    const val Super = "Super"
+    const val Symbol = "Symbol"
+    const val SymbolLock = "SymbolLock"
+    const val Enter = "Enter"
+    const val Tab = "Tab"
+    const val Space = " "
+    const val ArrowDown = "ArrowDown"
+    const val ArrowLeft = "ArrowLeft"
+    const val ArrowRight = "ArrowRight"
+    const val ArrowUp = "ArrowUp"
+    const val End = "End"
+    const val Home = "Home"
+    const val PageDown = "PageDown"
+    const val PageUp = "PageUp"
+    const val Backspace = "Backspace"
+    const val Clear = "Clear"
+    const val Copy = "Copy"
+    const val CrSel = "CrSel"
+    const val Cut = "Cut"
+    const val Delete = "Delete"
+    const val EraseEof = "EraseEof"
+    const val ExSel = "ExSel"
+    const val Insert = "Insert"
+    const val Paste = "Paste"
+    const val Redo = "Redo"
+    const val Undo = "Undo"
+    const val Accept = "Accept"
+    const val Again = "Again"
+    const val Attn = "Attn"
+    const val Cancel = "Cancel"
+    const val ContextMenu = "ContextMenu"
+    const val Escape = "Escape"
+    const val Execute = "Execute"
+    const val Find = "Find"
+    const val Help = "Help"
+    const val Pause = "Pause"
+    const val Play = "Play"
+    const val Props = "Props"
+    const val Select = "Select"
+    const val ZoomIn = "ZoomIn"
+    const val ZoomOut = "ZoomOut"
+    const val F1 = "F1"
+    const val F2 = "F2"
+    const val F3 = "F3"
+    const val F4 = "F4"
+    const val F5 = "F5"
+    const val F6 = "F6"
+    const val F7 = "F7"
+    const val F8 = "F8"
+    const val F9 = "F9"
+    const val F10 = "F10"
+    const val F11 = "F11"
+    const val F12 = "F12"
+    const val Num0 = "0"
+    const val Num1 = "1"
+    const val Num2 = "2"
+    const val Num3 = "3"
+    const val Num4 = "4"
+    const val Num5 = "5"
+    const val Num6 = "6"
+    const val Num7 = "7"
+    const val Num8 = "8"
+    const val Num9 = "9"
+    const val Separator = "Separator"
 }

--- a/core/src/jsMain/kotlin/dev/fritz2/dom/listener.kt
+++ b/core/src/jsMain/kotlin/dev/fritz2/dom/listener.kt
@@ -3,6 +3,7 @@ package dev.fritz2.dom
 import dev.fritz2.dom.html.Key
 import dev.fritz2.dom.html.Keys
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.mapNotNull
 import org.w3c.dom.*
@@ -163,12 +164,46 @@ fun DomListener<Event, HTMLSelectElement>.selectedText(): Flow<String> =
 fun <X : Element> DomListener<KeyboardEvent, X>.key(): Flow<Key> = events.map { Key(it) }
 
 /**
+ * Gives you the pressed key as [Key] combined with the [KeyboardEvent] filtered by a given set of keys.
+ * All other events from other keys will be dropped!
+ *
+ * This is very helpful if the event bubbling should be stopped for example, as the filtering has to be done before
+ * and the bubbling should in most cases only be stopped for the handled keys and not the other ones!
+ *
+ * @param keys a set with all keys that should be handled
+ */
+fun <X : Element> DomListener<KeyboardEvent, X>.keys(keys: Set<Key>) =
+    events.map { Key(it) to it }.filter { keys.contains(it.first) }
+
+/**
+ * Gives you the pressed key as [Key] combined with the [KeyboardEvent] filtered by arbitrary given keys.
+ * All other events from other keys will be dropped!
+ *
+ * This is very helpful if the event bubbling should be stopped for example, as the filtering has to be done before
+ * and the bubbling should in most cases only be stopped for the handled keys and not the other ones!
+ *
+ * @param keys an arbitrary amount of keys which should be handled
+ */
+fun <X : Element> DomListener<KeyboardEvent, X>.keys(vararg keys: Key) = this.keys(keys.toSet())
+
+/**
+ * Gives you the pressed key as [Key] combined with the [KeyboardEvent] filtered by exactly one key.
+ * All other events from other keys will be dropped!
+ *
+ * This is very helpful if the event bubbling should be stopped for example, as the filtering has to be done before
+ * and the bubbling should in most cases only be stopped for the handled key and for other ones!
+ *
+ * @param key the key to be handled
+ */
+fun <X : Element> DomListener<KeyboardEvent, X>.keys(key: Key) = events.map { Key(it) to it }.filter { it.first == key }
+
+/**
  * Gives you the pressed key as [Key] from a [KeyboardEvent].
  */
 fun WindowListener<KeyboardEvent>.key(): Flow<Key> = events.map { Key(it) }
 
 /**
- * Merges mutiple [DomListener] like the analog method on [Flow]s
+ * Merges multiple [DomListener] like the analog method on [Flow]s
  *
  * @param listener the [DomListener] to merge
  */

--- a/core/src/jsMain/kotlin/dev/fritz2/dom/listener.kt
+++ b/core/src/jsMain/kotlin/dev/fritz2/dom/listener.kt
@@ -88,7 +88,7 @@ fun DomListener<InputEvent, HTMLInputElement>.valuesAsNumber(): Flow<Double> =
  */
 fun DomListener<KeyboardEvent, HTMLInputElement>.enter(): Flow<String> =
     events.mapNotNull {
-        if (Key(it) == Keys.Enter) it.target.unsafeCast<HTMLInputElement>().value
+        if (Key(it).key == Keys.Enter) it.target.unsafeCast<HTMLInputElement>().value
         else null
     }
 
@@ -97,7 +97,7 @@ fun DomListener<KeyboardEvent, HTMLInputElement>.enter(): Flow<String> =
  */
 fun DomListener<KeyboardEvent, HTMLInputElement>.enterAsNumber(): Flow<Double> =
     events.mapNotNull {
-        if (Key(it) == Keys.Enter) it.target.unsafeCast<HTMLInputElement>().valueAsNumber
+        if (Key(it).key == Keys.Enter) it.target.unsafeCast<HTMLInputElement>().valueAsNumber
         else null
     }
 
@@ -118,7 +118,7 @@ fun DomListener<Event, HTMLTextAreaElement>.values(): Flow<String> =
  */
 fun DomListener<KeyboardEvent, HTMLTextAreaElement>.enter(): Flow<String> =
     events.mapNotNull {
-        if (Key(it) == Keys.Enter) it.target.unsafeCast<HTMLTextAreaElement>().value
+        if (Key(it).key == Keys.Enter) it.target.unsafeCast<HTMLTextAreaElement>().value
         else null
     }
 
@@ -161,46 +161,81 @@ fun DomListener<Event, HTMLSelectElement>.selectedText(): Flow<String> =
 /**
  * Gives you the pressed key as [Key] from a [KeyboardEvent].
  */
+@Deprecated("use .keys(vararg keys: String) instead in order to filter and handle specific keys")
 fun <X : Element> DomListener<KeyboardEvent, X>.key(): Flow<Key> = events.map { Key(it) }
 
 /**
- * Gives you the pressed key as [Key] combined with the [KeyboardEvent] filtered by a given set of keys.
+ * Gives you the pressed key as [Key] (including the [KeyboardEvent]) filtered by a given set of keys.
  * All other events from other keys will be dropped!
  *
  * This is very helpful if the event bubbling should be stopped for example, as the filtering has to be done before
  * and the bubbling should in most cases only be stopped for the handled keys and not the other ones!
  *
- * @param keys a set with all keys that should be handled
+ * @param keys a set with all keys that should be handled. Use [Keys] object for predefined key constants.
  */
-fun <X : Element> DomListener<KeyboardEvent, X>.keys(keys: Set<Key>) =
-    events.map { Key(it) to it }.filter { keys.contains(it.first) }
+fun <X : Element> DomListener<KeyboardEvent, X>.keys(keys: Set<String>) =
+    events.map { Key(it) }.filter { keys.contains(it.key) }
 
 /**
- * Gives you the pressed key as [Key] combined with the [KeyboardEvent] filtered by arbitrary given keys.
+ * Gives you the pressed key as [Key] (including the [KeyboardEvent]) filtered by arbitrary given keys.
  * All other events from other keys will be dropped!
  *
  * This is very helpful if the event bubbling should be stopped for example, as the filtering has to be done before
  * and the bubbling should in most cases only be stopped for the handled keys and not the other ones!
  *
- * @param keys an arbitrary amount of keys which should be handled
+ * @param keys an arbitrary amount of keys which should be handled. Use [Keys] object for predefined key constants.
  */
-fun <X : Element> DomListener<KeyboardEvent, X>.keys(vararg keys: Key) = this.keys(keys.toSet())
+fun <X : Element> DomListener<KeyboardEvent, X>.keys(vararg keys: String) = this.keys(keys.toSet())
 
 /**
- * Gives you the pressed key as [Key] combined with the [KeyboardEvent] filtered by exactly one key.
+ * Gives you the pressed key as [Key] (including the [KeyboardEvent]) filtered by exactly one key.
  * All other events from other keys will be dropped!
  *
  * This is very helpful if the event bubbling should be stopped for example, as the filtering has to be done before
  * and the bubbling should in most cases only be stopped for the handled key and for other ones!
  *
- * @param key the key to be handled
+ * @param key the key to be handled. Use [Keys] object for predefined key constants.
  */
-fun <X : Element> DomListener<KeyboardEvent, X>.keys(key: Key) = events.map { Key(it) to it }.filter { it.first == key }
+fun <X : Element> DomListener<KeyboardEvent, X>.keys(key: Key) = events.map { Key(it) }.filter { it == key }
 
 /**
  * Gives you the pressed key as [Key] from a [KeyboardEvent].
  */
+@Deprecated("use .keys(vararg keys: String) instead in order to filter and handle specific keys")
 fun WindowListener<KeyboardEvent>.key(): Flow<Key> = events.map { Key(it) }
+
+/**
+ * Gives you the pressed key as [Key] (inclusing the [KeyboardEvent]) filtered by a given set of keys.
+ * All other events from other keys will be dropped!
+ *
+ * This is very helpful if the event bubbling should be stopped for example, as the filtering has to be done before
+ * and the bubbling should in most cases only be stopped for the handled keys and not the other ones!
+ *
+ * @param keys a set with all keys that should be handled. Use [Keys] object for predefined key constants.
+ */
+fun WindowListener<KeyboardEvent>.keys(keys: Set<String>) = events.map { Key(it) }.filter { keys.contains(it.key) }
+
+/**
+ * Gives you the pressed key as [Key] (including the [KeyboardEvent]) filtered by arbitrary given keys.
+ * All other events from other keys will be dropped!
+ *
+ * This is very helpful if the event bubbling should be stopped for example, as the filtering has to be done before
+ * and the bubbling should in most cases only be stopped for the handled keys and not the other ones!
+ *
+ * @param keys an arbitrary amount of keys which should be handled. Use [Keys] object for predefined key constants.
+ */
+fun WindowListener<KeyboardEvent>.keys(vararg keys: String) = this.keys(keys.toSet())
+
+/**
+ * Gives you the pressed key as [Key] (including the [KeyboardEvent]) filtered by exactly one key.
+ * All other events from other keys will be dropped!
+ *
+ * This is very helpful if the event bubbling should be stopped for example, as the filtering has to be done before
+ * and the bubbling should in most cases only be stopped for the handled key and for other ones!
+ *
+ * @param key the key to be handled. Use [Keys] object for predefined key constants.
+ */
+fun WindowListener<KeyboardEvent>.keys(key: Key) = events.map { Key(it) }.filter { it == key }
 
 /**
  * Merges multiple [DomListener] like the analog method on [Flow]s

--- a/core/src/jsMain/kotlin/dev/fritz2/dom/listener.kt
+++ b/core/src/jsMain/kotlin/dev/fritz2/dom/listener.kt
@@ -86,18 +86,20 @@ fun DomListener<InputEvent, HTMLInputElement>.valuesAsNumber(): Flow<Double> =
 /**
  * Gives you the new value as [String] from the targeting [Element] when enter is pressed.
  */
+@Deprecated("use keys functions instead in order to filter and handle specific keys")
 fun DomListener<KeyboardEvent, HTMLInputElement>.enter(): Flow<String> =
     events.mapNotNull {
-        if (Key(it).key == Keys.Enter) it.target.unsafeCast<HTMLInputElement>().value
+        if (Key(it) == Keys.Enter) it.target.unsafeCast<HTMLInputElement>().value
         else null
     }
 
 /**
  * Gives you the new value as [Double] from the targeting [Element] when enter is pressed.
  */
+@Deprecated("use keys functions instead in order to filter and handle specific keys")
 fun DomListener<KeyboardEvent, HTMLInputElement>.enterAsNumber(): Flow<Double> =
     events.mapNotNull {
-        if (Key(it).key == Keys.Enter) it.target.unsafeCast<HTMLInputElement>().valueAsNumber
+        if (Key(it) == Keys.Enter) it.target.unsafeCast<HTMLInputElement>().valueAsNumber
         else null
     }
 
@@ -116,9 +118,10 @@ fun DomListener<Event, HTMLTextAreaElement>.values(): Flow<String> =
 /**
  * Gives you the new value as [String] from the targeting [Element].
  */
+@Deprecated("use keys functions instead in order to filter and handle specific keys")
 fun DomListener<KeyboardEvent, HTMLTextAreaElement>.enter(): Flow<String> =
     events.mapNotNull {
-        if (Key(it).key == Keys.Enter) it.target.unsafeCast<HTMLTextAreaElement>().value
+        if (Key(it) == Keys.Enter) it.target.unsafeCast<HTMLTextAreaElement>().value
         else null
     }
 
@@ -161,7 +164,7 @@ fun DomListener<Event, HTMLSelectElement>.selectedText(): Flow<String> =
 /**
  * Gives you the pressed key as [Key] from a [KeyboardEvent].
  */
-@Deprecated("use .keys(vararg keys: String) instead in order to filter and handle specific keys")
+@Deprecated("use keys functions instead in order to filter and handle specific keys")
 fun <X : Element> DomListener<KeyboardEvent, X>.key(): Flow<Key> = events.map { Key(it) }
 
 /**
@@ -173,11 +176,11 @@ fun <X : Element> DomListener<KeyboardEvent, X>.key(): Flow<Key> = events.map { 
  *
  * @param keys a set with all keys that should be handled. Use [Keys] object for predefined key constants.
  */
-fun <X : Element> DomListener<KeyboardEvent, X>.keys(keys: Set<String>) =
-    events.map { Key(it) }.filter { keys.contains(it.key) }
+fun <X : Element> DomListener<KeyboardEvent, X>.keys(keys: Set<Key>) =
+    events.map { Key(it) to it }.filter { keys.contains(it.first) }
 
 /**
- * Gives you the pressed key as [Key] (including the [KeyboardEvent]) filtered by arbitrary given keys.
+ * Gives you the pressed key as [Key] paired with the [KeyboardEvent] filtered by arbitrary given keys.
  * All other events from other keys will be dropped!
  *
  * This is very helpful if the event bubbling should be stopped for example, as the filtering has to be done before
@@ -185,10 +188,10 @@ fun <X : Element> DomListener<KeyboardEvent, X>.keys(keys: Set<String>) =
  *
  * @param keys an arbitrary amount of keys which should be handled. Use [Keys] object for predefined key constants.
  */
-fun <X : Element> DomListener<KeyboardEvent, X>.keys(vararg keys: String) = this.keys(keys.toSet())
+fun <X : Element> DomListener<KeyboardEvent, X>.keys(vararg keys: Key) = this.keys(keys.toSet())
 
 /**
- * Gives you the pressed key as [Key] (including the [KeyboardEvent]) filtered by exactly one key.
+ * Gives you the pressed key as [Key] paired with the [KeyboardEvent] filtered by exactly one key.
  * All other events from other keys will be dropped!
  *
  * This is very helpful if the event bubbling should be stopped for example, as the filtering has to be done before
@@ -196,16 +199,16 @@ fun <X : Element> DomListener<KeyboardEvent, X>.keys(vararg keys: String) = this
  *
  * @param key the key to be handled. Use [Keys] object for predefined key constants.
  */
-fun <X : Element> DomListener<KeyboardEvent, X>.keys(key: Key) = events.map { Key(it) }.filter { it == key }
+fun <X : Element> DomListener<KeyboardEvent, X>.keys(key: Key) = events.map { Key(it) to it }.filter { it.first == key }
 
 /**
  * Gives you the pressed key as [Key] from a [KeyboardEvent].
  */
-@Deprecated("use .keys(vararg keys: String) instead in order to filter and handle specific keys")
+@Deprecated("use keys functions instead in order to filter and handle specific keys")
 fun WindowListener<KeyboardEvent>.key(): Flow<Key> = events.map { Key(it) }
 
 /**
- * Gives you the pressed key as [Key] (inclusing the [KeyboardEvent]) filtered by a given set of keys.
+ * Gives you the pressed key as [Key] paired with the [KeyboardEvent] filtered by a given set of keys.
  * All other events from other keys will be dropped!
  *
  * This is very helpful if the event bubbling should be stopped for example, as the filtering has to be done before
@@ -213,10 +216,10 @@ fun WindowListener<KeyboardEvent>.key(): Flow<Key> = events.map { Key(it) }
  *
  * @param keys a set with all keys that should be handled. Use [Keys] object for predefined key constants.
  */
-fun WindowListener<KeyboardEvent>.keys(keys: Set<String>) = events.map { Key(it) }.filter { keys.contains(it.key) }
+fun WindowListener<KeyboardEvent>.keys(keys: Set<Key>) = events.map { Key(it) to it }.filter { keys.contains(it.first) }
 
 /**
- * Gives you the pressed key as [Key] (including the [KeyboardEvent]) filtered by arbitrary given keys.
+ * Gives you the pressed key as [Key] paired with the [KeyboardEvent] filtered by arbitrary given keys.
  * All other events from other keys will be dropped!
  *
  * This is very helpful if the event bubbling should be stopped for example, as the filtering has to be done before
@@ -224,10 +227,10 @@ fun WindowListener<KeyboardEvent>.keys(keys: Set<String>) = events.map { Key(it)
  *
  * @param keys an arbitrary amount of keys which should be handled. Use [Keys] object for predefined key constants.
  */
-fun WindowListener<KeyboardEvent>.keys(vararg keys: String) = this.keys(keys.toSet())
+fun WindowListener<KeyboardEvent>.keys(vararg keys: Key) = this.keys(keys.toSet())
 
 /**
- * Gives you the pressed key as [Key] (including the [KeyboardEvent]) filtered by exactly one key.
+ * Gives you the pressed key as [Key] paired with the [KeyboardEvent] filtered by exactly one key.
  * All other events from other keys will be dropped!
  *
  * This is very helpful if the event bubbling should be stopped for example, as the filtering has to be done before
@@ -235,7 +238,7 @@ fun WindowListener<KeyboardEvent>.keys(vararg keys: String) = this.keys(keys.toS
  *
  * @param key the key to be handled. Use [Keys] object for predefined key constants.
  */
-fun WindowListener<KeyboardEvent>.keys(key: Key) = events.map { Key(it) }.filter { it == key }
+fun WindowListener<KeyboardEvent>.keys(key: Key) = events.map { Key(it) to it }.filter { it.first == key }
 
 /**
  * Merges multiple [DomListener] like the analog method on [Flow]s

--- a/core/src/jsTest/kotlin/dev/fritz2/dom/html/events.kt
+++ b/core/src/jsTest/kotlin/dev/fritz2/dom/html/events.kt
@@ -7,7 +7,32 @@ import kotlin.test.assertTrue
 class KeyTests {
 
     @Test
-    fun testCanCombineKeyWithExtraKey() {
+    fun testCreateKeyWithUpperCaseWillConvertToLowercase() {
+        assertEquals(Key("K"), Key("k"))
+        assertEquals(Keys.Control + "K", Key("k", ctrl = true))
+    }
+
+    @Test
+    fun testKeysOfPredefinedKeyValuesWillRemainMixedCase() {
+        assertEquals(Keys.ArrowDown.name, "ArrowDown")
+        assertEquals(Key("ArrowDown").name, "ArrowDown")
+    }
+
+    /**
+     * This is a drawback of using private constructors with data classes!
+     * So this test is rather documentation of the pure fact than useful expected behaviour ;-)
+     *
+     * But keep in mind that the normalization process to convert all none predefined key names (that is all keys with
+     * a name longer than one character) is just a benevolent act to users - if somehow one would like to create a
+     * `Key` object with uppercase letter we cannot prevent this for all cases!
+     */
+    @Test
+    fun testUsingCopyCanCreateKeysWithSingleUppercaseLetter() {
+        assertEquals("k", Key("Foo").copy(name = "k").name)
+    }
+
+    @Test
+    fun testCanCombineKeyWithModifierKey() {
         // single concatenation
         assertEquals(Key("K", shift = true), Key("K") + Keys.Shift)
         assertEquals(Key("K", alt = true), Key("K") + Keys.Alt)
@@ -41,7 +66,7 @@ class KeyTests {
     }
 
     @Test
-    fun testCanCombineExtraKeyWithKey() {
+    fun testCanCombineModifierKeyWithKey() {
         // single concatenation
         assertEquals(Key("K", shift = true), Keys.Shift + Key("K"))
         assertEquals(Key("K", alt = true), Keys.Alt + Key("K"))
@@ -68,12 +93,12 @@ class KeyTests {
     }
 
     @Test
-    fun testCanCombineExtraKeyWithString() {
+    fun testCanCombineModifierKeyWithString() {
         assertEquals(Key("K", alt = true, shift = true), Keys.Alt + Keys.Shift + "K")
     }
 
     @Test
-    fun testCanCombineMultipleExtraKeys() {
+    fun testCanCombineMultipleModifierKeys() {
         with(Keys.Alt + Keys.Shift) {
             assertTrue(this.alt)
             assertTrue(this.shift)

--- a/core/src/jsTest/kotlin/dev/fritz2/dom/html/events.kt
+++ b/core/src/jsTest/kotlin/dev/fritz2/dom/html/events.kt
@@ -1,0 +1,95 @@
+package dev.fritz2.dom.html
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class KeyTests {
+
+    @Test
+    fun testCanCombineKeyWithExtraKey() {
+        // single concatenation
+        assertEquals(Key("K", shift = true), Key("K") + Keys.Shift)
+        assertEquals(Key("K", alt = true), Key("K") + Keys.Alt)
+        assertEquals(Key("K", ctrl = true), Key("K") + Keys.Control)
+        assertEquals(Key("K", meta = true), Key("K") + Keys.Meta)
+
+        // double concatenations
+        assertEquals(Key("K", shift = true, alt = true), Key("K") + Keys.Shift + Keys.Alt)
+        assertEquals(Key("K", shift = true, alt = true), Key("K") + Keys.Alt + Keys.Shift)
+
+        // triple  concatenations
+        assertEquals(
+            Key("K", shift = true, alt = true, ctrl = true),
+            Key("K") + Keys.Shift + Keys.Alt + Keys.Control
+        )
+        assertEquals(
+            Key("K", shift = true, alt = true, ctrl = true),
+            Key("K") + Keys.Control + Keys.Shift + Keys.Alt
+        )
+        assertEquals(
+            Key("K", shift = true, alt = true, ctrl = true),
+            Key("K") + Keys.Alt + Keys.Control + Keys.Shift
+        )
+
+        // plus is idempotent
+        assertEquals(Key("K", shift = true), Key("K") + Keys.Shift + Keys.Shift)
+        assertEquals(
+            Key("K", shift = true, alt = true),
+            Key("K") + Keys.Shift + Keys.Alt + Keys.Shift + Keys.Alt + Keys.Shift + Keys.Alt
+        )
+    }
+
+    @Test
+    fun testCanCombineExtraKeyWithKey() {
+        // single concatenation
+        assertEquals(Key("K", shift = true), Keys.Shift + Key("K"))
+        assertEquals(Key("K", alt = true), Keys.Alt + Key("K"))
+        assertEquals(Key("K", ctrl = true), Keys.Control + Key("K"))
+        assertEquals(Key("K", meta = true), Keys.Meta + Key("K"))
+
+        // double concatenations
+        assertEquals(Key("K", shift = true, alt = true), Keys.Shift + Keys.Alt + Key("K"))
+        assertEquals(Key("K", shift = true, alt = true), Keys.Alt + Keys.Shift + Key("K"))
+
+        // triple  concatenations
+        assertEquals(
+            Key("K", shift = true, alt = true, ctrl = true),
+            Keys.Shift + Keys.Alt + Keys.Control + Key("K")
+        )
+        assertEquals(
+            Key("K", shift = true, alt = true, ctrl = true),
+            Keys.Control + Keys.Shift + Keys.Alt + Key("K")
+        )
+        assertEquals(
+            Key("K", shift = true, alt = true, ctrl = true),
+            Keys.Alt + Keys.Control + Keys.Shift + Key("K")
+        )
+    }
+
+    @Test
+    fun testCanCombineExtraKeyWithString() {
+        assertEquals(Key("K", alt = true, shift = true), Keys.Alt + Keys.Shift + "K")
+    }
+
+    @Test
+    fun testCanCombineMultipleExtraKeys() {
+        with(Keys.Alt + Keys.Shift) {
+            assertTrue(this.alt)
+            assertTrue(this.shift)
+        }
+
+        with(Keys.Alt + Keys.Shift + Keys.Control) {
+            assertTrue(this.alt)
+            assertTrue(this.shift)
+            assertTrue(this.ctrl)
+        }
+
+        with(Keys.Alt + Keys.Shift + Keys.Control + Keys.Meta) {
+            assertTrue(this.alt)
+            assertTrue(this.shift)
+            assertTrue(this.ctrl)
+            assertTrue(this.meta)
+        }
+    }
+}

--- a/core/src/jsTest/kotlin/dev/fritz2/dom/listener.kt
+++ b/core/src/jsTest/kotlin/dev/fritz2/dom/listener.kt
@@ -181,7 +181,7 @@ class ListenerTest {
                     key.meta -> pressed = "meta+"
                     key.shift -> pressed = "shift+"
                 }
-                pressed += when (key.key) {
+                pressed += when (key) {
                     Keys.ArrowUp -> "up"
                     Keys.ArrowDown -> "down"
                     else -> "unknown"
@@ -214,10 +214,10 @@ class ListenerTest {
         val keyboardEvents = listOf(Keys.ArrowUp, Keys.ArrowDown)
             .flatMap {
                 listOf(
-                    KeyboardEvent("keydown", KeyboardEventInit(it, it, ctrlKey = true)),
-                    KeyboardEvent("keydown", KeyboardEventInit(it, it, altKey = true)),
-                    KeyboardEvent("keydown", KeyboardEventInit(it, it, shiftKey = true)),
-                    KeyboardEvent("keydown", KeyboardEventInit(it, it, metaKey = true))
+                    KeyboardEvent("keydown", KeyboardEventInit(it.name, it.name, ctrlKey = true)),
+                    KeyboardEvent("keydown", KeyboardEventInit(it.name, it.name, altKey = true)),
+                    KeyboardEvent("keydown", KeyboardEventInit(it.name, it.name, shiftKey = true)),
+                    KeyboardEvent("keydown", KeyboardEventInit(it.name, it.name, metaKey = true))
                 )
             }
 
@@ -233,7 +233,7 @@ class ListenerTest {
                 e.metaKey -> expected = "meta+"
                 e.shiftKey -> expected = "shift+"
             }
-            expected += when (Key(e).key) {
+            expected += when (Key(e)) {
                 Keys.ArrowUp -> "up"
                 Keys.ArrowDown -> "down"
                 else -> "unknown"
@@ -274,7 +274,7 @@ class ListenerTest {
         assertEquals("start", resultNode.textContent, "wrong dom content of result-node")
 
         input.value = "some other content"
-        val event = KeyboardEvent("keyup", KeyboardEventInit(Keys.Enter, code = Keys.Enter))
+        val event = KeyboardEvent("keyup", KeyboardEventInit(Keys.Enter.name, code = Keys.Enter.name))
         input.dispatchEvent(event)
         delay(200)
 

--- a/core/src/jsTest/kotlin/dev/fritz2/dom/listener.kt
+++ b/core/src/jsTest/kotlin/dev/fritz2/dom/listener.kt
@@ -181,7 +181,7 @@ class ListenerTest {
                     key.meta -> pressed = "meta+"
                     key.shift -> pressed = "shift+"
                 }
-                pressed += when (key) {
+                pressed += when (key.key) {
                     Keys.ArrowUp -> "up"
                     Keys.ArrowDown -> "down"
                     else -> "unknown"
@@ -214,10 +214,10 @@ class ListenerTest {
         val keyboardEvents = listOf(Keys.ArrowUp, Keys.ArrowDown)
             .flatMap {
                 listOf(
-                    KeyboardEvent("keydown", KeyboardEventInit(it.key, it.key, ctrlKey = true)),
-                    KeyboardEvent("keydown", KeyboardEventInit(it.key, it.key, altKey = true)),
-                    KeyboardEvent("keydown", KeyboardEventInit(it.key, it.key, shiftKey = true)),
-                    KeyboardEvent("keydown", KeyboardEventInit(it.key, it.key, metaKey = true))
+                    KeyboardEvent("keydown", KeyboardEventInit(it, it, ctrlKey = true)),
+                    KeyboardEvent("keydown", KeyboardEventInit(it, it, altKey = true)),
+                    KeyboardEvent("keydown", KeyboardEventInit(it, it, shiftKey = true)),
+                    KeyboardEvent("keydown", KeyboardEventInit(it, it, metaKey = true))
                 )
             }
 
@@ -233,7 +233,7 @@ class ListenerTest {
                 e.metaKey -> expected = "meta+"
                 e.shiftKey -> expected = "shift+"
             }
-            expected += when (Key(e)) {
+            expected += when (Key(e).key) {
                 Keys.ArrowUp -> "up"
                 Keys.ArrowDown -> "down"
                 else -> "unknown"
@@ -274,7 +274,7 @@ class ListenerTest {
         assertEquals("start", resultNode.textContent, "wrong dom content of result-node")
 
         input.value = "some other content"
-        val event = KeyboardEvent("keyup", KeyboardEventInit(Keys.Enter.key, code = Keys.Enter.key))
+        val event = KeyboardEvent("keyup", KeyboardEventInit(Keys.Enter, code = Keys.Enter))
         input.dispatchEvent(event)
         delay(200)
 


### PR DESCRIPTION
This PR improves the whole key event handling API by the following aspects:
* improved `Key`-class based upon a new concept of `Modifier`-interface, which enables constructing nice key shortcut combinations like "Strg + K" or "Shift + Alt + F" or alike.
* add some convenience methods to improve the event handling for `KeyboardEvent`s: `keys()`
* improved `Keys`-object with predefined common keys like `Tab`, `Enter` but also the modifier keys like `Alt`, `Shift`, `Meta` and `Control`
* mark some special interest functions as _deprecated_ in favour of using the new `keys` functions, which does the heavy work without being too specialized.

The new key API allows easily defining combinations of keys with modifier keys, constructing those from a `KeyboardEvent` and prevents meaningless combinations of "real" keys:

```kotlin
// constructing a key by hand
Key("K") // will convert "K" automatically to lower case -> Key(name = "k", ctrl = false, alt = false, shift = false, meta = false)
// same as
Key("k")
// set modifier states
Key("K", ctrl = true) // Key(name = "k", ctrl = true, alt = false, shift = false, meta = false)

// constructing a key from a KeyboardEvent
div {
    keydowns.map { Key(it) } handledBy { /* use Key-object for further processing */ }
    //                 ^^
    //                 use KeyboardEvent to construct a Key-object with all potentially modifier key states reflected!
}

// using predefined keys from Keys object
Keys.Enter // "real" Key
Keys.Alt // ModifierKey -> needs to be combined with a "real" key in order to use it for further processing
// the same but more cumbersome and open to typos
Key("Enter")
// not the same (!)
Key("Alt") // -> Key(name = "Alt", ..., alt = false)
Keys.Alt // -> ModifierKey-object with alt = true property!

// constructing a key with some modifier key
Key("K") + Keys.Control
// same result, but much more readable the other way round:
Keys.Control + "K"

// defining some common combination:
val searchKey = Keys.Control + Keys.Shift + "F"
//              ^^^^^^^^^^^^
//              You can start with a modifier key!
//              Appending a String to an ModifierKey will finally lead to a Key

val tabbing = setOf(Keys.Tab, Keys.Shift + Keys.Tab)

// API prevents accidently usage:
// won't compile!
Key("F") + Key("P") // cannot combine real keys!
```

As most of the time you will use keys within the handling of some `KeyboardEvent`, there are some new methods for leveraging some common work by the framework. Those `keys`-methods variants accept one, arbitrary or a set of `Key`s which should be handled. All events from other keys will be ignored, so that one can prevent default behaviour or stop bubbling explicitly only for the handled keys. The functions return a pair of the key and the corresponding event, so that calling `stopPropagation` or accessing other properties of the event is still possible for the client.

Example usage:
```kotlin
// within some Tag<*or WithDomNode<*>

// do something only for some key shortcut combination
keydowns.keys(Keys.Strg + "K").map { } handledBy { /* popup some command entry component */ }

// accessing the event after the filtering:
keydowns.keys(Keys.ArrowUp, Keys.ArrowDown).mapNotNull { (key, e) ->
    e.preventDefault() // page should not scroll up or down in this case!
    when (key) {
        Keys.ArrowDown -> // create / modify something to be handled
        Keys.ArrowUp -> // create / modify something to be handled
        else -> null
    }
} handledBy { /* ... */ }
```