### PR TITLE
Add default data-binding as fallback for headless components

### DIFF
--- a/headless/src/jsMain/kotlin/dev/fritz2/headless/components/checkboxGroup.kt
+++ b/headless/src/jsMain/kotlin/dev/fritz2/headless/components/checkboxGroup.kt
@@ -19,12 +19,23 @@ import org.w3c.dom.*
 class CheckboxGroup<C : HTMLElement, T>(tag: Tag<C>, private val explicitId: String?) :
     Tag<C> by tag {
 
+    companion object {
+        const val COMPONENT_NAME = "checkboxGroup"
+    }
+
     private var label: Tag<HTMLElement>? = null
     private var validationMessages: Tag<HTMLElement>? = null
 
     val value = DatabindingProperty<List<T>>()
 
-    val componentId: String by lazy { explicitId ?: value.id ?: Id.next() }
+    val componentId: String by lazy {
+        explicitId ?: value.id ?: Id.next().also {
+            if (value.value == null) {
+                value(storeOf(emptyList()))
+                warnAboutMissingDatabinding("value", COMPONENT_NAME, it, "a flow of empty list")
+            }
+        }
+    }
 
     fun render() {
         attr("id", componentId)
@@ -320,7 +331,7 @@ fun <C : HTMLElement, T> RenderContext.checkboxGroup(
     tag: TagFactory<Tag<C>>,
     initialize: CheckboxGroup<C, T>.() -> Unit
 ): Tag<C> {
-    addComponentStructureInfo("checkboxGroup", this@checkboxGroup.scope, this)
+    addComponentStructureInfo(CheckboxGroup.COMPONENT_NAME, this@checkboxGroup.scope, this)
     return tag(this, classes, id, scope) {
         CheckboxGroup<C, T>(this, id).run {
             initialize()

--- a/headless/src/jsMain/kotlin/dev/fritz2/headless/components/listbox.kt
+++ b/headless/src/jsMain/kotlin/dev/fritz2/headless/components/listbox.kt
@@ -22,8 +22,19 @@ import kotlin.math.max
 @Suppress("EXPERIMENTAL_IS_NOT_ENABLED")
 class Listbox<T, C : HTMLElement>(tag: Tag<C>, id: String?) : Tag<C> by tag, OpenClose() {
 
+    companion object {
+        const val COMPONENT_NAME = "listbox"
+    }
+
     val value = DatabindingProperty<T>()
-    val componentId: String by lazy { id ?: value.id ?: Id.next() }
+    val componentId: String by lazy {
+        id ?: value.id ?: Id.next().also {
+            if (value.value == null) {
+                value(data = emptyFlow())
+                warnAboutMissingDatabinding("value", COMPONENT_NAME, it, "an empty flow")
+            }
+        }
+    }
 
     private var button: Tag<HTMLElement>? = null
 
@@ -413,7 +424,7 @@ fun <T, C : HTMLElement> RenderContext.listbox(
     tag: TagFactory<Tag<C>>,
     initialize: Listbox<T, C>.() -> Unit
 ): Tag<C> {
-    addComponentStructureInfo("listbox", this@listbox.scope, this)
+    addComponentStructureInfo(Listbox.COMPONENT_NAME, this@listbox.scope, this)
     return tag(this, classes(classes, "relative"), id, scope) {
         Listbox<T, C>(this, id).run {
             initialize(this)

--- a/headless/src/jsMain/kotlin/dev/fritz2/headless/components/switch.kt
+++ b/headless/src/jsMain/kotlin/dev/fritz2/headless/components/switch.kt
@@ -14,11 +14,21 @@ import org.w3c.dom.*
  *
  * For more information refer to the [official documentation](https://www.fritz2.dev/headless/switch/)
  */
-abstract class AbstractSwitch<C : HTMLElement>(tag: Tag<C>, private val explicitId: String?) :
+abstract class AbstractSwitch<C : HTMLElement>(
+    tag: Tag<C>,
+    private val explicitId: String?,
+    private val componentName: String
+) :
     Tag<C> by tag {
 
     val value = DatabindingProperty<Boolean>()
-    val enabled: Flow<Boolean> by lazy { value.data }
+    val enabled: Flow<Boolean> by lazy {
+        if (value.value == null) {
+            value(storeOf(false))
+            warnAboutMissingDatabinding("value", componentName, componentId, "a boolean store")
+        }
+        value.data
+    }
 
     val componentId: String by lazy { explicitId ?: value.id ?: Id.next() }
 
@@ -91,7 +101,11 @@ abstract class AbstractSwitch<C : HTMLElement>(tag: Tag<C>, private val explicit
  * For more information refer to the [official documentation](https://www.fritz2.dev/headless/switch/)
  */
 class SwitchWithLabel<C : HTMLElement>(tag: Tag<C>, id: String?) :
-    AbstractSwitch<C>(tag, id) {
+    AbstractSwitch<C>(tag, id, COMPONENT_NAME) {
+
+    companion object {
+        const val COMPONENT_NAME = "switchWithLabel"
+    }
 
     private var toggle: Tag<HTMLElement>? = null
     private var label: Tag<HTMLElement>? = null
@@ -242,7 +256,7 @@ fun <C : HTMLElement> RenderContext.switchWithLabel(
     tag: TagFactory<Tag<C>>,
     initialize: SwitchWithLabel<C>.() -> Unit
 ): Tag<C> {
-    addComponentStructureInfo("switchWithLabel", this@switchWithLabel.scope, this)
+    addComponentStructureInfo(SwitchWithLabel.COMPONENT_NAME, this@switchWithLabel.scope, this)
     return tag(this, classes, id, scope) {
         SwitchWithLabel(this, id).run {
             initialize()
@@ -287,7 +301,11 @@ fun RenderContext.switchWithLabel(
  * For more information refer to the [official documentation](https://www.fritz2.dev/headless/switch/)
  */
 class Switch<C : HTMLElement>(tag: Tag<C>, explicitId: String?) :
-    AbstractSwitch<C>(tag, explicitId) {
+    AbstractSwitch<C>(tag, explicitId, COMPONENT_NAME) {
+
+    companion object {
+        const val COMPONENT_NAME = "switch"
+    }
 
     override fun render() {
         attr("id", componentId)
@@ -325,7 +343,7 @@ fun <C : HTMLElement> RenderContext.switch(
     tag: TagFactory<Tag<C>>,
     initialize: Switch<C>.() -> Unit
 ): Tag<C> {
-    addComponentStructureInfo("switch", this@switch.scope, this)
+    addComponentStructureInfo(Switch.COMPONENT_NAME, this@switch.scope, this)
     return tag(this, classes, id, scope) {
         Switch(this, id).run {
             initialize()

--- a/headless/src/jsMain/kotlin/dev/fritz2/headless/components/textfields.kt
+++ b/headless/src/jsMain/kotlin/dev/fritz2/headless/components/textfields.kt
@@ -17,11 +17,18 @@ import org.w3c.dom.*
  *      [official documentation](https://www.fritz2.dev/headless/textarea/)
  *
  */
-abstract class Textfield<C : HTMLElement>(tag: Tag<C>, id: String?) : Tag<C> by tag {
+abstract class Textfield<C : HTMLElement>(tag: Tag<C>, id: String?, private val componentName: String) : Tag<C> by tag {
 
     val value = DatabindingProperty<String>()
 
-    val componentId: String by lazy { id ?: value.id ?: Id.next() }
+    val componentId: String by lazy {
+        id ?: value.id ?: Id.next().also {
+            if (value.value == null) {
+                value(storeOf(""))
+                warnAboutMissingDatabinding("value", componentName, it, "a store of string")
+            }
+        }
+    }
     protected val fieldId by lazy { "$componentId-field" }
 
     protected var label: Tag<HTMLElement>? = null
@@ -120,7 +127,11 @@ abstract class Textfield<C : HTMLElement>(tag: Tag<C>, id: String?) : Tag<C> by 
  * For more information refer to the [official documentation](https://www.fritz2.dev/headless/inputfield/)
  */
 class InputField<C : HTMLElement>(tag: Tag<C>, id: String?) :
-    Textfield<C>(tag, id) {
+    Textfield<C>(tag, id, COMPONENT_NAME) {
+
+    companion object {
+        const val COMPONENT_NAME = "inputField"
+    }
 
     fun RenderContext.inputTextfield(
         classes: String? = null,
@@ -237,7 +248,7 @@ fun <C : HTMLElement> RenderContext.inputField(
     tag: TagFactory<Tag<C>>,
     initialize: InputField<C>.() -> Unit
 ): Tag<C> {
-    addComponentStructureInfo("inputField", this@inputField.scope, this)
+    addComponentStructureInfo(InputField.COMPONENT_NAME, this@inputField.scope, this)
     return tag(this, classes, id, scope) {
         InputField(this, id).run {
             initialize()
@@ -281,7 +292,11 @@ fun RenderContext.inputField(
  * For more information refer to the [official documentation](https://www.fritz2.dev/headless/textarea/)
  */
 class TextArea<C : HTMLElement>(tag: Tag<C>, id: String?) :
-    Textfield<C>(tag, id) {
+    Textfield<C>(tag, id, COMPONENT_NAME) {
+
+    companion object {
+        const val COMPONENT_NAME = "textArea"
+    }
 
     fun RenderContext.textareaTextfield(
         classes: String? = null,
@@ -398,7 +413,7 @@ fun <C : HTMLElement> RenderContext.textArea(
     tag: TagFactory<Tag<C>>,
     initialize: TextArea<C>.() -> Unit
 ): Tag<C> {
-    addComponentStructureInfo("textArea", this@textArea.scope, this)
+    addComponentStructureInfo(TextArea.COMPONENT_NAME, this@textArea.scope, this)
     return tag(this, classes, id, scope) {
         TextArea(this, id).run {
             initialize()

--- a/headless/src/jsMain/kotlin/dev/fritz2/headless/foundation/DatabindingProperty.kt
+++ b/headless/src/jsMain/kotlin/dev/fritz2/headless/foundation/DatabindingProperty.kt
@@ -65,3 +65,25 @@ class DatabindingProperty<T> : Property<DatabindingProperty.DataBinding<T>>() {
         this.invoke(store.id, store.data, store.messages()) { it handledBy store.update }
     }
 }
+
+/**
+ * Common function to log a warning message for missing data-bindings.
+ * This should be used for components, where the data-binding is crucial for their usage. A forgotten data-binding
+ * should be recognizable at runtime by this warning message
+ */
+internal fun warnAboutMissingDatabinding(
+    propertyName: String,
+    componentName: String,
+    componentId: String,
+    fallbackPhrase: String
+) {
+    console.warn(
+        buildString {
+            append("fritz2: Missing data-binding for `$propertyName` property of $componentName component ")
+            append("with id `$componentId`. Setting $fallbackPhrase as fallback.")
+            appendLine()
+            append("You should really consider to provide some data-binding, as for now you might neither see any ")
+            append("initial data, nor won't be able to access any resulting data.")
+        }
+    )
+}


### PR DESCRIPTION
As for some components it is absolutely mandatory to have some data-binding, in order to avoid some NPE at runtime, we have added default appropriate data-bindings for those. Additionally, some warning messages will be logged into the console in such a fallback case, so the user gets a hint, what he has forgotten to set. 

fixes #667