### PR TITLE
Fix test expectations

### DIFF
--- a/headless-demo/tests/datacollection.datatable.spec.ts
+++ b/headless-demo/tests/datacollection.datatable.spec.ts
@@ -210,8 +210,8 @@ test.describe('Navigating', () => {
 test.describe('To', () => {
 
     for (const data of [
-        {expression: "Kranz", filtered: 5, selected: 2},
-        {expression: "Timm", filtered: 1, selected: 2}
+        {expression: "Kranz", filtered: 5, selected: 1},
+        {expression: "Timm", filtered: 1, selected: 0}
     ]) {
         test(`filter some elements of Datatable type "${data.expression}" into filter inputfield`, async ({page}) => {
 

--- a/headless-demo/tests/datacollection.gridlist.spec.ts
+++ b/headless-demo/tests/datacollection.gridlist.spec.ts
@@ -217,8 +217,8 @@ test.describe('Navigating', () => {
 test.describe('To', () => {
 
     for (const data of [
-        {expression: "Kranz", filtered: 4, selected: 2},
-        {expression: "Timm", filtered: 1, selected: 2}
+        {expression: "Kranz", filtered: 4, selected: 1},
+        {expression: "Timm", filtered: 1, selected: 0}
     ]) {
         test(`filter some elements of Gridlist type "${data.expression}" into filter inputfield`, async ({page}) => {
 


### PR DESCRIPTION
Due to the change of filtering behaviour of PR #692, the amount of selected items changes now. The test expectations now corresponds to the actual remaining selected persons.

Does not need to be mentioned in the release note.