### PR TITLE
Add debug information for headless components

### DIFF
--- a/headless-demo/src/jsMain/kotlin/dev/fritz2/headlessdemo/app.kt
+++ b/headless-demo/src/jsMain/kotlin/dev/fritz2/headlessdemo/app.kt
@@ -1,6 +1,7 @@
 package dev.fritz2.headlessdemo
 
 import dev.fritz2.core.*
+import dev.fritz2.headless.foundation.headlessDebug
 import dev.fritz2.routing.routerOf
 
 data class DemoPage(val title: String, val description: String, val content: RenderContext.() -> Unit)
@@ -133,7 +134,7 @@ fun main() {
 
     render {
         router.data.render { route ->
-            div("p-4") {
+            div("p-4", scope = { set(headlessDebug, true) }) {
                 (pages[route]?.content ?: RenderContext::overview)()
             }
         }

--- a/headless/src/jsMain/kotlin/dev/fritz2/headless/components/checkboxGroup.kt
+++ b/headless/src/jsMain/kotlin/dev/fritz2/headless/components/checkboxGroup.kt
@@ -44,7 +44,10 @@ class CheckboxGroup<C : HTMLElement, T>(tag: Tag<C>, private val explicitId: Str
         scope: (ScopeContext.() -> Unit) = {},
         tag: TagFactory<Tag<CL>>,
         content: Tag<CL>.() -> Unit
-    ) = tag(this, classes, "$componentId-label", scope, content).also { label = it }
+    ): Tag<CL> {
+        addComponentDebugInfo("checkboxGroupLabel", this@checkboxGroupLabel.scope, this)
+        return tag(this, classes, "$componentId-label", scope, content).also { label = it }
+    }
 
     /**
      * Factory function to create a [checkboxGroupLabel] with a [HTMLLabelElement] as default [Tag].
@@ -72,6 +75,11 @@ class CheckboxGroup<C : HTMLElement, T>(tag: Tag<C>, private val explicitId: Str
     ) {
         value.validationMessages.map { it.isNotEmpty() }.distinctUntilChanged().render { isNotEmpty ->
             if (isNotEmpty) {
+                addComponentDebugInfo(
+                    "checkboxGroupValidationMessages",
+                    this@checkboxGroupValidationMessages.scope,
+                    this
+                )
                 tag(this, classes, "$componentId-${ValidationMessages.ID_SUFFIX}", scope) {
                     validationMessages = this
                     initialize(ValidationMessages(value.validationMessages, this))
@@ -128,34 +136,37 @@ class CheckboxGroup<C : HTMLElement, T>(tag: Tag<C>, private val explicitId: Str
             scope: (ScopeContext.() -> Unit) = {},
             tag: TagFactory<Tag<CT>>,
             content: Tag<CT>.() -> Unit
-        ) = tag(this, classes, "${optionId}-toggle", scope) {
-            content()
-            attr("role", Aria.Role.checkbox)
-            attr(Aria.checked, selected.asString())
-            attr("tabindex", "0")
-            var withKeyboardNavigation = true
-            var toggleEvent: Listener<*, *> = clicks
-            if (domNode is HTMLInputElement) {
-                if (domNode.getAttribute("name") == null) {
-                    attr("name", componentId)
+        ): Tag<CT> {
+            addComponentDebugInfo("checkboxGroupOptionToggle", this@checkboxGroupOptionToggle.scope, this)
+            return tag(this, classes, "${optionId}-toggle", scope) {
+                content()
+                attr("role", Aria.Role.checkbox)
+                attr(Aria.checked, selected.asString())
+                attr("tabindex", "0")
+                var withKeyboardNavigation = true
+                var toggleEvent: Listener<*, *> = clicks
+                if (domNode is HTMLInputElement) {
+                    if (domNode.getAttribute("name") == null) {
+                        attr("name", componentId)
+                    }
+                    withKeyboardNavigation = false
+                    toggleEvent = changes
                 }
-                withKeyboardNavigation = false
-                toggleEvent = changes
-            }
-            value.handler?.invoke(value.data.flatMapLatest { value ->
-                toggleEvent.map { if (value.contains(option)) value - option else value + option }
-            })
-            if (withKeyboardNavigation) {
-                value.handler?.invoke(
-                    value.data.flatMapLatest { value ->
-                        keydowns.filter { shortcutOf(it) == Keys.Space }.map {
-                            it.stopImmediatePropagation()
-                            it.preventDefault()
-                            if (value.contains(option)) value - option else value + option
-                        }
-                    })
-            }
-        }.also { toggle = it }
+                value.handler?.invoke(value.data.flatMapLatest { value ->
+                    toggleEvent.map { if (value.contains(option)) value - option else value + option }
+                })
+                if (withKeyboardNavigation) {
+                    value.handler?.invoke(
+                        value.data.flatMapLatest { value ->
+                            keydowns.filter { shortcutOf(it) == Keys.Space }.map {
+                                it.stopImmediatePropagation()
+                                it.preventDefault()
+                                if (value.contains(option)) value - option else value + option
+                            }
+                        })
+                }
+            }.also { toggle = it }
+        }
 
         /**
          * Factory function to create a [checkboxGroupOptionToggle] with a [HTMLDivElement] as default [Tag].
@@ -180,7 +191,10 @@ class CheckboxGroup<C : HTMLElement, T>(tag: Tag<C>, private val explicitId: Str
             scope: (ScopeContext.() -> Unit) = {},
             tag: TagFactory<Tag<CL>>,
             content: Tag<CL>.() -> Unit
-        ) = tag(this, classes, "$optionId-label", scope, content).also { label = it }
+        ): Tag<CL> {
+            addComponentDebugInfo("checkboxGroupOptionLabel", this@checkboxGroupOptionLabel.scope, this)
+            return tag(this, classes, "$optionId-label", scope, content).also { label = it }
+        }
 
         /**
          * Factory function to create a [checkboxGroupOptionLabel] with a [HTMLLabelElement] as default [Tag].
@@ -208,13 +222,16 @@ class CheckboxGroup<C : HTMLElement, T>(tag: Tag<C>, private val explicitId: Str
             scope: (ScopeContext.() -> Unit) = {},
             tag: TagFactory<Tag<CL>>,
             content: Tag<CL>.() -> Unit
-        ) = tag(
-            this,
-            classes,
-            "$optionId-description-${descriptions.size}",
-            scope,
-            content
-        ).also { descriptions.add(it) }
+        ): Tag<CL> {
+            addComponentDebugInfo("checkboxGroupOptionDescription", this@checkboxGroupOptionDescription.scope, this)
+            return tag(
+                this,
+                classes,
+                "$optionId-description-${descriptions.size}",
+                scope,
+                content
+            ).also { descriptions.add(it) }
+        }
 
         /**
          * Factory function to create a [checkboxGroupOptionDescription] with a [HTMLSpanElement] as default [Tag].
@@ -242,8 +259,10 @@ class CheckboxGroup<C : HTMLElement, T>(tag: Tag<C>, private val explicitId: Str
         scope: (ScopeContext.() -> Unit) = {},
         tag: TagFactory<Tag<CO>>,
         initialize: CheckboxGroupOption<CO>.() -> Unit
-    ): Tag<CO> = "$componentId-${id ?: Id.next()}".let { optionId ->
-        tag(this, classes, optionId, scope) {
+    ): Tag<CO> {
+        addComponentDebugInfo("checkboxGroupOption", this@checkboxGroupOption.scope, this)
+        val optionId = "$componentId-${id ?: Id.next()}"
+        return tag(this, classes, optionId, scope) {
             CheckboxGroupOption(this, option, optionId).run {
                 initialize()
                 render()
@@ -298,10 +317,13 @@ fun <C : HTMLElement, T> RenderContext.checkboxGroup(
     scope: (ScopeContext.() -> Unit) = {},
     tag: TagFactory<Tag<C>>,
     initialize: CheckboxGroup<C, T>.() -> Unit
-): Tag<C> = tag(this, classes, id, scope) {
-    CheckboxGroup<C, T>(this, id).run {
-        initialize()
-        render()
+): Tag<C> {
+    addComponentDebugInfo("checkboxGroup", this@checkboxGroup.scope, this)
+    return tag(this, classes, id, scope) {
+        CheckboxGroup<C, T>(this, id).run {
+            initialize()
+            render()
+        }
     }
 }
 

--- a/headless/src/jsMain/kotlin/dev/fritz2/headless/components/dataCollection.kt
+++ b/headless/src/jsMain/kotlin/dev/fritz2/headless/components/dataCollection.kt
@@ -376,6 +376,7 @@ class DataCollection<T, C : HTMLElement>(tag: Tag<C>) : Tag<C> by tag {
                 itemId,
                 scope
             ) {
+                addComponentDebugInfo("parent is dataCollectionItem", this@dataCollectionItem.scope, this)
                 DataCollectionItem(item, itemId, this).run {
                     initialize()
                     render()
@@ -412,6 +413,7 @@ class DataCollection<T, C : HTMLElement>(tag: Tag<C>) : Tag<C> by tag {
         tag: TagFactory<Tag<CI>>,
         initialize: DataCollectionItems<CI>.() -> Unit
     ) {
+        addComponentDebugInfo("dataCollectionItems", this@dataCollectionItems.scope, this)
         val collectionId = id ?: data.value?.id
         tag(this, classes, collectionId, scope) {
             DataCollectionItems(this, collectionId).run {
@@ -478,9 +480,12 @@ fun <T, C : HTMLElement> RenderContext.dataCollection(
     scope: (ScopeContext.() -> Unit) = {},
     tag: TagFactory<Tag<C>>,
     initialize: DataCollection<T, C>.() -> Unit
-): Tag<C> = tag(this, classes, id, scope) {
-    DataCollection<T, C>(this).run {
-        initialize(this)
+): Tag<C> {
+    addComponentDebugInfo("dataCollection", this@dataCollection.scope, this)
+    return tag(this, classes, id, scope) {
+        DataCollection<T, C>(this).run {
+            initialize(this)
+        }
     }
 }
 

--- a/headless/src/jsMain/kotlin/dev/fritz2/headless/components/disclosure.kt
+++ b/headless/src/jsMain/kotlin/dev/fritz2/headless/components/disclosure.kt
@@ -4,6 +4,7 @@ import dev.fritz2.core.*
 import dev.fritz2.headless.foundation.Aria
 import dev.fritz2.headless.foundation.OpenClose
 import dev.fritz2.headless.foundation.TagFactory
+import dev.fritz2.headless.foundation.addComponentDebugInfo
 import org.w3c.dom.HTMLButtonElement
 import org.w3c.dom.HTMLDivElement
 import org.w3c.dom.HTMLElement
@@ -41,13 +42,16 @@ class Disclosure<C : HTMLElement>(tag: Tag<C>, id: String?) : Tag<C> by tag, Ope
         scope: (ScopeContext.() -> Unit) = {},
         tag: TagFactory<Tag<CB>>,
         content: Tag<CB>.() -> Unit
-    ) = tag(this, classes, "$componentId-button", scope) {
-        if (!openState.isSet) openState(storeOf(false))
-        content()
-        attr(Aria.expanded, opened.asString())
-        attr("tabindex", "0")
-        toggleOnClicksEnterAndSpace()
-    }.also { button = it }
+    ): Tag<CB> {
+        addComponentDebugInfo("disclosureButton", this@disclosureButton.scope, this)
+        return tag(this, classes, "$componentId-button", scope) {
+            if (!openState.isSet) openState(storeOf(false))
+            content()
+            attr(Aria.expanded, opened.asString())
+            attr("tabindex", "0")
+            toggleOnClicksEnterAndSpace()
+        }.also { button = it }
+    }
 
     /**
      * Factory function to create a [disclosureButton] with a [HTMLButtonElement] as default [Tag].
@@ -79,9 +83,12 @@ class Disclosure<C : HTMLElement>(tag: Tag<C>, id: String?) : Tag<C> by tag, Ope
             scope: (ScopeContext.() -> Unit) = {},
             tag: TagFactory<Tag<CC>>,
             content: Tag<CC>.() -> Unit
-        ) = tag(this, classes, "$componentId-close-button", scope) {
-            content()
-            clicks handledBy close
+        ): Tag<CC> {
+            addComponentDebugInfo("disclosureCloseButton", this@disclosureCloseButton.scope, this)
+            return tag(this, classes, "$componentId-close-button", scope) {
+                content()
+                clicks handledBy close
+            }
         }
 
         /**
@@ -111,6 +118,7 @@ class Disclosure<C : HTMLElement>(tag: Tag<C>, id: String?) : Tag<C> by tag, Ope
         tag: TagFactory<Tag<CP>>,
         initialize: DisclosurePanel<CP>.() -> Unit
     ) {
+        addComponentDebugInfo("disclosurePanel", this@disclosurePanel.scope, this)
         panel = {
             tag(this, classes, "$componentId-panel", scope) {
                 DisclosurePanel(this).run {
@@ -162,10 +170,13 @@ fun <C : HTMLElement> RenderContext.disclosure(
     scope: (ScopeContext.() -> Unit) = {},
     tag: TagFactory<Tag<C>>,
     initialize: Disclosure<C>.() -> Unit
-): Tag<C> = tag(this, classes, id, scope) {
-    Disclosure(this, id).run {
-        initialize()
-        render()
+): Tag<C> {
+    addComponentDebugInfo("disclosure", this@disclosure.scope, this)
+    return tag(this, classes, id, scope) {
+        Disclosure(this, id).run {
+            initialize()
+            render()
+        }
     }
 }
 

--- a/headless/src/jsMain/kotlin/dev/fritz2/headless/components/listbox.kt
+++ b/headless/src/jsMain/kotlin/dev/fritz2/headless/components/listbox.kt
@@ -66,12 +66,15 @@ class Listbox<T, C : HTMLElement>(tag: Tag<C>, id: String?) : Tag<C> by tag, Ope
         scope: (ScopeContext.() -> Unit) = {},
         tag: TagFactory<Tag<CB>>,
         content: Tag<CB>.() -> Unit
-    ) = tag(this, classes, "$componentId-button", scope) {
-        if (!openState.isSet) openState(storeOf(false))
-        content()
-        attr(Aria.expanded, opened.asString())
-        toggleOnClicksEnterAndSpace()
-    }.also { button = it }
+    ): Tag<CB> {
+        addComponentDebugInfo("listboxButton", this@listboxButton.scope, this)
+        return tag(this, classes, "$componentId-button", scope) {
+            if (!openState.isSet) openState(storeOf(false))
+            content()
+            attr(Aria.expanded, opened.asString())
+            toggleOnClicksEnterAndSpace()
+        }.also { button = it }
+    }
 
     /**
      * Factory function to create a [listboxButton] with a [HTMLButtonElement] as default [Tag].
@@ -98,7 +101,10 @@ class Listbox<T, C : HTMLElement>(tag: Tag<C>, id: String?) : Tag<C> by tag, Ope
         scope: (ScopeContext.() -> Unit) = {},
         tag: TagFactory<Tag<CL>>,
         content: Tag<CL>.() -> Unit
-    ) = tag(this, classes, "$componentId-label", scope, content).also { label = it }
+    ): Tag<CL> {
+        addComponentDebugInfo("listboxLabel", this@listboxLabel.scope, this)
+        return tag(this, classes, "$componentId-label", scope, content).also { label = it }
+    }
 
     /**
      * Factory function to create a [listboxLabel] with a [HTMLLabelElement] as default [Tag].
@@ -125,7 +131,8 @@ class Listbox<T, C : HTMLElement>(tag: Tag<C>, id: String?) : Tag<C> by tag, Ope
         initialize: ValidationMessages<CV>.() -> Unit
     ) {
         value.validationMessages.map { it.isNotEmpty() }.distinctUntilChanged().render { isNotEmpty ->
-            if(isNotEmpty) {
+            if (isNotEmpty) {
+                addComponentDebugInfo("listboxValidationMessages", this@listboxValidationMessages.scope, this)
                 tag(this, classes, "$componentId-${ValidationMessages.ID_SUFFIX}", scope) {
                     validationMessages = this
                     initialize(ValidationMessages(value.validationMessages, this))
@@ -151,7 +158,15 @@ class Listbox<T, C : HTMLElement>(tag: Tag<C>, id: String?) : Tag<C> by tag, Ope
         tagFactory: TagFactory<Tag<CI>>,
         classes: String?,
         scope: ScopeContext.() -> Unit
-    ) : PopUpPanel<CI>(renderContext, tagFactory, classes, "$componentId-items", scope, this@Listbox.opened, reference = button) {
+    ) : PopUpPanel<CI>(
+        renderContext,
+        tagFactory,
+        classes,
+        "$componentId-items",
+        scope,
+        this@Listbox.opened,
+        reference = button
+    ) {
 
         private fun nextItem(currentIndex: Int, direction: Direction, entries: List<ListboxEntry<T>>): Int =
             when (direction) {
@@ -200,12 +215,12 @@ class Listbox<T, C : HTMLElement>(tag: Tag<C>, id: String?) : Tag<C> by tag, Ope
 
             entries.data.flatMapLatest { entries ->
                 keydowns.mapNotNull { event ->
-                        if (!Keys.NamedKeys.contains(event.key)) {
-                            event.preventDefault()
-                            event.stopImmediatePropagation()
-                            event.key.first().lowercaseChar()
-                        } else null
-                    }
+                    if (!Keys.NamedKeys.contains(event.key)) {
+                        event.preventDefault()
+                        event.stopImmediatePropagation()
+                        event.key.first().lowercaseChar()
+                    } else null
+                }
                     .mapNotNull { c ->
                         if (c.isLetterOrDigit()) itemByCharacter(entries, c)
                         else null
@@ -287,6 +302,7 @@ class Listbox<T, C : HTMLElement>(tag: Tag<C>, id: String?) : Tag<C> by tag, Ope
             val index = numberOfItems++
 
             entries.addEntry(ListboxEntry(entry, false, null))
+            addComponentDebugInfo("listboxItem", this@listboxItem.scope, this)
             tag(this, classes, "$componentId-item-$index", scope) {
                 ListboxItem(entry, this, index).run {
                     initialize()
@@ -323,6 +339,7 @@ class Listbox<T, C : HTMLElement>(tag: Tag<C>, id: String?) : Tag<C> by tag, Ope
         tag: TagFactory<Tag<CI>>,
         initialize: ListboxItems<CI>.() -> Unit
     ) {
+        addComponentDebugInfo("listboxItems", this@listboxItems.scope, this)
         if (!openState.isSet) openState(storeOf(false))
         ListboxItems(this, tag, classes, scope).run {
             initialize()
@@ -391,10 +408,13 @@ fun <T, C : HTMLElement> RenderContext.listbox(
     scope: (ScopeContext.() -> Unit) = {},
     tag: TagFactory<Tag<C>>,
     initialize: Listbox<T, C>.() -> Unit
-): Tag<C> = tag(this, classes(classes, "relative"), id, scope) {
-    Listbox<T, C>(this, id).run {
-        initialize(this)
-        render()
+): Tag<C> {
+    addComponentDebugInfo("listbox", this@listbox.scope, this)
+    return tag(this, classes(classes, "relative"), id, scope) {
+        Listbox<T, C>(this, id).run {
+            initialize(this)
+            render()
+        }
     }
 }
 

--- a/headless/src/jsMain/kotlin/dev/fritz2/headless/components/menu.kt
+++ b/headless/src/jsMain/kotlin/dev/fritz2/headless/components/menu.kt
@@ -66,12 +66,15 @@ class Menu<C : HTMLElement>(tag: Tag<C>, id: String?) : Tag<C> by tag, OpenClose
         scope: (ScopeContext.() -> Unit) = {},
         tag: TagFactory<Tag<CB>>,
         content: Tag<CB>.() -> Unit
-    ) = tag(this, classes, "$componentId-button", scope) {
-        if (!openState.isSet) openState(storeOf(false))
-        content()
-        attr(Aria.expanded, opened.asString())
-        toggleOnClicksEnterAndSpace()
-    }.also { button = it }
+    ) : Tag<CB> {
+        addComponentDebugInfo("menuButton", this@menuButton.scope, this)
+        return tag(this, classes, "$componentId-button", scope) {
+            if (!openState.isSet) openState(storeOf(false))
+            content()
+            attr(Aria.expanded, opened.asString())
+            toggleOnClicksEnterAndSpace()
+        }.also { button = it }
+    }
 
     /**
      * Factory function to create a [menuButton] with a [HTMLButtonElement] as default [Tag].
@@ -211,6 +214,7 @@ class Menu<C : HTMLElement>(tag: Tag<C>, id: String?) : Tag<C> by tag, OpenClose
         ) {
             val index = numberOfItems++
             items.addItem(MenuEntry(false, null))
+            addComponentDebugInfo("menuItem", this@menuItem.scope, this)
             tag(this, classes, "$componentId-item-$index", scope) {
                 MenuItem(this, index).run {
                     initialize()
@@ -247,6 +251,7 @@ class Menu<C : HTMLElement>(tag: Tag<C>, id: String?) : Tag<C> by tag, OpenClose
         initialize: MenuItems<CI>.() -> Unit
     ) {
         if (!openState.isSet) openState(storeOf(false))
+        addComponentDebugInfo("menuItems", this@menuItems.scope, this)
         MenuItems(this, tag, classes, scope).run {
             initialize()
             render()
@@ -309,10 +314,13 @@ fun <C : HTMLElement> RenderContext.menu(
     scope: (ScopeContext.() -> Unit) = {},
     tag: TagFactory<Tag<C>>,
     initialize: Menu<C>.() -> Unit
-): Tag<C> = tag(this, classes(classes, "relative"), id, scope) {
-    Menu(this, id).run {
-        initialize(this)
-        render()
+): Tag<C> {
+    addComponentDebugInfo("menu", this@menu.scope, this)
+    return tag(this, classes(classes, "relative"), id, scope) {
+        Menu(this, id).run {
+            initialize(this)
+            render()
+        }
     }
 }
 

--- a/headless/src/jsMain/kotlin/dev/fritz2/headless/components/modal.kt
+++ b/headless/src/jsMain/kotlin/dev/fritz2/headless/components/modal.kt
@@ -60,9 +60,12 @@ class Modal(val renderContext: RenderContext) : RenderContext by renderContext, 
             scope: (ScopeContext.() -> Unit) = {},
             tag: TagFactory<Tag<CO>>,
             content: Tag<CO>.() -> Unit
-        ) = tag(this, classes, "$componentId-overlay", scope) {
-            attr(Aria.hidden, "true")
-            content()
+        ): Tag<CO> {
+            addComponentDebugInfo("modalOverlay", this@modalOverlay.scope, this)
+            return tag(this, classes, "$componentId-overlay", scope) {
+                attr(Aria.hidden, "true")
+                content()
+            }
         }
 
         /**
@@ -88,7 +91,10 @@ class Modal(val renderContext: RenderContext) : RenderContext by renderContext, 
             scope: (ScopeContext.() -> Unit) = {},
             tag: TagFactory<Tag<CT>>,
             content: Tag<CT>.() -> Unit
-        ) = tag(this, classes, "$componentId-title", scope, content).also { title = it }
+        ): Tag<CT> {
+            addComponentDebugInfo("modalTitle", this@modalTitle.scope, this)
+            return tag(this, classes, "$componentId-title", scope, content).also { title = it }
+        }
 
         /**
          * Factory function to create a [modalTitle] with a [HTMLHeadingElement] as default [Tag].
@@ -113,13 +119,16 @@ class Modal(val renderContext: RenderContext) : RenderContext by renderContext, 
             scope: (ScopeContext.() -> Unit) = {},
             tag: TagFactory<Tag<CD>>,
             content: Tag<CD>.() -> Unit
-        ) = tag(
-            this,
-            classes,
-            "$componentId-description-${descriptions.size}",
-            scope,
-            content
-        ).also { descriptions.add(it) }
+        ): Tag<CD> {
+            addComponentDebugInfo("modalDescription", this@modalDescription.scope, this)
+            return tag(
+                this,
+                classes,
+                "$componentId-description-${descriptions.size}",
+                scope,
+                content
+            ).also { descriptions.add(it) }
+        }
 
         /**
          * Factory function to create a [modalDescription] with a [HTMLParagraphElement] as default [Tag].
@@ -149,6 +158,7 @@ class Modal(val renderContext: RenderContext) : RenderContext by renderContext, 
     ) {
         panel = {
             tag(this, classes, id, internalScope) {
+                addComponentDebugInfo("parent is modalPanel", this@modalPanel.scope, this)
                 ModalPanel(this).run {
                     initialize()
                     render()

--- a/headless/src/jsMain/kotlin/dev/fritz2/headless/components/popOver.kt
+++ b/headless/src/jsMain/kotlin/dev/fritz2/headless/components/popOver.kt
@@ -36,12 +36,15 @@ class PopOver<C : HTMLElement>(tag: Tag<C>, id: String?) : Tag<C> by tag, OpenCl
         scope: (ScopeContext.() -> Unit) = {},
         tag: TagFactory<Tag<CB>>,
         content: Tag<CB>.() -> Unit
-    ) = tag(this, classes, "$componentId-button", scope) {
-        if (!openState.isSet) openState(storeOf(false))
-        content()
-        attr(Aria.expanded, opened.asString())
-        toggleOnClicksEnterAndSpace()
-    }.also { button = it }
+    ) : Tag<CB> {
+        addComponentDebugInfo("popOverButton", this@popOverButton.scope, this)
+        return tag(this, classes, "$componentId-button", scope) {
+            if (!openState.isSet) openState(storeOf(false))
+            content()
+            attr(Aria.expanded, opened.asString())
+            toggleOnClicksEnterAndSpace()
+        }.also { button = it }
+    }
 
     /**
      * Factory function to create a [popOverButton] with a [HTMLButtonElement] as default [Tag].
@@ -76,6 +79,7 @@ class PopOver<C : HTMLElement>(tag: Tag<C>, id: String?) : Tag<C> by tag, OpenCl
         tag: TagFactory<Tag<CP>>,
         initialize: PopOverPanel<CP>.() -> Unit
     ) {
+        addComponentDebugInfo("popOverPanel", this@popOverPanel.scope, this)
         PopOverPanel(this, tag, classes, scope).run {
             initialize()
             render()
@@ -130,12 +134,15 @@ fun <C : HTMLElement> RenderContext.popOver(
     scope: (ScopeContext.() -> Unit) = {},
     tag: TagFactory<Tag<C>>,
     initialize: PopOver<C>.() -> Unit
-): Tag<C> = tag(this, classes(classes, "relative"), id, scope) {
-    PopOver(this, id).run {
-        initialize(this)
-        render()
+): Tag<C> {
+    addComponentDebugInfo("popOver", this@popOver.scope, this)
+    return tag(this, classes(classes, "relative"), id, scope) {
+        PopOver(this, id).run {
+            initialize(this)
+            render()
+        }
+        trapFocus()
     }
-    trapFocus()
 }
 
 /**

--- a/headless/src/jsMain/kotlin/dev/fritz2/headless/components/radioGroup.kt
+++ b/headless/src/jsMain/kotlin/dev/fritz2/headless/components/radioGroup.kt
@@ -65,7 +65,10 @@ class RadioGroup<C : HTMLElement, T>(tag: Tag<C>, private val explicitId: String
         scope: (ScopeContext.() -> Unit) = {},
         tag: TagFactory<Tag<CL>>,
         content: Tag<CL>.() -> Unit
-    ) = tag(this, classes, "$componentId-label", scope, content).also { label = it }
+    ): Tag<CL> {
+        addComponentDebugInfo("radioGroupLabel", this@radioGroupLabel.scope, this)
+        return tag(this, classes, "$componentId-label", scope, content).also { label = it }
+    }
 
     /**
      * Factory function to create a [radioGroupLabel] with a [HTMLLabelElement] as default [Tag].
@@ -93,6 +96,7 @@ class RadioGroup<C : HTMLElement, T>(tag: Tag<C>, private val explicitId: String
     ) {
         value.validationMessages.map { it.isNotEmpty() }.distinctUntilChanged().render { isNotEmpty ->
             if (isNotEmpty) {
+                addComponentDebugInfo("radioGroupValidationMessages", this@radioGroupValidationMessages.scope, this)
                 tag(this, classes, "$componentId-${ValidationMessages.ID_SUFFIX}", scope) {
                     validationMessages = this
                     initialize(ValidationMessages(value.validationMessages, this))
@@ -150,28 +154,31 @@ class RadioGroup<C : HTMLElement, T>(tag: Tag<C>, private val explicitId: String
             scope: (ScopeContext.() -> Unit) = {},
             tag: TagFactory<Tag<CT>>,
             content: Tag<CT>.() -> Unit
-        ) = tag(this, classes, "$optionId-toggle", scope) {
-            content()
-            attr("role", Aria.Role.radio)
-            attr(Aria.checked, selected.asString())
-            attr("tabindex", selected.map { if (it) "0" else "-1" })
-            var toggleEvent: Listener<*, *> = clicks
-            if (domNode is HTMLInputElement) {
-                if (domNode.getAttribute("name") == null) {
-                    attr("name", componentId)
+        ): Tag<CT> {
+            addComponentDebugInfo("radioGroupOptionToggle", this@radioGroupOptionToggle.scope, this)
+            return tag(this, classes, "$optionId-toggle", scope) {
+                content()
+                attr("role", Aria.Role.radio)
+                attr(Aria.checked, selected.asString())
+                attr("tabindex", selected.map { if (it) "0" else "-1" })
+                var toggleEvent: Listener<*, *> = clicks
+                if (domNode is HTMLInputElement) {
+                    if (domNode.getAttribute("name") == null) {
+                        attr("name", componentId)
+                    }
+                    withKeyboardNavigation = false
+                    toggleEvent = changes
                 }
-                withKeyboardNavigation = false
-                toggleEvent = changes
-            }
-            value.handler?.invoke(toggleEvent.map { option })
-            active handledBy {
-                if (it && domNode != document.activeElement) {
-                    domNode.focus()
+                value.handler?.invoke(toggleEvent.map { option })
+                active handledBy {
+                    if (it && domNode != document.activeElement) {
+                        domNode.focus()
+                    }
                 }
-            }
-            focuss.map { option } handledBy isActive.update
-            blurs.map { null } handledBy isActive.update
-        }.also { toggle = it }
+                focuss.map { option } handledBy isActive.update
+                blurs.map { null } handledBy isActive.update
+            }.also { toggle = it }
+        }
 
         /**
          * Factory function to create a [radioGroupOptionToggle] with a [HTMLDivElement] as default [Tag].
@@ -196,7 +203,10 @@ class RadioGroup<C : HTMLElement, T>(tag: Tag<C>, private val explicitId: String
             scope: (ScopeContext.() -> Unit) = {},
             tag: TagFactory<Tag<CL>>,
             content: Tag<CL>.() -> Unit
-        ) = tag(this, classes, "$optionId-label", scope, content).also { label = it }
+        ): Tag<CL> {
+            addComponentDebugInfo("radioGroupOptionLabel", this@radioGroupOptionLabel.scope, this)
+            return tag(this, classes, "$optionId-label", scope, content).also { label = it }
+        }
 
         /**
          * Factory function to create a [radioGroupOptionLabel] with a [HTMLLabelElement] as default [Tag].
@@ -224,13 +234,16 @@ class RadioGroup<C : HTMLElement, T>(tag: Tag<C>, private val explicitId: String
             scope: (ScopeContext.() -> Unit) = {},
             tag: TagFactory<Tag<CL>>,
             content: Tag<CL>.() -> Unit
-        ) = tag(
-            this,
-            classes,
-            "$optionId-description-${descriptions.size}",
-            scope,
-            content
-        ).also { descriptions.add(it) }
+        ): Tag<CL> {
+            addComponentDebugInfo("radioGroupOptionDescription", this@radioGroupOptionDescription.scope, this)
+            return tag(
+                this,
+                classes,
+                "$optionId-description-${descriptions.size}",
+                scope,
+                content
+            ).also { descriptions.add(it) }
+        }
 
         /**
          * Factory function to create a [radioGroupOptionDescription] with a [HTMLSpanElement] as default [Tag].
@@ -262,8 +275,10 @@ class RadioGroup<C : HTMLElement, T>(tag: Tag<C>, private val explicitId: String
         scope: (ScopeContext.() -> Unit) = {},
         tag: TagFactory<Tag<CO>>,
         initialize: RadioGroupOption<CO>.() -> Unit
-    ): Tag<CO> = "$componentId-${id ?: Id.next()}".let { optionId ->
-        tag(this, classes, optionId, scope) {
+    ): Tag<CO> {
+        addComponentDebugInfo("radioGroupOption", this@radioGroupOption.scope, this)
+        val optionId = "$componentId-${id ?: Id.next()}"
+        return tag(this, classes, optionId, scope) {
             RadioGroupOption(this, option, optionId).run {
                 initialize()
                 render()
@@ -319,10 +334,13 @@ fun <C : HTMLElement, T> RenderContext.radioGroup(
     scope: (ScopeContext.() -> Unit) = {},
     tag: TagFactory<Tag<C>>,
     initialize: RadioGroup<C, T>.() -> Unit
-): Tag<C> = tag(this, classes, id, scope) {
-    RadioGroup<C, T>(this, id).run {
-        initialize()
-        render()
+): Tag<C> {
+    addComponentDebugInfo("radioGroup", this@radioGroup.scope, this)
+    return tag(this, classes, id, scope) {
+        RadioGroup<C, T>(this, id).run {
+            initialize()
+            render()
+        }
     }
 }
 

--- a/headless/src/jsMain/kotlin/dev/fritz2/headless/components/switch.kt
+++ b/headless/src/jsMain/kotlin/dev/fritz2/headless/components/switch.kt
@@ -56,6 +56,7 @@ abstract class AbstractSwitch<C : HTMLElement>(tag: Tag<C>, private val explicit
     ) {
         value.validationMessages.map { it.isNotEmpty() }.distinctUntilChanged().render { isNotEmpty ->
             if(isNotEmpty) {
+                addComponentDebugInfo("switchValidationMessages", this@switchValidationMessages.scope, this)
                 tag(this, classes, "$componentId-${ValidationMessages.ID_SUFFIX}", scope) {
                     validationMessages = this
                     initialize(ValidationMessages(value.validationMessages, this))
@@ -117,10 +118,13 @@ class SwitchWithLabel<C : HTMLElement>(tag: Tag<C>, id: String?) :
         scope: (ScopeContext.() -> Unit) = {},
         tag: TagFactory<Tag<CT>>,
         content: Tag<CT>.() -> Unit
-    ) = tag(this, classes, "$componentId-toggle", scope) {
-        content()
-        renderSwitchCore(this)
-    }.also { toggle = it }
+    ) : Tag<CT> {
+        addComponentDebugInfo("switchToggle", this@switchToggle.scope, this)
+        return tag(this, classes, "$componentId-toggle", scope) {
+            content()
+            renderSwitchCore(this)
+        }.also { toggle = it }
+    }
 
     /**
      * Factory function to create a [switchToggle] with a [HTMLButtonElement] as default [Tag].
@@ -147,9 +151,12 @@ class SwitchWithLabel<C : HTMLElement>(tag: Tag<C>, id: String?) :
         scope: (ScopeContext.() -> Unit) = {},
         tag: TagFactory<Tag<CL>>,
         content: Tag<CL>.() -> Unit
-    ) = tag(this, classes, "$componentId-label", scope, content).apply {
-        value.handler?.invoke(value.data.flatMapLatest { state -> clicks.map { !state } })
-    }.also { label = it }
+    ) : Tag<CL> {
+        addComponentDebugInfo("switchLabel", this@switchLabel.scope, this)
+        return tag(this, classes, "$componentId-label", scope, content).apply {
+            value.handler?.invoke(value.data.flatMapLatest { state -> clicks.map { !state } })
+        }.also { label = it }
+    }
 
     /**
      * Factory function to create a [switchLabel] with a [HTMLLabelElement] as default [Tag].
@@ -177,13 +184,16 @@ class SwitchWithLabel<C : HTMLElement>(tag: Tag<C>, id: String?) :
         scope: (ScopeContext.() -> Unit) = {},
         tag: TagFactory<Tag<CL>>,
         content: Tag<CL>.() -> Unit
-    ) = tag(
-        this,
-        classes,
-        "$componentId-description-${descriptions.size}",
-        scope,
-        content
-    ).also { descriptions.add(it) }
+    ) : Tag<CL> {
+        addComponentDebugInfo("switchDescription", this@switchDescription.scope, this)
+        return tag(
+            this,
+            classes,
+            "$componentId-description-${descriptions.size}",
+            scope,
+            content
+        ).also { descriptions.add(it) }
+    }
 
     /**
      * Factory function to create a [switchDescription] with a [HTMLSpanElement] as default [Tag].
@@ -225,10 +235,13 @@ fun <C : HTMLElement> RenderContext.switchWithLabel(
     scope: (ScopeContext.() -> Unit) = {},
     tag: TagFactory<Tag<C>>,
     initialize: SwitchWithLabel<C>.() -> Unit
-): Tag<C> = tag(this, classes, id, scope) {
-    SwitchWithLabel(this, id).run {
-        initialize()
-        render()
+): Tag<C> {
+    addComponentDebugInfo("switchWithLabel", this@switchWithLabel.scope, this)
+    return tag(this, classes, id, scope) {
+        SwitchWithLabel(this, id).run {
+            initialize()
+            render()
+        }
     }
 }
 
@@ -305,10 +318,13 @@ fun <C : HTMLElement> RenderContext.switch(
     scope: (ScopeContext.() -> Unit) = {},
     tag: TagFactory<Tag<C>>,
     initialize: Switch<C>.() -> Unit
-): Tag<C> = tag(this, classes, id, scope) {
-    Switch(this, id).run {
-        initialize()
-        render()
+): Tag<C> {
+    addComponentDebugInfo("switch", this@switch.scope, this)
+    return tag(this, classes, id, scope) {
+        Switch(this, id).run {
+            initialize()
+            render()
+        }
     }
 }
 

--- a/headless/src/jsMain/kotlin/dev/fritz2/headless/components/tabGroup.kt
+++ b/headless/src/jsMain/kotlin/dev/fritz2/headless/components/tabGroup.kt
@@ -176,11 +176,14 @@ class TabGroup<C : HTMLElement>(tag: Tag<C>, id: String?) : Tag<C> by tag {
             scope: (ScopeContext.() -> Unit) = {},
             tag: TagFactory<Tag<CT>>,
             initialize: Tab<CT>.() -> Unit
-        ) = tag(this, classes, tabId(nextIndex), scope) {
-            disabledTabs.addTab()
-            Tab(this, nextIndex++).run {
-                initialize()
-                render()
+        ): Tag<CT> {
+            addComponentDebugInfo("tab", this@tab.scope, this)
+            return tag(this, classes, tabId(nextIndex), scope) {
+                disabledTabs.addTab()
+                Tab(this, nextIndex++).run {
+                    initialize()
+                    render()
+                }
             }
         }
 
@@ -208,10 +211,13 @@ class TabGroup<C : HTMLElement>(tag: Tag<C>, id: String?) : Tag<C> by tag {
         scope: (ScopeContext.() -> Unit) = {},
         tag: TagFactory<Tag<CL>>,
         initialize: TabList<CL>.() -> Unit
-    ): Tag<CL> = tag(this, classes, "$componentId-tab-list", scope) {
-        TabList(this).run {
-            initialize()
-            render()
+    ): Tag<CL> {
+        addComponentDebugInfo("tabList", this@tabList.scope, this)
+        return tag(this, classes, "$componentId-tab-list", scope) {
+            TabList(this).run {
+                initialize()
+                render()
+            }
         }
     }
 
@@ -260,6 +266,7 @@ class TabGroup<C : HTMLElement>(tag: Tag<C>, id: String?) : Tag<C> by tag {
             val currentIndex = nextIndex
             panels.add {
                 tag(this, classes, panelId(currentIndex), scope) {
+                    addComponentDebugInfo("parent is panel", this@add.scope, this)
                     content()
                     attr("tabindex", "0")
                     attr("role", Aria.Role.tabpanel)
@@ -293,10 +300,13 @@ class TabGroup<C : HTMLElement>(tag: Tag<C>, id: String?) : Tag<C> by tag {
         scope: (ScopeContext.() -> Unit) = {},
         tag: TagFactory<Tag<CP>>,
         initialize: TabPanels<CP>.() -> Unit
-    ): Tag<CP> = tag(this, classes, "$componentId-tab-panels", scope) {
-        TabPanels(this).run {
-            initialize()
-            render()
+    ): Tag<CP> {
+        addComponentDebugInfo("tabPanels", this@tabPanels.scope, this)
+        return tag(this, classes, "$componentId-tab-panels", scope) {
+            TabPanels(this).run {
+                initialize()
+                render()
+            }
         }
     }
 
@@ -349,10 +359,13 @@ fun <C : HTMLElement> RenderContext.tabGroup(
     scope: (ScopeContext.() -> Unit) = {},
     tag: TagFactory<Tag<C>>,
     initialize: TabGroup<C>.() -> Unit
-): Tag<C> = tag(this, classes, id, scope) {
-    TabGroup(this, id).run {
-        initialize()
-        render()
+): Tag<C> {
+    addComponentDebugInfo("tabGroup", this@tabGroup.scope, this)
+    return tag(this, classes, id, scope) {
+        TabGroup(this, id).run {
+            initialize()
+            render()
+        }
     }
 }
 

--- a/headless/src/jsMain/kotlin/dev/fritz2/headless/components/textfields.kt
+++ b/headless/src/jsMain/kotlin/dev/fritz2/headless/components/textfields.kt
@@ -50,7 +50,10 @@ abstract class Textfield<C : HTMLElement, CT : Tag<HTMLElement>>(tag: Tag<C>, id
         scope: (ScopeContext.() -> Unit) = {},
         tag: TagFactory<Tag<CL>>,
         content: Tag<CL>.() -> Unit
-    ) = tag(this, classes, "$componentId-label", scope, content).also { label = it }
+    ): Tag<CL> {
+        addComponentDebugInfo("textfieldLabel", this@textfieldLabel.scope, this)
+        return tag(this, classes, "$componentId-label", scope, content).also { label = it }
+    }
 
     protected fun RenderContext.textfieldLabel(
         classes: String? = null,
@@ -65,13 +68,16 @@ abstract class Textfield<C : HTMLElement, CT : Tag<HTMLElement>>(tag: Tag<C>, id
         scope: (ScopeContext.() -> Unit) = {},
         tag: TagFactory<Tag<CD>>,
         content: Tag<CD>.() -> Unit
-    ) = tag(
-        this,
-        classes,
-        "$componentId-description-${descriptions.size}",
-        scope,
-        content
-    ).also { descriptions.add(it) }
+    ): Tag<CD> {
+        addComponentDebugInfo("textfieldDescription", this@textfieldDescription.scope, this)
+        return tag(
+            this,
+            classes,
+            "$componentId-description-${descriptions.size}",
+            scope,
+            content
+        ).also { descriptions.add(it) }
+    }
 
     protected fun RenderContext.textfieldDescription(
         classes: String? = null,
@@ -86,7 +92,8 @@ abstract class Textfield<C : HTMLElement, CT : Tag<HTMLElement>>(tag: Tag<C>, id
         initialize: ValidationMessages<CV>.() -> Unit
     ) {
         value.validationMessages.map { it.isNotEmpty() }.distinctUntilChanged().render { isNotEmpty ->
-            if(isNotEmpty) {
+            if (isNotEmpty) {
+                addComponentDebugInfo("textfieldValidationMessages", this@textfieldValidationMessages.scope, this)
                 tag(this, classes, "$componentId-${ValidationMessages.ID_SUFFIX}", scope) {
                     validationMessages = this
                     initialize(ValidationMessages(value.validationMessages, this))
@@ -125,12 +132,15 @@ class InputField<C : HTMLElement>(tag: Tag<C>, id: String?) :
         classes: String? = null,
         scope: (ScopeContext.() -> Unit) = {},
         content: HtmlTag<HTMLInputElement>.() -> Unit
-    ) = input(classes, id = fieldId, scope = scope, content).apply {
-        attr(Aria.invalid, "true".whenever(value.hasError))
-        value.handler?.invoke(changes.values())
-        value(value.data)
-        hook(placeholder, type, disabled)
-    }.also { field = it }
+    ): Tag<HTMLInputElement> {
+        addComponentDebugInfo("inputTextfield", this@inputTextfield.scope, this)
+        return input(classes, id = fieldId, scope = scope, content).apply {
+            attr(Aria.invalid, "true".whenever(value.hasError))
+            value.handler?.invoke(changes.values())
+            value(value.data)
+            hook(placeholder, type, disabled)
+        }.also { field = it }
+    }
 
     /**
      * Factory function to create a [inputLabel].
@@ -235,10 +245,13 @@ fun <C : HTMLElement> RenderContext.inputField(
     scope: (ScopeContext.() -> Unit) = {},
     tag: TagFactory<Tag<C>>,
     initialize: InputField<C>.() -> Unit
-): Tag<C> = tag(this, classes, id, scope) {
-    InputField(this, id).run {
-        initialize()
-        render()
+): Tag<C> {
+    addComponentDebugInfo("inputField", this@inputField.scope, this)
+    return tag(this, classes, id, scope) {
+        InputField(this, id).run {
+            initialize()
+            render()
+        }
     }
 }
 
@@ -290,12 +303,15 @@ class TextArea<C : HTMLElement>(tag: Tag<C>, id: String?) :
         classes: String? = null,
         scope: (ScopeContext.() -> Unit) = {},
         content: HtmlTag<HTMLTextAreaElement>.() -> Unit
-    ) = textarea(classes, id = fieldId, scope = scope, content).apply {
-        attr(Aria.invalid, "true".whenever(value.hasError))
-        value.handler?.invoke(changes.values())
-        value(value.data)
-        hook(placeholder, disabled)
-    }.also { field = it }
+    ): Tag<HTMLTextAreaElement> {
+        addComponentDebugInfo("textareaTextfield", this@textareaTextfield.scope, this)
+        return textarea(classes, id = fieldId, scope = scope, content).apply {
+            attr(Aria.invalid, "true".whenever(value.hasError))
+            value.handler?.invoke(changes.values())
+            value(value.data)
+            hook(placeholder, disabled)
+        }.also { field = it }
+    }
 
     /**
      * Factory function to create a [textareaLabel].
@@ -400,10 +416,13 @@ fun <C : HTMLElement> RenderContext.textArea(
     scope: (ScopeContext.() -> Unit) = {},
     tag: TagFactory<Tag<C>>,
     initialize: TextArea<C>.() -> Unit
-): Tag<C> = tag(this, classes, id, scope) {
-    TextArea(this, id).run {
-        initialize()
-        render()
+): Tag<C> {
+    addComponentDebugInfo("textArea", this@textArea.scope, this)
+    return tag(this, classes, id, scope) {
+        TextArea(this, id).run {
+            initialize()
+            render()
+        }
     }
 }
 

--- a/headless/src/jsMain/kotlin/dev/fritz2/headless/components/tooltip.kt
+++ b/headless/src/jsMain/kotlin/dev/fritz2/headless/components/tooltip.kt
@@ -43,7 +43,9 @@ fun <C : HTMLElement> Tag<HTMLElement>.tooltip(
     tag: TagFactory<Tag<C>>,
     initialize: Tooltip<C>.() -> Unit
 ) {
-    return Tooltip(this, tag, classes, id, scope).run {
+    return Tooltip(this, tag, classes, id, scope).apply {
+        addComponentDebugInfo("parent is tooltip", this@tooltip.scope, this)
+    }.run {
         initialize()
         render()
         attr("role", Aria.Role.tooltip)

--- a/headless/src/jsMain/kotlin/dev/fritz2/headless/foundation/foundation.kt
+++ b/headless/src/jsMain/kotlin/dev/fritz2/headless/foundation/foundation.kt
@@ -1,7 +1,9 @@
 package dev.fritz2.headless.foundation
 
 import dev.fritz2.core.RenderContext
+import dev.fritz2.core.Scope
 import dev.fritz2.core.ScopeContext
+import dev.fritz2.core.Tag
 
 /**
  * Alias in order to reduce boilerplate code for the awkward signature of a [Tag]-factory of [RenderContext].
@@ -56,3 +58,8 @@ enum class Direction(val value: Int) {
 enum class Orientation {
     Horizontal, Vertical
 }
+
+val HEADLESS_DEBUG = Scope.keyOf<Boolean>("fritz2HeadlessDebug")
+
+fun addComponentDebugInfo(comment: String, scope: Scope, context: RenderContext) =
+    scope[HEADLESS_DEBUG]?.let { if (it) with(context as Tag<*>) { !comment } }


### PR DESCRIPTION
In order to improve the usage of headless components all components and its bricks will render out HTML comments that name their corresponding component or brick name. This way the matching between the Kotlin names and its HTML equivalents is much easier.

Most hint comments are located as direct predecessor of the created HTML element. For all bricks that are based upon some `Flow` this is not possible due to their managed nature. In those cases the comment appears as first sub-node within the created element and its text startes with "parent is xyz" to clarify its relationship. 

In order to activate those helpful "debugging" information, one must put the `HEADLESS_DEBUG` key into the scope with a `true` value.

fixes #626