### PR TITLE
Fixed exception handling in Handlers

### DIFF
--- a/core/src/jsMain/kotlin/dev/fritz2/binding/substores.kt
+++ b/core/src/jsMain/kotlin/dev/fritz2/binding/substores.kt
@@ -42,14 +42,8 @@ class SubStore<P, T>(
     /**
      * Since a [SubStore] is just a view on a [RootStore] holding the real value, it forwards the [Update] to it, using it's [Lens] to transform it.
      */
-    override suspend fun enqueue(update: QueuedUpdate<T>) {
-        parent.enqueue(QueuedUpdate({
-            try {
-                lens.apply(it, update.update)
-            } catch (e: Throwable) {
-                lens.apply(it) { oldValue -> update.errorHandler(e, oldValue) }
-            }
-        }, parent::errorHandler))
+    override suspend fun enqueue(update: Update<T>) {
+        parent.enqueue { lens.apply(it, update) }
     }
 
     /**

--- a/core/src/jsMain/kotlin/dev/fritz2/dom/html/job.kt
+++ b/core/src/jsMain/kotlin/dev/fritz2/dom/html/job.kt
@@ -25,7 +25,7 @@ interface WithJob {
      *
      * @param exception Exception to handle
      */
-    private fun errorHandler(exception: Throwable) {
+    fun errorHandler(exception: Throwable) {
         console.error("ERROR: ${exception.message}", exception)
     }
 
@@ -44,7 +44,7 @@ interface WithJob {
      * @receiver [Flow] of action/events to bind to
      */
     infix fun <A> Flow<A>.handledBy(execute: suspend (A) -> Unit) =
-        this.catch { errorHandler(it) }.onEach { execute(it) }.launchIn(MainScope() + job)
+        this.onEach { execute(it) }.catch { errorHandler(it) }.launchIn(MainScope() + job)
 
 
     /**
@@ -63,7 +63,7 @@ interface WithJob {
      * @param execute function that will handle the fired [Event]
      */
     infix fun <E : Event, X : Element> DomListener<E, X>.handledBy(execute: suspend (E) -> Unit) =
-        this.events.catch { errorHandler(it) }.onEach { execute(it) }.launchIn(MainScope() + job)
+        this.events.onEach { execute(it) }.catch { errorHandler(it) }.launchIn(MainScope() + job)
 
 
     /**
@@ -82,7 +82,7 @@ interface WithJob {
      * @param execute function that will handle the fired [Event]
      */
     infix fun <E : Event> WindowListener<E>.handledBy(execute: suspend (E) -> Unit) =
-        this.events.catch { errorHandler(it) }.onEach { execute(it) }.launchIn(MainScope() + job)
+        this.events.onEach { execute(it) }.catch { errorHandler(it) }.launchIn(MainScope() + job)
 
 }
 
@@ -101,5 +101,4 @@ infix fun <A> Flow<A>.handledBy(handler: Handler<A>) = handler.collect(this, Job
  * @receiver [Flow] of action/events to bind to an [Handler]
  */
 infix fun <A> Flow<A>.handledBy(execute: suspend (A) -> Unit) =
-    this.catch { console.error("ERROR: ${it.message}", it) }
-        .onEach { execute(it) }.launchIn(MainScope() + Job())
+    this.onEach { execute(it) }.catch { console.error("ERROR: ${it.message}", it) }.launchIn(MainScope() + Job())

--- a/core/src/jsMain/kotlin/dev/fritz2/routing/routing.kt
+++ b/core/src/jsMain/kotlin/dev/fritz2/routing/routing.kt
@@ -1,7 +1,7 @@
 package dev.fritz2.routing
 
-import dev.fritz2.binding.QueuedUpdate
 import dev.fritz2.binding.Store
+import dev.fritz2.binding.Update
 import dev.fritz2.dom.html.Events
 import kotlinx.browser.window
 import kotlinx.coroutines.Job
@@ -71,15 +71,11 @@ open class Router<T>(
      */
     open val navTo = this.handle<T> { _, newValue -> newValue }
 
-    override suspend fun enqueue(update: QueuedUpdate<T>) {
-        try {
-            mutex.withLock {
-                val newRoute = update.update(state.value)
-                state.value = newRoute
-                window.location.hash = prefix + defaultRoute.serialize(newRoute)
-            }
-        } catch (e: Throwable) {
-            update.errorHandler(e, state.value)
+    override suspend fun enqueue(update: Update<T>) {
+        mutex.withLock {
+            val newRoute = update(state.value)
+            state.value = newRoute
+            window.location.hash = prefix + defaultRoute.serialize(newRoute)
         }
     }
 

--- a/core/src/jsTest/kotlin/dev/fritz2/binding/handlers.kt
+++ b/core/src/jsTest/kotlin/dev/fritz2/binding/handlers.kt
@@ -11,7 +11,7 @@ class HandlersTests {
     @Test
     fun testSimpleHandler() = runTest {
         val store = object : RootStore<Int>(0) {
-            override fun errorHandler(exception: Throwable, oldValue: Int): Int {
+            override fun errorHandler(exception: Throwable) {
                 fail(exception.message)
             }
         }

--- a/core/src/jsTest/kotlin/dev/fritz2/binding/mount.kt
+++ b/core/src/jsTest/kotlin/dev/fritz2/binding/mount.kt
@@ -45,7 +45,7 @@ class MountTests {
 
         return GlobalScope.promise {
             values.forEach { value ->
-                store.enqueue(QueuedUpdate({ value }, store::errorHandler))
+                store.enqueue { value }
             }
             done.await()
         }

--- a/core/src/jsTest/kotlin/dev/fritz2/remote/websocket.kt
+++ b/core/src/jsTest/kotlin/dev/fritz2/remote/websocket.kt
@@ -174,7 +174,7 @@ class WebSocketTests {
         val socket = websocket.append("json")
 
         val entityStore = object : RootStore<SocketPerson>(defaultPerson) {
-            override fun errorHandler(exception: Throwable, oldValue: SocketPerson): SocketPerson {
+            override fun errorHandler(exception: Throwable) {
                 fail(exception.message)
             }
 

--- a/core/src/jsTest/kotlin/dev/fritz2/repositories/localstorage/localStorage.kt
+++ b/core/src/jsTest/kotlin/dev/fritz2/repositories/localstorage/localStorage.kt
@@ -45,7 +45,7 @@ class LocalStorageTests {
         val changedAge = 99
 
         val entityStore = object : RootStore<LocalPerson>(defaultPerson) {
-            override fun errorHandler(exception: Throwable, oldValue: LocalPerson): LocalPerson {
+            override fun errorHandler(exception: Throwable) {
                 fail(exception.message)
             }
 
@@ -122,7 +122,7 @@ class LocalStorageTests {
         )
 
         val queryStore = object : RootStore<List<LocalPerson>>(emptyList()) {
-            override fun errorHandler(exception: Throwable, oldValue: List<LocalPerson>): List<LocalPerson> {
+            override fun errorHandler(exception: Throwable) {
                 fail(exception.message)
             }
 
@@ -200,7 +200,7 @@ class LocalStorageTests {
         )
 
         val queryStore = object : RootStore<List<LocalPerson>>(emptyList()) {
-            override fun errorHandler(exception: Throwable, oldValue: List<LocalPerson>): List<LocalPerson> {
+            override fun errorHandler(exception: Throwable) {
                 fail(exception.message)
             }
 

--- a/core/src/jsTest/kotlin/dev/fritz2/repositories/rest/rest.kt
+++ b/core/src/jsTest/kotlin/dev/fritz2/repositories/rest/rest.kt
@@ -53,7 +53,7 @@ class RestTests {
         val remote = testHttpServer(rest)
 
         val entityStore = object : RootStore<RestPerson>(defaultPerson) {
-            override fun errorHandler(exception: Throwable, oldValue: RestPerson): RestPerson {
+            override fun errorHandler(exception: Throwable) {
                 fail(exception.message)
             }
 
@@ -130,7 +130,7 @@ class RestTests {
         val remote = testHttpServer(rest)
 
         val queryStore = object : RootStore<List<RestPerson>>(emptyList()) {
-            override fun errorHandler(exception: Throwable, oldValue: List<RestPerson>): List<RestPerson> {
+            override fun errorHandler(exception: Throwable) {
                 fail(exception.message)
             }
 
@@ -205,7 +205,7 @@ class RestTests {
         val remote = testHttpServer(rest)
 
         val queryStore = object : RootStore<List<RestPerson>>(emptyList()) {
-            override fun errorHandler(exception: Throwable, oldValue: List<RestPerson>): List<RestPerson> {
+            override fun errorHandler(exception: Throwable) {
                 fail(exception.message)
             }
 


### PR DESCRIPTION
To make sure, that the coroutine of a `Store` or `RenderContext` is not cancelled by an uncaught exception, we changed the way of exception handling in fritz2:

You cannot provide a lambda specifying, how to handle uncaught exceptions, to a handler anymore. Just use `try ... catch` 
- in your handler's code, 
- in any intermediate operation on the `Flow` or  
- by using `.catch()` on the `Flow` 

to deal with an exception the way you want.

An exception you did not catch earlier (by `try ... catch` or `.catch()` on a `Flow`) will be caught by fritz2 for any type of handler, including ad hoc handlers.

By default, the exception will be just logged to the console. You can change this behavior be overriding the `errorHandler` function of your `Store`, `RenderContext`, etc.

