### PR TITLE
Repair the ksp config

### DIFF
--- a/examples-demo/build.gradle.kts
+++ b/examples-demo/build.gradle.kts
@@ -1,6 +1,5 @@
 plugins {
     kotlin("multiplatform")
-    id("com.google.devtools.ksp")
 }
 
 kotlin {
@@ -33,21 +32,3 @@ kotlin {
     }
 }
 
-/**
- * KSP support - start
- */
-ksp {
-
-}
-
-kotlin.sourceSets.commonMain { kotlin.srcDir("build/generated/ksp/commonMain/kotlin") }
-
-// Fixes webpack-cli incompatibility by pinning the newest version.
-// https://youtrack.jetbrains.com/issue/KTIJ-22030
-rootProject.extensions.configure<org.jetbrains.kotlin.gradle.targets.js.nodejs.NodeJsRootExtension> {
-    versions.webpackCli.version = "4.10.0"
-}
-
-/**
- * KSP support - end
- */

--- a/headless-demo/build.gradle.kts
+++ b/headless-demo/build.gradle.kts
@@ -40,18 +40,18 @@ kotlin {
 /**
  * KSP support - start
  */
-ksp {
-
+dependencies {
+    add("kspCommonMainMetadata",  project(":lenses-annotation-processor"))
 }
-
-kotlin.sourceSets.commonMain { kotlin.srcDir("build/generated/ksp/commonMain/kotlin") }
-
+kotlin.sourceSets.commonMain { kotlin.srcDir("build/generated/ksp/metadata/commonMain/kotlin") }
+tasks.withType<org.jetbrains.kotlin.gradle.dsl.KotlinCompile<*>>().all {
+    if (name != "kspCommonMainKotlinMetadata") dependsOn("kspCommonMainKotlinMetadata")
+}
 // Fixes webpack-cli incompatibility by pinning the newest version.
 // https://youtrack.jetbrains.com/issue/KTIJ-22030
 rootProject.extensions.configure<org.jetbrains.kotlin.gradle.targets.js.nodejs.NodeJsRootExtension> {
     versions.webpackCli.version = "4.10.0"
 }
-
 /**
  * KSP support - end
  */

--- a/headless-demo/src/commonMain/kotlin/dev/fritz2/headlessdemo/dataCollectionModel.kt
+++ b/headless-demo/src/commonMain/kotlin/dev/fritz2/headlessdemo/dataCollectionModel.kt
@@ -2,9 +2,9 @@ package dev.fritz2.headlessdemo
 
 import dev.fritz2.core.Id
 
-//import dev.fritz2.core.Lenses
+import dev.fritz2.core.Lenses
 
-//@Lenses
+@Lenses
 data class Person(
     val id: String = "",
     val fullName: String = "",
@@ -18,7 +18,7 @@ data class Person(
     companion object
 }
 
-//@Lenses
+@Lenses
 data class Address(
     val street: String = "",
     val houseNumber: String = "",


### PR DESCRIPTION
Lenses generation was not possible due to oversimplification of the ksp config section in the build.gradle.kt. In order to preserve regressions on this topic, the ``@Lenses`` annotation were enabled again for our models in the demo, even though the generated lenses are currently not used.

Not worth mentioning in the release note!