### PR TITLE
Fix functionality of `attr()` functions

### DIFF
--- a/core/src/jsMain/kotlin/dev/fritz2/core/tags.kt
+++ b/core/src/jsMain/kotlin/dev/fritz2/core/tags.kt
@@ -50,7 +50,8 @@ interface Tag<out E : Element> : RenderContext, WithDomNode<E>, WithEvents<E> {
      * @param value to use
      */
     fun attr(name: String, value: String?) {
-        value?.let { domNode.setAttribute(name, it) }
+        if(value != null) domNode.setAttribute(name, value)
+        else domNode.removeAttribute(name)
     }
 
     /**
@@ -70,10 +71,7 @@ interface Tag<out E : Element> : RenderContext, WithDomNode<E>, WithEvents<E> {
      * @param value to use
      */
     fun attr(name: String, value: Flow<String?>) {
-        mountSimple(job, value) { v ->
-            if (v != null) attr(name, v)
-            else domNode.removeAttribute(name)
-        }
+        mountSimple(job, value) { v -> attr(name, v) }
     }
 
     /**
@@ -83,7 +81,7 @@ interface Tag<out E : Element> : RenderContext, WithDomNode<E>, WithEvents<E> {
      * @param value to use
      */
     fun <T> attr(name: String, value: T) {
-        value?.let { domNode.setAttribute(name, it.toString()) }
+        attr(name, value?.toString())
     }
 
     /**
@@ -93,10 +91,7 @@ interface Tag<out E : Element> : RenderContext, WithDomNode<E>, WithEvents<E> {
      * @param value to use
      */
     fun <T> attr(name: String, value: Flow<T>) {
-        mountSimple(job, value.map { it?.toString() }) { v ->
-            if (v != null) attr(name, v)
-            else domNode.removeAttribute(name)
-        }
+        mountSimple(job, value.map { it?.toString() }) { v -> attr(name, v) }
     }
 
     /**
@@ -119,10 +114,8 @@ interface Tag<out E : Element> : RenderContext, WithDomNode<E>, WithEvents<E> {
      * @param trueValue value to use if attribute is set (default "")
      */
     fun attr(name: String, value: Boolean?, trueValue: String = "") {
-        value?.let {
-            if (it) domNode.setAttribute(name, trueValue)
-            else domNode.removeAttribute(name)
-        }
+        if (value != null && value) domNode.setAttribute(name, trueValue)
+        else domNode.removeAttribute(name)
     }
 
     /**

--- a/core/src/jsTest/kotlin/dev/fritz2/core/attributes.kt
+++ b/core/src/jsTest/kotlin/dev/fritz2/core/attributes.kt
@@ -95,6 +95,28 @@ class AttributeTests {
     }
 
     @Test
+    fun testOverridingAStaticAttributeWithNullWillRemoveAttribute() = runTest {
+        val testId = Id.next()
+
+        lateinit var sut: HtmlTag<HTMLDivElement>
+        render {
+            sut = div(id = testId) {
+                attr("data-test", "important data")
+            }
+        }
+
+        delay(200)
+        assertTrue(sut.domNode.hasAttribute("data-test"))
+
+        sut.apply {
+            attr<String?>("data-test", null)
+        }
+
+        delay(200)
+        assertFalse(sut.domNode.hasAttribute("data-test"))
+    }
+
+    @Test
     fun testAlternatingNullableStringFlows() = runTest {
         val testId = Id.next()
 
@@ -179,7 +201,7 @@ class AttributeTests {
         val storedState = storeOf(false)
 
         lateinit var textInput: Tag<HTMLInputElement>
-        lateinit var checkBox: Tag<HTMLInputElement>
+        //lateinit var checkBox: Tag<HTMLInputElement>
         render {
             textInput = input(id = id) {
                 placeholder("Foo")
@@ -187,10 +209,12 @@ class AttributeTests {
                 value(storedText.data)
                 changes.values() handledBy { console.log(it) }
             }
+            /*
             checkBox = input {
                 type("checkbox")
                 checked(storedState.data)
             }
+             */
         }
 
         delay(100)
@@ -205,7 +229,7 @@ class AttributeTests {
         delay(100)
 
         // Per Keyevent String Wert in Input schreiben
-        val keyEvent = KeyboardEvent("keydown", KeyboardEventInit(key = "e", "KeyE", ))
+        val keyEvent = KeyboardEvent("keydown", KeyboardEventInit(key = "e", "KeyE"))
         window.dispatchEvent(keyEvent)
 
         // Prüfen: domnode.value == Eingabe?


### PR DESCRIPTION
Streamline internal behavior of the `attr()` functions by using it each other. This also fixes the issues that it is not possible to remove an attribute by using `null` as value.