### PR TITLE
Improve textfield API

### DIFF
--- a/headless-demo/src/jsMain/kotlin/dev/fritz2/headlessdemo/inputField.kt
+++ b/headless-demo/src/jsMain/kotlin/dev/fritz2/headlessdemo/inputField.kt
@@ -2,6 +2,7 @@ package dev.fritz2.headlessdemo
 
 import dev.fritz2.core.RenderContext
 import dev.fritz2.core.classes
+import dev.fritz2.core.placeholder
 import dev.fritz2.core.storeOf
 import dev.fritz2.headless.components.inputField
 import kotlinx.coroutines.flow.map
@@ -14,7 +15,6 @@ fun RenderContext.inputFieldDemo() {
 
         inputField("mb-8") {
             value(name)
-            placeholder("The name is...")
             inputLabel("block mb-1.5 ml-1 text-sm font-medium text-primary-800") {
                 +"Enter the framework's name"
             }
@@ -39,6 +39,7 @@ fun RenderContext.inputFieldDemo() {
                                 | focus:outline-none focus:ring-4 focus:ring-primary-600 focus:border-primary-800""".trimMargin()
                         )
                     })
+                    placeholder("The name is...")
                 }
             }
             inputDescription("ml-1 mt-2 text-xs text-primary-700") {

--- a/headless-demo/src/jsMain/kotlin/dev/fritz2/headlessdemo/textArea.kt
+++ b/headless-demo/src/jsMain/kotlin/dev/fritz2/headlessdemo/textArea.kt
@@ -2,6 +2,7 @@ package dev.fritz2.headlessdemo
 
 import dev.fritz2.core.RenderContext
 import dev.fritz2.core.classes
+import dev.fritz2.core.placeholder
 import dev.fritz2.core.storeOf
 import dev.fritz2.headless.components.textArea
 import kotlinx.coroutines.flow.map
@@ -13,7 +14,6 @@ fun RenderContext.textAreaDemo() {
     div("max-w-sm") {
         textArea {
             value(description)
-            placeholder("fritz2 is super cool")
             textareaLabel(
                 """block mb-1.5 ml-1
                 | text-sm font-medium text-primary-800""".trimMargin()
@@ -41,6 +41,7 @@ fun RenderContext.textAreaDemo() {
                                 | focus:outline-none focus:ring-4 focus:ring-primary-600 focus:border-primary-800""".trimMargin()
                         )
                     })
