### PR TITLE
Improve Headless Input API

### DIFF
--- a/headless-demo/README.playwright.md
+++ b/headless-demo/README.playwright.md
@@ -8,6 +8,16 @@ To run the tests just type:
 npx playwright test    
 ```
 
+*BEWARE*: If there are local changes to test, remember to configure the ``baseURL`` appropriately in the 
+``playwright.config.ts``, like in the following example:
+```typescript
+    /* Base URL to use in actions like `await page.goto('/')`. */
+    //baseURL: 'https://next.fritz2.dev/headless-demo/',
+    /* Uncomment this to test local running demos as testing base */
+    baseURL: 'http://localhost:8080/',
+```
+
+
 ## General Design Principles
 
 - Write one test for all platforms! (Headless components are meant to work the same on all platforms after all!)

--- a/headless-demo/src/jsMain/kotlin/dev/fritz2/headlessdemo/inputField.kt
+++ b/headless-demo/src/jsMain/kotlin/dev/fritz2/headlessdemo/inputField.kt
@@ -1,9 +1,6 @@
 package dev.fritz2.headlessdemo
 
-import dev.fritz2.core.RenderContext
-import dev.fritz2.core.classes
-import dev.fritz2.core.placeholder
-import dev.fritz2.core.storeOf
+import dev.fritz2.core.*
 import dev.fritz2.headless.components.inputField
 import kotlinx.coroutines.flow.map
 
@@ -40,6 +37,7 @@ fun RenderContext.inputFieldDemo() {
                         )
                     })
                     placeholder("The name is...")
+                    type("text")
                 }
             }
             inputDescription("ml-1 mt-2 text-xs text-primary-700") {

--- a/headless-demo/tests/checkbox.spec.ts
+++ b/headless-demo/tests/checkbox.spec.ts
@@ -17,7 +17,7 @@ test.describe('Checking', () => {
 
     for (const num of ["1", "2", "3"]) {
 
-        test(`unique result for checkbox ${num} and verify in result when selected throug click`, async ({page}) =>{
+        test(`unique result for checkbox ${num} and verify in result when selected through click`, async ({page}) =>{
             /* locator for each checkbox label (tag: checkboxGroupLabel) */
             const label = await page.locator(`#checkboxGroup-${num}-label`).textContent(); 
             /* locator for each checkbox toggle (tag: checkboxGroupOptionToggle) */

--- a/headless/src/jsMain/kotlin/dev/fritz2/headless/components/checkboxGroup.kt
+++ b/headless/src/jsMain/kotlin/dev/fritz2/headless/components/checkboxGroup.kt
@@ -195,7 +195,7 @@ class CheckboxGroup<C : HTMLElement, T>(tag: Tag<C>, private val explicitId: Str
             content: Tag<CL>.() -> Unit
         ): Tag<CL> {
             addComponentStructureInfo("checkboxGroupOptionLabel", this@checkboxGroupOptionLabel.scope, this)
-            return tag(this, classes, "${optionId}-toggle", scope, content).also { label = it }
+            return tag(this, classes, "${optionId}-label", scope, content).also { label = it }
         }
 
         /**

--- a/headless/src/jsMain/kotlin/dev/fritz2/headless/components/textfields.kt
+++ b/headless/src/jsMain/kotlin/dev/fritz2/headless/components/textfields.kt
@@ -17,7 +17,7 @@ import org.w3c.dom.*
  *      [official documentation](https://www.fritz2.dev/headless/textarea/)
  *
  */
