### PR TITLE
Fix invocation of Handlers

### DIFF
--- a/core/src/jsMain/kotlin/dev/fritz2/core/handlers.kt
+++ b/core/src/jsMain/kotlin/dev/fritz2/core/handlers.kt
@@ -35,18 +35,6 @@ fun <T> flowOnceOf(value: T) = OnlyOnceFlow(value)
  */
 interface Handler<A> {
     val process: (Flow<A>, Job) -> Unit
-
-    /**
-     * Calls this handler exactly once.
-     *
-     * @param data parameter forwarded to the handler
-     */
-    operator fun invoke(data: A) = this.process(flowOnceOf(data), Job())
-
-    /**
-     * Calls this handler exactly once.
-     */
-    operator fun invoke() = this.process(flowOnceOf(Unit.unsafeCast<A>()), Job())
 }
 
 /**

--- a/core/src/jsMain/kotlin/dev/fritz2/core/handlers.kt
+++ b/core/src/jsMain/kotlin/dev/fritz2/core/handlers.kt
@@ -4,50 +4,72 @@ import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.FlowCollector
 import kotlinx.coroutines.flow.MutableSharedFlow
-import kotlinx.coroutines.flow.flowOf
+
+/**
+ * This [Flow] implementation represents a flow that emits exactly one value during its lifetime.
+ *
+ * @param value the value to emit on the flow
+ */
+class OnlyOnceFlow<T>(private val value: T) : Flow<T> {
+    private var collected = false
+
+    override suspend fun collect(collector: FlowCollector<T>) {
+        if (!collected) {
+            collected = true
+            collector.emit(value)
+        }
+    }
+}
+
+/**
+ * This factory function creates an [OnlyOnceFlow].
+ *
+ * @param value the value to emit on the flow
+ */
+fun <T> flowOnceOf(value: T) = OnlyOnceFlow(value)
 
 /**
  * Base-interface of the different types of handlers
  *
- * @property collect function describing how this handler collects a flow when called
+ * @property process function describing how this handler collects a flow when called
  */
 interface Handler<A> {
-    val collect: (Flow<A>, Job) -> Unit
+    val process: (Flow<A>, Job) -> Unit
 
     /**
      * Calls this handler exactly once.
      *
      * @param data parameter forwarded to the handler
      */
-    operator fun invoke(data: A) = this.collect(flowOf(data), Job())
+    operator fun invoke(data: A) = this.process(flowOnceOf(data), Job())
 
     /**
      * Calls this handler exactly once.
      */
-    operator fun invoke() = this.collect(flowOf(Unit.unsafeCast<A>()), Job())
+    operator fun invoke() = this.process(flowOnceOf(Unit.unsafeCast<A>()), Job())
 }
 
 /**
  * Defines, how to handle actions in your [Store]. Each Handler accepts actions of a defined type.
  * If your handler just needs the current value of the [Store] and no action, use [Unit].
  *
- * @param collect defines how to handle the values of the connected [Flow]
+ * @param process defines how to handle the values of the connected [Flow]
  */
-value class SimpleHandler<A>(override inline val collect: (Flow<A>, Job) -> Unit) : Handler<A>
+value class SimpleHandler<A>(override inline val process: (Flow<A>, Job) -> Unit) : Handler<A>
 
 /**
  * An [EmittingHandler] is a special [Handler] that constitutes a new [Flow] by itself. You can emit values to this [Flow] from your code
  * and connect it to other [Handler]s on this or on other [Store]s. This way inter-store-communication is done in fritz2.
  *
  * @param collectWithChannel defines how to handle the values of the connected [Flow]
- * @property collect function defining how this [Handler] collects a [Flow] when connected using [handledBy]
+ * @property process function defining how this [Handler] collects a [Flow] when connected using [handledBy]
  */
 class EmittingHandler<A, E>(
     inline val collectWithChannel: (Flow<A>, FlowCollector<E>, Job) -> Unit,
     private val flow: MutableSharedFlow<E> = MutableSharedFlow()
 ) : Handler<A>, Flow<E> by flow {
 
-    override val collect: (Flow<A>, Job) -> Unit = { upstream, job ->
+    override val process: (Flow<A>, Job) -> Unit = { upstream, job ->
         collectWithChannel(upstream, flow, job)
     }
 }

--- a/core/src/jsMain/kotlin/dev/fritz2/core/job.kt
+++ b/core/src/jsMain/kotlin/dev/fritz2/core/job.kt
@@ -90,6 +90,19 @@ interface WithJob {
             }
         }
     }
+
+    /**
+     * Calls this handler exactly once.
+     *
+     * @param data parameter forwarded to the handler
+     */
+    operator fun <A> Handler<A>.invoke(data: A) = this.process(flowOnceOf(data), job)
+
+    /**
+     * Calls this handler exactly once.
+     */
+    operator fun Handler<Unit>.invoke() = this.process(flowOnceOf(Unit), job)
+
 }
 
 /**

--- a/core/src/jsMain/kotlin/dev/fritz2/core/job.kt
+++ b/core/src/jsMain/kotlin/dev/fritz2/core/job.kt
@@ -42,7 +42,7 @@ interface WithJob {
      * @param handler [Handler] that will be called for each action/event on the [Flow]
      * @receiver [Flow] of action/events to bind to a [Handler]
      */
