### PR TITLE
Access annex via property

### DIFF
--- a/core/src/jsMain/kotlin/dev/fritz2/dom/tag.kt
+++ b/core/src/jsMain/kotlin/dev/fritz2/dom/tag.kt
@@ -239,7 +239,6 @@ open class Tag<out E : Element>(
 
     private fun addToClasses(classesToAdd: String) {
         className = classes(className, classesToAdd)
-        console.error("****" + className)
         updateClasses()
     }
 

--- a/core/src/jsMain/kotlin/dev/fritz2/dom/tag.kt
+++ b/core/src/jsMain/kotlin/dev/fritz2/dom/tag.kt
@@ -395,11 +395,8 @@ open class Tag<out E : Element>(
     }
 
     /**
-     * renders some context next to this Tag on the same DOM-level
+     * provides [RenderContext] next to this [Tag] on the same DOM-level.
      *
-     * @param content lambda building the content to render
      */
-    fun <E : Element> annex(content: RenderContext.() -> Tag<E>) {
-        AnnexContext().content()
-    }
+    val annex: RenderContext by lazy { AnnexContext() }
 }

--- a/core/src/jsTest/kotlin/dev/fritz2/dom/tag.kt
+++ b/core/src/jsTest/kotlin/dev/fritz2/dom/tag.kt
@@ -167,7 +167,7 @@ class TagTests {
             div(id = contentId) {
                 div {
                     +"inner div"
-                }.annex {
+                }.annex.apply {
                     span { +"outer div" }
                 }
                 span { +"after inner div" }


### PR DESCRIPTION
It seems to be more flexible to access the annex (neighborhood) - context of a Tag by a property instead of a render-like method.

```kotlin
div(id = contentId) {
                div {
                    +"inner div"
                }.annex.apply {
                    span { +"outer div" }
                }
                span { +"after inner div" }
            }
```

results in 

```html
<div>inner div</div><span>outer div</span><span>after inner div</span>
```