### PR TITLE
`Authentication.getPrincipal()` function returns the principal also when pre-setting it before any process is started

### DIFF
--- a/core/src/jsMain/kotlin/dev/fritz2/remote/auth.kt
+++ b/core/src/jsMain/kotlin/dev/fritz2/remote/auth.kt
@@ -20,13 +20,15 @@ import kotlinx.coroutines.flow.map
  * authentication information provided by the [addAuthentication] method.
  * When the user logs out you have to call the [clear] function to clear all authentication information.
  */
-abstract class Authentication<P> : Middleware {
+abstract class
+Authentication<P> : Middleware {
 
     private val principalStore = MutableStateFlow<P?>(null)
 
     private var state: CompletableDeferred<P>? = null
 
-    final override suspend fun enrichRequest(request: Request): Request = addAuthentication(request, getPrincipal())
+    final override suspend fun enrichRequest(request: Request): Request =
+        addAuthentication(request, state?.await() ?: principalStore.value)
 
     final override suspend fun handleResponse(response: Response): Response =
         if (statusCodesEnforcingAuthentication.contains(response.status)) {
@@ -60,7 +62,7 @@ abstract class Authentication<P> : Middleware {
      *
      * @return P principal information
      */
-    suspend fun getPrincipal(): P? = if(state != null) state?.await() else principalStore.value
+    fun getPrincipal(): P? = principalStore.value
 
     /**
      * implements the authentication process.

--- a/core/src/jsMain/kotlin/dev/fritz2/remote/http.kt
+++ b/core/src/jsMain/kotlin/dev/fritz2/remote/http.kt
@@ -139,7 +139,7 @@ open class Request(
 
         var response = Response(browserWindow.fetch(url, init).await(), request)
         for (interceptor in middlewares.reversed()) {
-            if (!response.propagate) break;
+            if (!response.propagate) break
             response = interceptor.handleResponse(response)
         }
 

--- a/core/src/jsTest/kotlin/dev/fritz2/remote/auth.kt
+++ b/core/src/jsTest/kotlin/dev/fritz2/remote/auth.kt
@@ -35,13 +35,13 @@ class AuthenticatedRemoteTests {
             }
         }
 
-        assertEquals(null, simple.getPrincipal())
+        assertEquals(null, simple.current)
 
         simple.clear()
-        testHttpServer(authenticated).use(simple).get("get")
+        assertEquals("GET", testHttpServer(authenticated).use(simple).get("get").body())
 
         simple.clear()
-        testHttpServer(test).use(simple).get("get")
+        assertEquals("GET", testHttpServer(test).use(simple).get("get").body())
 
         assertFailsWith(FetchException::class) {
             testHttpServer(authenticated).get("get")
@@ -60,10 +60,11 @@ class AuthenticatedRemoteTests {
         }
         val remote = testHttpServer(authenticated).use(simple)
 
-        remote.get("get")
-        remote.get("get")
-        remote.get("get")
-        remote.get("get")
+        assertEquals("GET", remote.get("get").body())
+        assertEquals("GET", remote.get("get").body())
+        assertEquals("GET", remote.get("get").body())
+        assertEquals("GET", remote.get("get").body())
+        assertEquals("GET", remote.get("get").body())
     }
 
     @Test
@@ -78,13 +79,14 @@ class AuthenticatedRemoteTests {
             }
         }
 
-        assertEquals(simple.valid, simple.getPrincipal())
+        assertEquals(simple.valid, simple.current)
 
         val remote = testHttpServer(authenticated).use(simple)
 
-        remote.get("get")
-        remote.get("get")
-        remote.get("get")
-        remote.get("get")
+        assertEquals("GET", remote.get("get").body())
+        assertEquals("GET", remote.get("get").body())
+        assertEquals("GET", remote.get("get").body())
+        assertEquals("GET", remote.get("get").body())
+        assertEquals("GET", remote.get("get").body())
     }
 }

--- a/core/src/jsTest/kotlin/dev/fritz2/remote/auth.kt
+++ b/core/src/jsTest/kotlin/dev/fritz2/remote/auth.kt
@@ -60,10 +60,8 @@ class AuthenticatedRemoteTests {
             
             override fun authenticate() {
                 countAuthenticate++
-                println("authenticate")
                 window.setTimeout({
                     complete(valid)
-                    println("completed\n")
                 }, 1000)
             }
         }
@@ -76,7 +74,7 @@ class AuthenticatedRemoteTests {
                 })
             }
         }.joinAll()
-        assertTrue(simple.countAuthenticate == 1)
+        assertEquals(1, simple.countAuthenticate)
         assertTrue(simple.countAddAuthentication <= 8)
     }
 
@@ -96,10 +94,15 @@ class AuthenticatedRemoteTests {
 
         val remote = testHttpServer(authenticated).use(simple)
 
-        assertEquals("GET", remote.get("get").body())
-        assertEquals("GET", remote.get("get").body())
-        assertEquals("GET", remote.get("get").body())
-        assertEquals("GET", remote.get("get").body())
+        buildList {
+            repeat(4) {
+                add(MainScope().launch {
+                    assertEquals("GET", remote.get("get").body())
+                })
+            }
+        }.joinAll()
+        assertEquals(4, simple.countAddAuthentication)
+        // test pure sequential request too
         assertEquals("GET", remote.get("get").body())
     }
 }

--- a/core/src/jsTest/kotlin/dev/fritz2/remote/auth.kt
+++ b/core/src/jsTest/kotlin/dev/fritz2/remote/auth.kt
@@ -6,6 +6,7 @@ import dev.fritz2.test.test
 import dev.fritz2.test.testHttpServer
 import kotlinx.browser.window
 import kotlin.test.Test
+import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
 
 data class Principal(
@@ -33,6 +34,9 @@ class AuthenticatedRemoteTests {
                 complete(valid)
             }
         }
+
+        assertEquals(null, simple.getPrincipal())
+
         simple.clear()
         testHttpServer(authenticated).use(simple).get("get")
 
@@ -54,6 +58,28 @@ class AuthenticatedRemoteTests {
                 }, 500)
             }
         }
+        val remote = testHttpServer(authenticated).use(simple)
+
+        remote.get("get")
+        remote.get("get")
+        remote.get("get")
+        remote.get("get")
+    }
+
+    @Test
+    fun testPreAuthentication() = runTest {
+        val simple = object : TestAuthenticationMiddleware() {
+            override fun authenticate() {
+                throw Exception("should not be called!")
+            }
+
+            init {
+                complete(valid)
+            }
+        }
+
+        assertEquals(simple.valid, simple.getPrincipal())
+
         val remote = testHttpServer(authenticated).use(simple)
 
         remote.get("get")

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 org.gradle.parallel=true
-org.gradle.jvmargs=-XX:MaxMetaspaceSize=512m -Xmx2048M
+org.gradle.jvmargs=-XX:MaxMetaspaceSize=1024m -Xmx2048M
 kotlin.mpp.stability.nowarn=true
 kotlin.code.style=official
 kotlin.incremental.js=true

--- a/test-server/src/main/kotlin/dev/fritz2/Server.kt
+++ b/test-server/src/main/kotlin/dev/fritz2/Server.kt
@@ -62,7 +62,6 @@ object CRUDRepo {
     }
 }
 
-@KtorExperimentalAPI
 fun Application.main() {
 
     install(CallLogging) {


### PR DESCRIPTION
Fixes #577