-    infix fun <A> Flow<A>.handledBy(handler: Handler<A>) = handler.collect(this, job)
+    infix fun <A> Flow<A>.handledBy(handler: Handler<A>) = handler.process(this, job)
 
     /**
      * Connects a [Flow] to a suspendable [execute] function.
@@ -61,7 +61,7 @@ interface WithJob {
      * @param handler that will handle the fired [Event]
      */
     infix fun <E : Event> Flow<E>.handledBy(handler: Handler<Unit>) =
-        handler.collect(this.map { }, job)
+        handler.process(this.map { }, job)
 
     /**
      * Connects a [Flow] to a suspendable [execute] function.
@@ -98,7 +98,7 @@ interface WithJob {
  * @param handler [Handler] that will be called for each action/event on the [Flow]
  * @receiver [Flow] of action/events to bind to an [Handler]
  */
-infix fun <A> Flow<A>.handledBy(handler: Handler<A>) = handler.collect(this, Job())
+infix fun <A> Flow<A>.handledBy(handler: Handler<A>) = handler.process(this, Job())
 
 /**
  * Connects a [Flow] to a suspendable [execute] function.

--- a/core/src/jsTest/kotlin/dev/fritz2/core/handlers.kt
+++ b/core/src/jsTest/kotlin/dev/fritz2/core/handlers.kt
@@ -3,10 +3,17 @@ package dev.fritz2.core
 import dev.fritz2.runTest
 import kotlinx.browser.document
 import kotlinx.coroutines.delay
-import kotlinx.coroutines.flow.*
+import kotlinx.coroutines.flow.asFlow
+import kotlinx.coroutines.flow.flatMapLatest
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.single
 import org.w3c.dom.HTMLButtonElement
 import org.w3c.dom.HTMLDivElement
-import kotlin.test.*
+import org.w3c.dom.HTMLParagraphElement
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFails
+import kotlin.test.fail
 
 class HandlersTests {
 
@@ -16,15 +23,55 @@ class HandlersTests {
             override fun errorHandler(cause: Throwable) {
                 fail(cause.message)
             }
+
+            val dec = handle { it -1 }
         }
 
-        store.handle { assertTrue(true); it }()
-        store.handle { assertTrue(true); it }(Unit)
-        store.handle<String> { n, s -> assertFalse(s::class == String::class); n }()
-        store.handle<String> { n, s -> assertTrue(s::class == Unit::class); n }()
-        store.handle<String> { n, s -> assertTrue(s.length == undefined); n }()
-        store.handle<String> { n, s -> assertTrue(s.substring(1) == undefined); n }()
-        store.handle<String> { n, _ -> assertTrue(true); n }("Hello")
+        lateinit var currentParagraph: HTMLParagraphElement
+        lateinit var button: HTMLButtonElement
+        lateinit var buttonDynamic: HTMLButtonElement
+
+        render {
+            currentParagraph = p {
+                store.data.renderText()
+            }.domNode
+
+            button = button {
+                clicks handledBy store.dec
+            }.domNode
+
+            store.data.render {
+                if (it > 40) {
+                    buttonDynamic = button {
+                        clicks handledBy { store.dec() }
+                    }.domNode
+                }
+            }
+        }
+
+        delay(100)
+        assertEquals("0", currentParagraph.textContent)
+
+        store.handle { it + 1 }()
+        delay(100)
+        assertEquals("1", currentParagraph.textContent)
+
+        store.handle<Int> { _, new -> new }(42)
+        delay(100)
+        assertEquals("42", currentParagraph.textContent)
+
+        button.click()
+        delay(100)
+        assertEquals("41", currentParagraph.textContent)
+
+        buttonDynamic.click()
+        delay(100)
+        assertEquals("40", currentParagraph.textContent)
+
+        button.click()
+        delay(100)
+        assertEquals("39", currentParagraph.textContent)
+
     }
 
     @Test

--- a/core/src/jsTest/kotlin/dev/fritz2/core/handlers.kt
+++ b/core/src/jsTest/kotlin/dev/fritz2/core/handlers.kt
@@ -3,6 +3,7 @@ package dev.fritz2.core
 import dev.fritz2.runTest
 import kotlinx.browser.document
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.*
 import org.w3c.dom.HTMLButtonElement
 import org.w3c.dom.HTMLDivElement
 import kotlin.test.*
@@ -28,7 +29,7 @@ class HandlersTests {
 
     @Test
     fun eventHandlerDomChange() = runTest {
-        
+
         val resultId = Id.next()
         val buttonId = Id.next()
 
@@ -78,4 +79,30 @@ class HandlersTests {
         assertEquals("value: start..", result.textContent, "wrong dom content of result-node")
     }
 
+    @Test
+    fun flowOnceOfWillEmitOnlyOneValue() = runTest {
+        val films = listOf("Highlander", "Star Wars", "Jurassic Park").asFlow()
+        val sut = flowOnceOf("There can only be one")
+
+        val result = films.flatMapLatest { film ->
+            sut.map {
+                "$it $film"
+            }
+        }.single()
+
+        assertEquals("There can only be one Highlander", result)
+    }
+
+    @Test
+    fun flowOnceOfWillThrowIfCollectedTwice() = runTest {
+        val sut = flowOnceOf("Atom")
+
+        sut.single()
+        assertEquals(
+            "Flow is empty",
+            assertFails {
+                sut.single()
+            }.message
+        )
+    }
 }

--- a/core/src/jsTest/kotlin/dev/fritz2/test.kt
+++ b/core/src/jsTest/kotlin/dev/fritz2/test.kt
@@ -1,14 +1,17 @@
 package dev.fritz2
 
+import dev.fritz2.core.WithJob
 import dev.fritz2.core.mountSimple
 import dev.fritz2.remote.Request
 import dev.fritz2.remote.http
 import kotlinx.coroutines.*
 import kotlinx.coroutines.flow.Flow
 
-fun <T> runTest(block: suspend () -> T): dynamic = MainScope().promise {
+fun <T> runTest(block: suspend WithJob.() -> T): dynamic = MainScope().promise {
     delay(50)
-    block()
+    block(object : WithJob {
+        override val job: Job = Job()
+    })
     delay(50)
 }
 

--- a/headless/src/jsMain/kotlin/dev/fritz2/headless/foundation/OpenClose.kt
+++ b/headless/src/jsMain/kotlin/dev/fritz2/headless/foundation/OpenClose.kt
@@ -41,16 +41,15 @@ abstract class OpenClose {
         }
     }
 
-    //FIXME: endless loop!?
-//    val toggle by lazy {
-//        SimpleHandler<Unit> { data, _ ->
-//            openState.handler?.invoke(openState.data.flatMapLatest { state ->
-//                data.map {
-//                    !state
-//                }
-//            })
-//        }
-//    }
+    val toggle by lazy {
+        SimpleHandler<Unit> { data, _ ->
+            openState.handler?.invoke(openState.data.flatMapLatest { state ->
+                data.map {
+                    !state
+                }
+            })
+        }
+    }
 
     /**
      * Use this function on [Tag]s, that should trigger the component to open or to close in order to enable

--- a/headless/src/jsTest/kotlin/dev/fritz2/headless/foundation/OpenClose.kt
+++ b/headless/src/jsTest/kotlin/dev/fritz2/headless/foundation/OpenClose.kt
@@ -39,20 +39,22 @@ class OpenCloseTest {
         delay(100)
         assertEquals("false", div.getAttribute("open"), "after close")
 
-//        openClose.toggle()
-//        delay(100)
-//        assertEquals("true", div.getAttribute("open"), "after toggle")
-//
-//        openClose.toggle()
-//        delay(100)
-//        assertEquals("false", div.getAttribute("open"), "after second toggle")
+        openClose.toggle()
+        delay(100)
+        assertEquals("true", div.getAttribute("open"), "after toggle")
+
+        openClose.toggle()
+        delay(100)
+        assertEquals("false", div.getAttribute("open"), "after second toggle")
     }
 
     class OpenCloseTest : OpenClose() {
 
         val id = Id.next()
 
-        init { openState(storeOf(false)) }
+        init {
+            openState(storeOf(false))
+        }
 
         fun create(context: RenderContext) = with(context) {
             div(id = id) {

--- a/headless/src/jsTest/kotlin/dev/fritz2/headless/test.kt
+++ b/headless/src/jsTest/kotlin/dev/fritz2/headless/test.kt
@@ -2,7 +2,9 @@ package dev.fritz2.headless
 
 import dev.fritz2.core.Scope
 import dev.fritz2.core.Shortcut
+import dev.fritz2.core.WithJob
 import kotlinx.browser.document
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.MainScope
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.promise
@@ -13,11 +15,14 @@ import org.w3c.dom.events.KeyboardEventInit
 import org.w3c.dom.pointerevents.PointerEvent
 import org.w3c.dom.pointerevents.PointerEventInit
 
-fun <T> runTest(block: suspend () -> T): dynamic = MainScope().promise {
+fun <T> runTest(block: suspend WithJob.() -> T): dynamic = MainScope().promise {
     delay(50)
-    block()
+    block(object : WithJob {
+        override val job: Job = Job()
+    })
     delay(50)
 }
+
 
 inline fun <reified E: Element> getElementById(id: String) = document.getElementById(id) as E
 


### PR DESCRIPTION
- add new `OnlyOnceFlow` flow with corresponding `flowOnceOf` factory
- use this new flow inside the `invoke` methods of a handler, so that it is guaranteed the value is really emitted only once
- enable `toggle` handler of `OpenClose` again including its unit tests
- add unit tests for new handler