### PR TITLE
Improve Headless Components and some Documentation

### DIFF
--- a/headless-demo/src/jsMain/kotlin/dev/fritz2/headlessdemo/checkboxGroup.kt
+++ b/headless-demo/src/jsMain/kotlin/dev/fritz2/headlessdemo/checkboxGroup.kt
@@ -16,7 +16,7 @@ fun RenderContext.checkboxGroupDemo() {
         Newsletter(3, "Trial Users", "Last message sent 4 days ago", 2740)
     )
 
-    val subscriptions = storeOf(emptyList<Newsletter>())
+    val subscriptions = storeOf(emptyList<Newsletter>(), id = "checkboxGroup")
 
     div("max-w-sm") {
         checkboxGroup<HTMLFieldSetElement, Newsletter>(tag = RenderContext::fieldset) {
@@ -26,7 +26,7 @@ fun RenderContext.checkboxGroupDemo() {
             }
             div("mt-4 grid grid-cols-1 gap-y-4") {
                 mailingList.forEach { option ->
-                    checkboxGroupOption(option) {
+                    checkboxGroupOption(option, id = option.id.toString()) {
                         checkboxGroupOptionToggle(
                             """relative bg-white border rounded-lg shadow-sm p-2 flex cursor-pointer 
                             | focus:outline-none focus:border-2""".trimMargin(),

--- a/headless-demo/src/jsMain/kotlin/dev/fritz2/headlessdemo/checkboxGroup.kt
+++ b/headless-demo/src/jsMain/kotlin/dev/fritz2/headlessdemo/checkboxGroup.kt
@@ -63,7 +63,7 @@ fun RenderContext.checkboxGroupDemo() {
             }
         }
 
-        div("bg-gray-300 mt-4 p-2 rounded-lg ring-2 ring-gray-50") {
+        div("bg-gray-300 mt-4 p-2 rounded-lg ring-2 ring-gray-50", id = "result") {
             em { +"Selected: " }
             ul("") {
                 subscriptions.data.renderEach {

--- a/headless-demo/src/jsMain/kotlin/dev/fritz2/headlessdemo/dataCollection.kt
+++ b/headless-demo/src/jsMain/kotlin/dev/fritz2/headlessdemo/dataCollection.kt
@@ -150,7 +150,7 @@ fun RenderContext.dataTableDemo(amount: Int) {
 
     }
 
-    div("bg-gray-300 mt-4 p-2 rounded-lg ring-2 ring-gray-50") {
+    div("bg-gray-300 mt-4 p-2 rounded-lg ring-2 ring-gray-50", id = "result") {
         em {
             selectionStore.data.map { it.count() }
                 .combine(storedFilteredSize.data) { sel, count -> "Selected ($sel/$count):" }
@@ -277,7 +277,7 @@ fun RenderContext.gridListDemo(amount: Int) {
         }
     }
 
-    div("bg-gray-300 mt-4 p-2 rounded-lg ring-2 ring-gray-50") {
+    div("bg-gray-300 mt-4 p-2 rounded-lg ring-2 ring-gray-50", id = "result") {
         em {
             selectionStore.data.map { it.count() }
                 .combine(storedFilteredSize.data) { sel, count -> "Selected ($sel/$count):" }

--- a/headless-demo/src/jsMain/kotlin/dev/fritz2/headlessdemo/disclosure.kt
+++ b/headless-demo/src/jsMain/kotlin/dev/fritz2/headlessdemo/disclosure.kt
@@ -28,8 +28,9 @@ fun RenderContext.disclosureDemo() {
                 +"Frequently asked questions"
             }
             dl("mt-6 space-y-6 divide-y divide-gray-200") {
-                faqs.forEach { (question, answer) ->
-                    disclosure("pt-6") {
+                faqs.withIndex().forEach { (index, faq) ->
+                    val (question, answer) = faq
+                    disclosure("pt-6", id = "disclosure-$index") {
                         dt("text-lg") {
                             /* <!-- Expand/collapse question button --> */
                             disclosureButton(

--- a/headless-demo/src/jsMain/kotlin/dev/fritz2/headlessdemo/inputField.kt
+++ b/headless-demo/src/jsMain/kotlin/dev/fritz2/headlessdemo/inputField.kt
@@ -8,7 +8,7 @@ import kotlinx.coroutines.flow.map
 
 fun RenderContext.inputFieldDemo() {
 
-    val name = storeOf("")
+    val name = storeOf("", id="inputField")
 
     div("max-w-sm") {
 

--- a/headless-demo/src/jsMain/kotlin/dev/fritz2/headlessdemo/inputField.kt
+++ b/headless-demo/src/jsMain/kotlin/dev/fritz2/headlessdemo/inputField.kt
@@ -39,7 +39,7 @@ fun RenderContext.inputFieldDemo() {
             }
         }
 
-        div("bg-gray-300 mt-8 p-2 rounded-lg ring-2 ring-gray-50") {
+        div("bg-gray-300 mt-8 p-2 rounded-lg ring-2 ring-gray-50", id = "result") {
             em { +"Name: " }
             name.data.renderText()
         }

--- a/headless-demo/src/jsMain/kotlin/dev/fritz2/headlessdemo/listbox.kt
+++ b/headless-demo/src/jsMain/kotlin/dev/fritz2/headlessdemo/listbox.kt
@@ -94,7 +94,7 @@ fun RenderContext.listboxDemo() {
             }
         }
 
-        div("bg-gray-300 mt-4 p-2 rounded-lg ring-2 ring-gray-50") {
+        div("bg-gray-300 mt-4 p-2 rounded-lg ring-2 ring-gray-50", id = "result") {
             em { +"Selected: " }
             span { bestCharacter.data.renderText() }
         }

--- a/headless-demo/src/jsMain/kotlin/dev/fritz2/headlessdemo/menu.kt
+++ b/headless-demo/src/jsMain/kotlin/dev/fritz2/headlessdemo/menu.kt
@@ -22,7 +22,7 @@ fun RenderContext.menuDemo() {
         MenuEntry("Encrypt", HeroIcons.key)
     )
 
-    val action = storeOf("")
+    val action = storeOf("", id = "menu")
 
     div("max-w-sm") {
         div("w-full h-72") {

--- a/headless-demo/src/jsMain/kotlin/dev/fritz2/headlessdemo/menu.kt
+++ b/headless-demo/src/jsMain/kotlin/dev/fritz2/headlessdemo/menu.kt
@@ -79,7 +79,7 @@ fun RenderContext.menuDemo() {
         }
 
 
-        div("bg-gray-300 mt-4 p-2 rounded-lg ring-2 ring-gray-50") {
+        div("bg-gray-300 mt-4 p-2 rounded-lg ring-2 ring-gray-50", id = "result") {
             em { +"Execute Action: " }
             span { action.data.map { "$it file..." }.renderText() }
         }

--- a/headless-demo/src/jsMain/kotlin/dev/fritz2/headlessdemo/modal.kt
+++ b/headless-demo/src/jsMain/kotlin/dev/fritz2/headlessdemo/modal.kt
@@ -81,25 +81,37 @@ fun RenderContext.modalDemo() {
                             }
                         }
                     }
-                    div("mt-5 sm:mt-4 sm:flex sm:flex-row-reverse") {
+                    div("mt-5 sm:mt-4 sm:flex sm:flex-row sm:justify-end") {
                         button(
-                            """w-full inline-flex justify-center rounded-md border border-transparent shadow-sm 
-                                | px-4 py-2 bg-blue-700 text-base font-medium text-white hover:bg-blue-700
+                            """mt-3 w-full inline-flex justify-center rounded-md border border-gray-300 shadow-sm 
+                                | px-4 py-2 bg-white text-base font-medium text-gray-700 hover:bg-gray-50 
                                 | focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-600 
-                                | sm:ml-3 sm:w-auto sm:text-sm""".trimMargin()
+                                | sm:mt-0 sm:w-auto sm:text-sm""".trimMargin(),
+                            id = "button-stay"
                         ) {
                             type("button")
-                            +"Back to Dashboard"
-                            clicks handledBy close
+                            +"Stay"
                         }
                         button(
                             """mt-3 w-full inline-flex justify-center rounded-md border border-gray-300 shadow-sm 
                                 | px-4 py-2 bg-white text-base font-medium text-gray-700 hover:bg-gray-50 
                                 | focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-600 
-                                | sm:mt-0 sm:w-auto sm:text-sm""".trimMargin()
+                                | sm:mt-0 sm:ml-3 sm:w-auto sm:text-sm""".trimMargin(),
+                            id = "button-cancel"
                         ) {
                             type("button")
                             +"Cancel"
+                            clicks handledBy close
+                        }
+                        button(
+                            """mt-3 w-full inline-flex justify-center rounded-md border border-transparent shadow-sm 
+                                | px-4 py-2 bg-blue-700 text-base font-medium text-white hover:bg-blue-700
+                                | focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-600 
+                                | sm:mt-0 sm:ml-3 sm:w-auto sm:text-sm""".trimMargin(),
+                            id = "button-close"
+                        ) {
+                            type("button")
+                            +"Back to Dashboard"
                             clicks handledBy close
                         }
                     }

--- a/headless-demo/src/jsMain/kotlin/dev/fritz2/headlessdemo/popOver.kt
+++ b/headless-demo/src/jsMain/kotlin/dev/fritz2/headlessdemo/popOver.kt
@@ -18,7 +18,7 @@ fun RenderContext.popOverDemo() {
         Solution("Reports", "Keep track of your growth", HeroIcons.archive)
     )
 
-    popOver {
+    popOver(id = "popOver") {
         popOverButton(
             """w-32 inline-flex justify-center rounded-md border border-transparent 
             | shadow-sm px-4 py-2 bg-blue-700 text-base font-medium text-white hover:bg-blue-800 

--- a/headless-demo/src/jsMain/kotlin/dev/fritz2/headlessdemo/radioGroup.kt
+++ b/headless-demo/src/jsMain/kotlin/dev/fritz2/headlessdemo/radioGroup.kt
@@ -68,7 +68,7 @@ fun RenderContext.radioGroupDemo() {
             }
         }
 
-        div("bg-gray-300 mt-4 p-2 rounded-lg ring-2 ring-gray-50") {
+        div("bg-gray-300 mt-4 p-2 rounded-lg ring-2 ring-gray-50", id = "result") {
             em { +"Selected: " }
             choice.data.filterNotNull().map { "${it.name} ${it.cpus} ${it.ram} ${it.price}/mo" }.renderText()
         }

--- a/headless-demo/src/jsMain/kotlin/dev/fritz2/headlessdemo/radioGroup.kt
+++ b/headless-demo/src/jsMain/kotlin/dev/fritz2/headlessdemo/radioGroup.kt
@@ -21,7 +21,7 @@ fun RenderContext.radioGroupDemo() {
         Plan("Enterprise", "32GB", "12 CPUs", "1024 GB SSD disk", "240€"),
     )
 
-    val choice = storeOf<Plan?>(null)
+    val choice = storeOf<Plan?>(null, id = "radioGroup")
 
     div("max-w-sm") {
         radioGroup<HTMLFieldSetElement, Plan?>(tag = RenderContext::fieldset) {
@@ -29,7 +29,7 @@ fun RenderContext.radioGroupDemo() {
             radioGroupLabel("sr-only") { +"Server size" }
             div("space-y-2") {
                 plans.forEach { option ->
-                    radioGroupOption(option) {
+                    radioGroupOption(option, id = option.name) {
                         radioGroupOptionToggle(
                             "relative flex justify-between border rounded-lg shadow-sm px-6 py-2 cursor-pointer focus:outline-none",
                             tag = RenderContext::label

--- a/headless-demo/src/jsMain/kotlin/dev/fritz2/headlessdemo/switch.kt
+++ b/headless-demo/src/jsMain/kotlin/dev/fritz2/headlessdemo/switch.kt
@@ -10,8 +10,8 @@ import kotlinx.coroutines.flow.map
 
 fun RenderContext.switchDemo() {
 
-    val switchState = storeOf(false)
-    val switchWithLabelState = storeOf(true)
+    val switchState = storeOf(false, id = "switch")
+    val switchWithLabelState = storeOf(true, id = "switchWithLabel")
 
     div("max-w-sm") {
         switch(

--- a/headless-demo/src/jsMain/kotlin/dev/fritz2/headlessdemo/tabGroup.kt
+++ b/headless-demo/src/jsMain/kotlin/dev/fritz2/headlessdemo/tabGroup.kt
@@ -24,7 +24,7 @@ fun RenderContext.tabsDemo() {
         )
     )
 
-    tabGroup("max-w-sm") {
+    tabGroup("max-w-sm", id = "tabGroup") {
         tabList("flex p-1 space-x-1 bg-blue-900/20 rounded-xl") {
             categories.keys.forEach { category ->
                 tab(

--- a/headless-demo/src/jsMain/kotlin/dev/fritz2/headlessdemo/textArea.kt
+++ b/headless-demo/src/jsMain/kotlin/dev/fritz2/headlessdemo/textArea.kt
@@ -38,7 +38,7 @@ fun RenderContext.textAreaDemo() {
             }
         }
 
-        div("bg-gray-300 mt-8 p-2 rounded-lg ring-2 ring-gray-50") {
+        div("bg-gray-300 mt-8 p-2 rounded-lg ring-2 ring-gray-50", id = "result") {
             em { +"Description: " }
             description.data.renderText()
         }

--- a/headless-demo/src/jsMain/kotlin/dev/fritz2/headlessdemo/textArea.kt
+++ b/headless-demo/src/jsMain/kotlin/dev/fritz2/headlessdemo/textArea.kt
@@ -8,7 +8,7 @@ import kotlinx.coroutines.flow.map
 
 fun RenderContext.textAreaDemo() {
 
-    val description = storeOf("")
+    val description = storeOf("", id = "textArea")
 
     div("max-w-sm") {
         textArea {

--- a/headless/src/jsMain/kotlin/dev/fritz2/headless/components/checkboxGroup.kt
+++ b/headless/src/jsMain/kotlin/dev/fritz2/headless/components/checkboxGroup.kt
@@ -71,7 +71,7 @@ class CheckboxGroup<C : HTMLElement, T>(tag: Tag<C>, private val explicitId: Str
         initialize: ValidationMessages<CV>.() -> Unit
     ) {
         value.validationMessages.map { it.isNotEmpty() }.distinctUntilChanged().render { isNotEmpty ->
-            if(isNotEmpty) {
+            if (isNotEmpty) {
                 tag(this, classes, "$componentId-${ValidationMessages.ID_SUFFIX}", scope) {
                     validationMessages = this
                     initialize(ValidationMessages(value.validationMessages, this))
@@ -95,7 +95,7 @@ class CheckboxGroup<C : HTMLElement, T>(tag: Tag<C>, private val explicitId: Str
     inner class CheckboxGroupOption<CO : HTMLElement>(
         tag: Tag<CO>,
         private val option: T,
-        id: String?
+        val optionId: String
     ) : Tag<CO> by tag {
 
         val selected = value.data.map { it.contains(option) }
@@ -103,8 +103,6 @@ class CheckboxGroup<C : HTMLElement, T>(tag: Tag<C>, private val explicitId: Str
         private var toggle: Tag<HTMLElement>? = null
         private var label: Tag<HTMLElement>? = null
         private var descriptions: MutableList<Tag<HTMLElement>> = mutableListOf()
-
-        val optionId = "$componentId-${id ?: Id.next()}"
 
         fun render() {
             toggle?.apply {
@@ -130,7 +128,7 @@ class CheckboxGroup<C : HTMLElement, T>(tag: Tag<C>, private val explicitId: Str
             scope: (ScopeContext.() -> Unit) = {},
             tag: TagFactory<Tag<CT>>,
             content: Tag<CT>.() -> Unit
-        ) = tag(this, classes, optionId, scope) {
+        ) = tag(this, classes, "${optionId}-toggle", scope) {
             content()
             attr("role", Aria.Role.checkbox)
             attr(Aria.checked, selected.asString())
@@ -244,10 +242,12 @@ class CheckboxGroup<C : HTMLElement, T>(tag: Tag<C>, private val explicitId: Str
         scope: (ScopeContext.() -> Unit) = {},
         tag: TagFactory<Tag<CO>>,
         initialize: CheckboxGroupOption<CO>.() -> Unit
-    ): Tag<CO> = tag(this, classes, id, scope) {
-        CheckboxGroupOption(this, option, id).run {
-            initialize()
-            render()
+    ): Tag<CO> = "$componentId-${id ?: Id.next()}".let { optionId ->
+        tag(this, classes, optionId, scope) {
+            CheckboxGroupOption(this, option, optionId).run {
+                initialize()
+                render()
+            }
         }
     }
 

--- a/headless/src/jsMain/kotlin/dev/fritz2/headless/components/radioGroup.kt
+++ b/headless/src/jsMain/kotlin/dev/fritz2/headless/components/radioGroup.kt
@@ -92,7 +92,7 @@ class RadioGroup<C : HTMLElement, T>(tag: Tag<C>, private val explicitId: String
         initialize: ValidationMessages<CV>.() -> Unit
     ) {
         value.validationMessages.map { it.isNotEmpty() }.distinctUntilChanged().render { isNotEmpty ->
-            if(isNotEmpty) {
+            if (isNotEmpty) {
                 tag(this, classes, "$componentId-${ValidationMessages.ID_SUFFIX}", scope) {
                     validationMessages = this
                     initialize(ValidationMessages(value.validationMessages, this))
@@ -116,7 +116,7 @@ class RadioGroup<C : HTMLElement, T>(tag: Tag<C>, private val explicitId: String
     inner class RadioGroupOption<CO : HTMLElement>(
         tag: Tag<CO>,
         private val option: T,
-        id: String?
+        val optionId: String
     ) : Tag<CO> by tag {
 
         val selected = value.data.map { it == option }
@@ -125,8 +125,6 @@ class RadioGroup<C : HTMLElement, T>(tag: Tag<C>, private val explicitId: String
         private var toggle: Tag<HTMLElement>? = null
         private var label: Tag<HTMLElement>? = null
         private var descriptions: MutableList<Tag<HTMLElement>> = mutableListOf()
-
-        val optionId = "$componentId-${id ?: Id.next()}"
 
         fun render() {
             toggle?.apply {
@@ -152,7 +150,7 @@ class RadioGroup<C : HTMLElement, T>(tag: Tag<C>, private val explicitId: String
             scope: (ScopeContext.() -> Unit) = {},
             tag: TagFactory<Tag<CT>>,
             content: Tag<CT>.() -> Unit
-        ) = tag(this, classes, optionId, scope) {
+        ) = tag(this, classes, "$optionId-toggle", scope) {
             content()
             attr("role", Aria.Role.radio)
             attr(Aria.checked, selected.asString())
@@ -264,10 +262,12 @@ class RadioGroup<C : HTMLElement, T>(tag: Tag<C>, private val explicitId: String
         scope: (ScopeContext.() -> Unit) = {},
         tag: TagFactory<Tag<CO>>,
         initialize: RadioGroupOption<CO>.() -> Unit
-    ): Tag<CO> = tag(this, classes, id, scope) {
-        RadioGroupOption(this, option, id).run {
-            initialize()
-            render()
+    ): Tag<CO> = "$componentId-${id ?: Id.next()}".let { optionId ->
+        tag(this, classes, optionId, scope) {
+            RadioGroupOption(this, option, optionId).run {
+                initialize()
+                render()
+            }
         }
     }
 

--- a/www/src/pages/headless/inputField.md
+++ b/www/src/pages/headless/inputField.md
@@ -96,6 +96,22 @@ inputField {
 }
 ```
 
+## Mouse Interaction
+
+Clicking outside the input field (so the focus gets lost) will update the `value` to the content of the field.
+
+If the HTML `label` tag is used for the label (by default), a mouse click on the label causes the input field to be
+focused.
+
+## Keyboard Interaction
+
+| Command                                                              | Description         |
+|----------------------------------------------------------------------|---------------------|
+| Any key that will trigger a `change` event like [[Tab]] or [[Enter]] | updates the `value` |
+
+For more details which key will trigger a change, refer to this 
+[documentation](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/change_event)
+
 ## API
 
 ### Summary / Sketch

--- a/www/src/pages/headless/textArea.md
+++ b/www/src/pages/headless/textArea.md
@@ -58,7 +58,7 @@ textArea {
 
 ## Deactivate
 
-The TextArea component supports the (dynamic) deactivation and activation of the input field. To do this, the boolean
+The TextArea component supports the (dynamic) deactivation and activation of the text field. To do this, the boolean
 Attribute hook `disabled` must be set accordingly.
 
 ```kotlin
@@ -95,6 +95,23 @@ textArea {
     }
 }
 ```
+
+
+## Mouse Interaction
+
+Clicking outside the TextArea component (so the focus gets lost) will update the `value` to the content of the area.
+
+If the HTML `label` tag is used for the label (by default), a mouse click on the label causes the text area to be
+focused.
+
+## Keyboard Interaction
+
+| Command                                                              | Description         |
+|----------------------------------------------------------------------|---------------------|
+| Any key that will trigger a `change` event like [[Tab]] or [[Enter]] | updates the `value` |
+
+For more details which key will trigger a change, refer to this
+[documentation](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/change_event)
 
 ## API
 


### PR DESCRIPTION
- Adds lot of explicit IDs for the headless components, so the automatic testing will become much easier: The detection of an HTML element of the component can now be based upon deterministic IDs.
- Add third button for modal demo, so the tabbing direction will become obvious
- Add missing keyboard and mouse interaction sections for `inputField` and `textArea` component's documentation.