-abstract class Textfield<C : HTMLElement, CT : Tag<HTMLElement>>(tag: Tag<C>, id: String?) : Tag<C> by tag {
+abstract class Textfield<C : HTMLElement>(tag: Tag<C>, id: String?) : Tag<C> by tag {
 
     val value = DatabindingProperty<String>()
 
@@ -120,9 +120,7 @@ abstract class Textfield<C : HTMLElement, CT : Tag<HTMLElement>>(tag: Tag<C>, id
  * For more information refer to the [official documentation](https://www.fritz2.dev/headless/inputfield/)
  */
 class InputField<C : HTMLElement>(tag: Tag<C>, id: String?) :
-    Textfield<C, HtmlTag<HTMLInputElement>>(tag, id) {
-
-    val type = AttributeHook(HtmlTag<HTMLInputElement>::type, HtmlTag<HTMLInputElement>::type).apply { this("text") }
+    Textfield<C>(tag, id) {
 
     fun RenderContext.inputTextfield(
         classes: String? = null,
@@ -134,7 +132,6 @@ class InputField<C : HTMLElement>(tag: Tag<C>, id: String?) :
             attr(Aria.invalid, "true".whenever(value.hasError))
             value.handler?.invoke(changes.values())
             value(value.data)
-            hook(type)
         }.also { field = it }
     }
 
@@ -221,8 +218,6 @@ class InputField<C : HTMLElement>(tag: Tag<C>, id: String?) :
  * ```kotlin
  * inputField() {
  *     val value: DatabindingProperty<String>
- *     val placeHolder: AttributeHook<String>
- *     val disabled: BooleanAttributeHook
  *
  *     inputTextfield() { }
  *     inputLabel() { }
@@ -258,8 +253,6 @@ fun <C : HTMLElement> RenderContext.inputField(
  * ```kotlin
  * inputField() {
  *     val value: DatabindingProperty<String>
- *     val placeHolder: AttributeHook<String>
- *     val disabled: BooleanAttributeHook
  *
  *     inputTextfield() { }
  *     inputLabel() { }
@@ -288,7 +281,7 @@ fun RenderContext.inputField(
  * For more information refer to the [official documentation](https://www.fritz2.dev/headless/textarea/)
  */
 class TextArea<C : HTMLElement>(tag: Tag<C>, id: String?) :
-    Textfield<C, HtmlTag<HTMLTextAreaElement>>(tag, id) {
+    Textfield<C>(tag, id) {
 
     fun RenderContext.textareaTextfield(
         classes: String? = null,
@@ -386,8 +379,6 @@ class TextArea<C : HTMLElement>(tag: Tag<C>, id: String?) :
  * ```kotlin
  * textArea() {
  *     val value: DatabindingProperty<String>
- *     val placeHolder: AttributeHook<String>
- *     val disabled: BooleanAttributeHook
  *
  *     textareaTextfield() { }
  *     textareaLabel() { }
@@ -423,8 +414,6 @@ fun <C : HTMLElement> RenderContext.textArea(
  * ```kotlin
  * textArea() {
  *     val value: DatabindingProperty<String>
- *     val placeHolder: AttributeHook<String>
- *     val disabled: BooleanAttributeHook
  *
  *     textareaTextfield() { }
  *     textareaLabel() { }

--- a/www/src/pages/headless/inputField.md
+++ b/www/src/pages/headless/inputField.md
@@ -18,8 +18,6 @@ demoHeight: 14rem
 An InputField is created with the `inputField` component factory function. Within its scope a `string` based data
 binding named `value` has to be initialized.
 
-Optionally, the type can be set using the `type` attribute hook; the default value is ``text``.
-
 Furthermore, the actual input element must be created using `inputTextfield`.
 
 ```kotlin
@@ -27,8 +25,9 @@ val name = storeOf("")
 
 inputField {
     value(name)
-    type("text")
     inputTextfield {
+        // set common ``<input>`` tag attributes
+        type("text")
         placeholder("The name is...")
     }
 }
@@ -99,7 +98,6 @@ For more details which key will trigger a change, refer to this
 ```kotlin
 inputField() {
     val value: DatabindingProperty<String>
-    val type: AttributeHook<String>
 
     inputTextfield() { }
     inputLabel() { }
@@ -118,7 +116,6 @@ Default-Tag: `div`
 | Scope property | Typ                           | Description                                             |
 |----------------|-------------------------------|---------------------------------------------------------|
 | `value`        | `DatabindingProperty<String>` | Mandatory (two-way) data-binding for the input value.   |
-| `type`         | `AttributeHook<String>`       | Optional hook to (dynamically) set the type.            |
 
 ### inputTextfield
 


### PR DESCRIPTION
## Main fixes

The ``type`` is no longer a (poorly) encapsulated attribute offered by ``inputField``. This makes the internal code much simpler and would theoretically allow to choose the tag for ``inputTextfiled`` in the future.

fixes #678

## Additional fixes

- correct small ID setting mistake in checkboxGroup component
- add some useful remark in the playwright readme for local testing.