+                    placeholder("fritz2 is super cool")
                 }
             }
             textareaDescription("block ml-1 text-xs text-primary-700") {

--- a/headless/src/jsMain/kotlin/dev/fritz2/headless/components/textfields.kt
+++ b/headless/src/jsMain/kotlin/dev/fritz2/headless/components/textfields.kt
@@ -20,8 +20,6 @@ import org.w3c.dom.*
 abstract class Textfield<C : HTMLElement, CT : Tag<HTMLElement>>(tag: Tag<C>, id: String?) : Tag<C> by tag {
 
     val value = DatabindingProperty<String>()
-    abstract val placeholder: AttributeHook<CT, String>
-    abstract val disabled: BooleanAttributeHook<CT>
 
     val componentId: String by lazy { id ?: value.id ?: Id.next() }
     protected val fieldId by lazy { "$componentId-field" }
@@ -120,12 +118,6 @@ abstract class Textfield<C : HTMLElement, CT : Tag<HTMLElement>>(tag: Tag<C>, id
 class InputField<C : HTMLElement>(tag: Tag<C>, id: String?) :
     Textfield<C, HtmlTag<HTMLInputElement>>(tag, id) {
 
-    override val placeholder =
-        AttributeHook(HtmlTag<HTMLInputElement>::placeholder, HtmlTag<HTMLInputElement>::placeholder)
-    override val disabled = BooleanAttributeHook(
-        HtmlTag<HTMLInputElement>::disabled,
-        HtmlTag<HTMLInputElement>::disabled
-    )
     val type = AttributeHook(HtmlTag<HTMLInputElement>::type, HtmlTag<HTMLInputElement>::type).apply { this("text") }
 
     fun RenderContext.inputTextfield(
@@ -138,7 +130,7 @@ class InputField<C : HTMLElement>(tag: Tag<C>, id: String?) :
             attr(Aria.invalid, "true".whenever(value.hasError))
             value.handler?.invoke(changes.values())
             value(value.data)
-            hook(placeholder, type, disabled)
+            hook(type)
         }.also { field = it }
     }
 
@@ -294,11 +286,6 @@ fun RenderContext.inputField(
 class TextArea<C : HTMLElement>(tag: Tag<C>, id: String?) :
     Textfield<C, HtmlTag<HTMLTextAreaElement>>(tag, id) {
 
-    override val placeholder =
-        AttributeHook(HtmlTag<HTMLTextAreaElement>::placeholder, HtmlTag<HTMLTextAreaElement>::placeholder)
-    override val disabled =
-        BooleanAttributeHook(HtmlTag<HTMLTextAreaElement>::disabled, HtmlTag<HTMLTextAreaElement>::disabled)
-
     fun RenderContext.textareaTextfield(
         classes: String? = null,
         scope: (ScopeContext.() -> Unit) = {},
@@ -309,7 +296,6 @@ class TextArea<C : HTMLElement>(tag: Tag<C>, id: String?) :
             attr(Aria.invalid, "true".whenever(value.hasError))
             value.handler?.invoke(changes.values())
             value(value.data)
-            hook(placeholder, disabled)
         }.also { field = it }
     }
 

--- a/www/src/pages/headless/inputField.md
+++ b/www/src/pages/headless/inputField.md
@@ -1,16 +1,7 @@
 ---
-title: InputField
-description: "An InputField offers a single line of text input."
-layout: layouts/docs.njk
-permalink: /headless/inputfield/
-eleventyNavigation:
-    key: inputfield
-    title: InputField
-    parent: headless
-    order: 30
-teaser: true
-demoHash: inputfield
-demoHeight: 14rem
+title: InputField description: "An InputField offers a single line of text input."
+layout: layouts/docs.njk permalink: /headless/inputfield/ eleventyNavigation:
+key: inputfield title: InputField parent: headless order: 30 teaser: true demoHash: inputfield demoHeight: 14rem
 ---
 
 ## Basic Example
@@ -18,7 +9,7 @@ demoHeight: 14rem
 An InputField is created with the `inputField` component factory function. Within its scope a `string` based data
 binding named `value` has to be initialized.
 
-Optionally, a placeholder text can be set using the `placeholder` attribute hook.
+Optionally, the type can be set using the `type` attribute hook; the default value is ``text``.
 
 Furthermore, the actual input element must be created using `inputTextfield`.
 
@@ -27,8 +18,10 @@ val name = storeOf("")
 
 inputField {
     value(name)
-    placeholder("The name is...")
-    inputTextfield { }
+    type("text")
+    inputTextfield {
+        placeholder("The name is...")
+    }
 }
 ```
 
@@ -45,37 +38,15 @@ val name = storeOf("")
 
 inputField {
     value(name)
-    placeholder("The name is...")
     inputLabel {
         +"Enter the framework's name"
     }
-    inputTextfield { }
+    inputTextfield {
+        placeholder("The name is...")
+    }
     inputDescription {
         +"The name should reflect the concept of the whole framework."
     }
-}
-```
-
-## Deactivate
-
-The InputField component supports the (dynamic) deactivation and activation of the input field. To do this, the boolean
-Attribute hook `disabled` must be set accordingly.
-
-```kotlin
-val toggle = storeOf(false) 
-
-button {
-    +"Enable / Disable"
-    clicks.map{ !toggle.current } handledBy toggle.update
-}
-
-inputField {
-    value(name)
-    
-    // values on the `FLow` will disable or enable the input field
-    disabled(toggle.data)
-    
-    inputTextfield { }
 }
 ```
 
@@ -89,7 +60,7 @@ its scope as a data stream `msgs`.
 inputField {
     value(name)
     inputTextfield { }
-    
+
     inputValidationMessages(tag = RenderContext::ul) {
         msgs.renderEach { li { +it.message } }
     }
@@ -109,23 +80,22 @@ focused.
 |----------------------------------------------------------------------|---------------------|
 | Any key that will trigger a `change` event like [[Tab]] or [[Enter]] | updates the `value` |
 
-For more details which key will trigger a change, refer to this 
+For more details which key will trigger a change, refer to this
 [documentation](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/change_event)
 
 ## API
 
 ### Summary / Sketch
+
 ```kotlin
 inputField() {
     val value: DatabindingProperty<String>
-    val placeHolder: AttributeHook<String>
-    val disabled: BooleanAttributeHook
+    val type: AttributeHook<String>
 
     inputTextfield() { }
     inputLabel() { }
     inputDescription() { } // use multiple times
-    inputValidationMessages() { 
-        msgs: Flow<List<ComponentValidationMessage>>
+    inputValidationMessages() { msgs: Flow<List<ComponentValidationMessage>>
     }
 }
 ```
@@ -139,9 +109,7 @@ Default-Tag: `div`
 | Scope property | Typ                           | Description                                             |
 |----------------|-------------------------------|---------------------------------------------------------|
 | `value`        | `DatabindingProperty<String>` | Mandatory (two-way) data-binding for the input value.   |
-| `placeHolder`  | `AttributeHook<String>`       | Optional hook to (dynamically) set a placeholder.       |
-| `disabled`     | `BooleanAttributeHook`        | Optional hook to (dynamically) enable or disable input. |
-
+| `type`         | `AttributeHook<String>`       | Optional hook to (dynamically) set the type.            |
 
 ### inputTextfield
 
@@ -151,7 +119,6 @@ Parameters: `classes`, `scope`, `tag`, `initialize`
 
 Tag: `input` (not customizable!)
 
-
 ### inputLabel
 
 Available in the scope of: `inputField`
@@ -160,7 +127,6 @@ Parameters: `classes`, `scope`, `tag`, `initialize`
 
 Default-Tag: `label`
 
-
 ### inputDescription
 
 Available in the scope of: `inputField`
@@ -168,7 +134,6 @@ Available in the scope of: `inputField`
 Parameters: `classes`, `scope`, `tag`, `initialize`
 
 Default-Tag: `p`
-
 
 ### inputValidationMessages
 

--- a/www/src/pages/headless/inputField.md
+++ b/www/src/pages/headless/inputField.md
@@ -1,7 +1,16 @@
 ---
-title: InputField description: "An InputField offers a single line of text input."
-layout: layouts/docs.njk permalink: /headless/inputfield/ eleventyNavigation:
-key: inputfield title: InputField parent: headless order: 30 teaser: true demoHash: inputfield demoHeight: 14rem
+title: InputField
+description: "An InputField offers a single line of text input."
+layout: layouts/docs.njk
+permalink: /headless/inputfield/
+eleventyNavigation:
+    key: inputfield
+    title: InputField
+    parent: headless
+    order: 30
+teaser: true
+demoHash: inputfield
+demoHeight: 14rem
 ---
 
 ## Basic Example

--- a/www/src/pages/headless/modal.md
+++ b/www/src/pages/headless/modal.md
@@ -177,7 +177,7 @@ be some clickable element, which triggers the `close` handler and thus the dialo
 ```kotlin
 modal() {
     var restoreFocus: Boolean
-    var setInitialFocus: Boolean    
+    var setInitialFocus: InitialFocus = InsistToSet // DoNotSet, TryToSet, InsistToSet    
     // inherited by `OpenClose`
     val openState: DatabindingProperty<Boolean>
     val opened: Flow<Boolean>

--- a/www/src/pages/headless/textArea.md
+++ b/www/src/pages/headless/textArea.md
@@ -18,8 +18,6 @@ demoHeight: 14rem
 A TextArea is created with the `textArea` component factory function. Within its scope a `string` based data
 binding named `value` has to be initialized.
 
-Optionally, a placeholder text can be set using the `placeholder` attribute hook.
-
 Furthermore, the actual input element must be created using `textareaTextfield`.
 
 ```kotlin
@@ -27,8 +25,9 @@ val name = storeOf("")
 
 textArea {
     value(name)
-    placeholder("The name is...")
-    textareaTextfield { }
+    textareaTextfield {
+        placeholder("The name is...")
+    }
 }
 ```
 
@@ -53,29 +52,6 @@ textArea {
     textareaDescription {
         +"The name should reflect the concept of the whole framework."
     }
-}
-```
-
-## Deactivate
-
-The TextArea component supports the (dynamic) deactivation and activation of the text field. To do this, the boolean
-Attribute hook `disabled` must be set accordingly.
-
-```kotlin
-val toggle = storeOf(false) 
-
-button {
-    +"Enable / Disable"
-    clicks.map{ !toggle.current } handledBy toggle.update
-}
-
-textArea {
-    value(name)
-    
-    // values on the `FLow` will disable or enable the textarea field
-    disabled(toggle.data)
-    
-    textareaTextfield { }
 }
 ```
 
@@ -119,8 +95,6 @@ For more details which key will trigger a change, refer to this
 ```kotlin
 textArea() {
     val value: DatabindingProperty<String>
-    val placeHolder: AttributeHook<String>
-    val disabled: BooleanAttributeHook
 
     textareaTextfield() { }
     textareaLabel() { }
@@ -140,8 +114,6 @@ Default-Tag: `div`
 | Scope property | Typ                           | Description                                             |
 |----------------|-------------------------------|---------------------------------------------------------|
 | `value`        | `DatabindingProperty<String>` | Mandatory (two-way) data-binding for the input value.   |
-| `placeHolder`  | `AttributeHook<String>`       | Optional hook to (dynamically) set a placeholder.       |
-| `disabled`     | `BooleanAttributeHook`        | Optional hook to (dynamically) enable or disable input. |
 
 ### textareaTextfield
 


### PR DESCRIPTION
- removes ``disabled`` and ``placeholder`` properties; both aspects needs to be handled from the outside anyway (in order to react to state changes for example). There is no benefit to expose those two from the headless level.
- correct small typing aspect within modal documentation

fixes #619 