### PR TITLE
Improves OpenClose's toggle behaviour

### DIFF
--- a/headless-demo/tests/tabgroup.spec.ts
+++ b/headless-demo/tests/tabgroup.spec.ts
@@ -118,6 +118,8 @@ test.describe('Navigating', () => {
             await expect(panel).toBeVisible();
         }
 
+        await tabGroup.press("Tab")
+
         /* right */
         await tabGroup.press("ArrowRight");
         await tabActive("1");

--- a/headless/src/jsMain/kotlin/dev/fritz2/headless/foundation/OpenClose.kt
+++ b/headless/src/jsMain/kotlin/dev/fritz2/headless/foundation/OpenClose.kt
@@ -62,7 +62,6 @@ abstract class OpenClose {
                 clicks,
                 keydowns.filter { setOf(Keys.Space, Keys.Enter).contains(shortcutOf(it)) }
             ).map {
-                it.stopImmediatePropagation()
                 it.preventDefault()
                 !state
             }


### PR DESCRIPTION
Some opening action of a ``OpenClose`` based component will now close any other already opened component, as the ``click`` event will bubble and therefor enable the window object to emit a ``blur`` event.

Fixes also some testing problem: As the TagGroup does not capture the focus anymore, one test needs now an explicit focus action before key events will be evaluated.

fixes #693 