### PR TITLE
Add default z-Index for PopUpPanel

### DIFF
--- a/headless/src/jsMain/kotlin/dev/fritz2/headless/foundation/PopUpPanel.kt
+++ b/headless/src/jsMain/kotlin/dev/fritz2/headless/foundation/PopUpPanel.kt
@@ -125,6 +125,7 @@ abstract class PopUpPanel<C : HTMLElement>(
             }""".trimIndent(),
                     """.$POPUP_VISIBLE {
                 visibility: visible;
+                z-index: 30;
             }""".trimIndent(),
                     """.$POPUP_HIDDEN {
                 visibility: hidden;
@@ -132,6 +133,7 @@ abstract class PopUpPanel<C : HTMLElement>(
                     """.$POPUP_VISIBLE_FULL {
                 width: 100%;
                 visibility: visible;
+                z-index: 30;
             }""".trimIndent(),
                     """.$POPUP_HIDDEN_FULL {
                 width: 100%;

--- a/www/src/pages/headless/headlessComponents.md
+++ b/www/src/pages/headless/headlessComponents.md
@@ -527,3 +527,12 @@ popOverPanel {
     arrow("h-3 w-3 bg-white")
 }
 ```
+
+::: info
+As such a floating panel will often need a higher ``z-index`` than the rest of the page(-section) it appears in, 
+we have set a default value of ``30`` for it. This offers enough flexibility to position elements below or above the 
+popup. 
+
+The value is chosen inspired by the [tailwindcss](https://tailwindcss.com/docs/z-index) scale for ``z-index``: 
+It is the median of the predefined ones.
+:::


### PR DESCRIPTION
I order to render the floating content of a PopUpPanel based component, we have defined a static z-Index with value ``30`` for the popper div, which can't be styled in a safe and reliable way from the outside.

This value corresponds to the median value of the predefined [tailwindcss](https://tailwindcss.com/docs/z-index) z-indices. 

fixes #670