### PR TITLE
Fix for issue #550: Removed touchends-event scrolling from appFrame component

### DIFF
--- a/components/src/jsMain/kotlin/dev/fritz2/components/appFrame/component.kt
+++ b/components/src/jsMain/kotlin/dev/fritz2/components/appFrame/component.kt
@@ -238,8 +238,6 @@ open class AppFrameComponent : Component<Unit>,
         id: String?,
         prefix: String
     ) {
-        Window.touchends.events handledBy { document.documentElement?.scrollTo(0.0,0.0) }
-
         context.apply {
             div({
                 display(


### PR DESCRIPTION
As discussed with Jens. Fixes issue #550 where on Mobile (Safari), UIs with AppFrame skip to the top of the page after leaving any field. Fix needed in January 2022 for a UI in production.

https://github.com/jwstegemann/fritz2/issues/550