### PR TITLE
Improve Focus Management on various headless Components

### DIFF
--- a/headless-demo/src/jsMain/kotlin/dev/fritz2/headlessdemo/tabGroup.kt
+++ b/headless-demo/src/jsMain/kotlin/dev/fritz2/headlessdemo/tabGroup.kt
@@ -29,7 +29,7 @@ fun RenderContext.tabsDemo() {
                 tab(
                     """w-full py-2.5 leading-5
                     | text-sm font-medium rounded
-                    | focus:outline-none focus-visible:ring-4 focus-visible:ring-primary-600""".trimMargin()
+                    | focus:outline-none focus:ring-4 focus:ring-primary-600""".trimMargin()
                 ) {
                     className(selected.map { sel ->
                         if (sel == index) "bg-primary-800 text-white shadow-md"

--- a/headless/src/jsMain/kotlin/dev/fritz2/headless/components/popOver.kt
+++ b/headless/src/jsMain/kotlin/dev/fritz2/headless/components/popOver.kt
@@ -23,6 +23,7 @@ class PopOver<C : HTMLElement>(tag: Tag<C>, id: String?) : Tag<C> by tag, OpenCl
 
     fun render() {
         attr("id", componentId)
+        trapFocusWhenever(opened)
     }
 
     /**
@@ -141,7 +142,6 @@ fun <C : HTMLElement> RenderContext.popOver(
             initialize(this)
             render()
         }
-        trapFocus()
     }
 }
 

--- a/headless/src/jsMain/kotlin/dev/fritz2/headless/components/tabGroup.kt
+++ b/headless/src/jsMain/kotlin/dev/fritz2/headless/components/tabGroup.kt
@@ -268,7 +268,6 @@ class TabGroup<C : HTMLElement>(tag: Tag<C>, id: String?) : Tag<C> by tag {
                 tag(this, classes, panelId(currentIndex), scope) {
                     addComponentStructureInfo("parent is panel", this@add.scope, this)
                     content()
-                    attr("tabindex", "0")
                     attr("role", Aria.Role.tabpanel)
                     attr(Aria.labelledby, tabId(currentIndex))
                 }

--- a/www/src/pages/headless/tabGroup.md
+++ b/www/src/pages/headless/tabGroup.md
@@ -68,11 +68,10 @@ tabGroup {
 }
 ```
 
-## Styling the active Tab
+## Styling the selected Tab
 
 In order to distinguish the active tab from the rest in terms of style, within the scope of `tab` the boolean data
-stream
-`selected` is available.
+stream `selected` is available.
 
 This can be used in combination with `className` to apply different styles to a tab or even show and hide entire
 elements (e.g. an icon for the selected tab).
@@ -89,6 +88,42 @@ tabGroup {
                 })
                 
                 +category 
+            }
+        }
+    }
+    tabPanels {
+        // omitted
+    }
+}
+```
+
+## Styling the active Element
+
+A TabGroup also provides information about which tab is currently active, i.e. has the focus.
+
+For this purpose, the scope of `tab` offers the Boolean data stream `active`. This one can (and should)
+be used to provide a specific style for the `true` state.
+
+Since often both the status of the selection and the focus stylistically affect the same elements, it is a
+typical pattern to combine both data streams. Use the `combine` method on `Flow`s for this purpose:
+
+```kotlin
+tabGroup {
+    tabList {
+        categories.keys.forEach { category ->
+            tab {
+                // combine `selected` and `active`-Flow with `className` to react to state changes
+                className(selected.combine(active) { sel, act ->
+                    // use `classes` to attach both styling results
+                    classes(
+                        if (sel == index) "bg-primary-800 text-white shadow-md"
+                        else "text-primary-100 hover:bg-primary-900/[0.12]",
+                        if (act) "ring-2 ring-white border-transparent" 
+                        else "border-gray-300"
+                    )
+                })
+
+                +category
             }
         }
     }
@@ -227,6 +262,7 @@ tabGroup() {
                 val index: Int
                 val disabled: Flow<Int>
                 val disable: SimpleHandler<Int>
+                val active: Flow<Boolean>
             }
         // }
     }
@@ -269,11 +305,12 @@ Parameters: `classes`, `scope`, `tag`, `initialize`
 
 Default-Tag: `div`
 
-| Scope property | Typ                      | Description                                                    |
-|----------------|--------------------------|----------------------------------------------------------------|
-| `index`        | `Int`                    | The index of the tab in the group.                             |
-| `disabled`     | `Flow<Boolean>`          | Stream of data indicating whether a tab is active or inactive. |
-| `disable`      | `SimpleHandler<Boolean>` | Handler for setting the inactive state.                        |
+| Scope property | Typ                      | Description                                                        |
+|----------------|--------------------------|--------------------------------------------------------------------|
+| `index`        | `Int`                    | The index of the tab in the group.                                 |
+| `disabled`     | `Flow<Boolean>`          | Stream of data indicating whether a tab is active or inactive.     |
+| `disable`      | `SimpleHandler<Boolean>` | Handler for setting the inactive state.                            |
+| `active`       | `Flow<Boolean>`          | Boolean flow that is ``true`` if tab has the focus, else ``false`` |
 
 
 ### tabPanels


### PR DESCRIPTION
This PR fixes two main issues and introduces some new functionality as side effect, that might be useable for dealing with similar focus management situations.

### Improved Focus-Trap

The focus-trap is now also reactive by adding a new variant function ``trapFocusWhenever`` to the established ``trapFocus`` one. Theis alternative requires  some boolean flow as first parameter that acts as a conditional decider: Only on ``true`` values on the flow the focus-trap will get established; on ``false`` values it will get disabled.

This is very useful for situations, where some kind of "open" state (as for ``PopUpPanel`` based components for example) triggers the visibility of a content, where the trap should be active. After closing however, the tab should be freed again, so that the user can continue to tab through the application.

It fixes the focus "stealing" behaviour of the Popover component, which until now kept the focus trapped, once you have reached it by tab. Now based upon the ``opened`` flow of the ``PopUpPanel`` this behaviour is limited to the situation, the Popover is opened.

### Improved Focus Handling of TabGroup

The focus management of the TabGroup was kinda broken. It always set the focus on initial rendering, even though the tab-group was not having the focus. This was wrong, as it has stolen the focus from any other explicitly focused element.

Now there is an additional boolean flow called ``active`` available inside the ``tab`` brick of the ``tabGroup`` component. It will offer the ``true`` value only if this tab currently has the focus. This is used internally to set the focus, if the selected tab has changed by user interaction.

fixes #672