### PR TITLE
Add headless `Toast` component

### DIFF
--- a/headless-demo/src/jsMain/kotlin/dev/fritz2/headlessdemo/app.kt
+++ b/headless-demo/src/jsMain/kotlin/dev/fritz2/headlessdemo/app.kt
@@ -80,6 +80,11 @@ val pages = mapOf(
         "Headless Tooltip",
         """Some information that is displayed, whenever you hover a target element using your pointer device.""".trimMargin(),
         RenderContext::tooltipDemo
+    ),
+    "toast" to DemoPage(
+        "Headless Toast",
+        """Display notification-like content in arbitrary positions on the screen.""".trimMargin(),
+        RenderContext::toastDemo
     )
 )
 
@@ -87,7 +92,7 @@ fun RenderContext.overview() {
     div("flex flex-col justify-start items-center h-screen") {
         h1("mb-8 tracking-tight font-bold text-gray-900 text-4xl") {
             span("block sm:inline") { +"fritz2" }
-            span("block text-primary-800 sm:inline") { +" Headless Demos" }
+            span("block text-primary-800 sm:inline") { +"Headless Demos" }
         }
         div("w-3/4 grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-12") {
             pages.forEach {

--- a/headless-demo/src/jsMain/kotlin/dev/fritz2/headlessdemo/toast.kt
+++ b/headless-demo/src/jsMain/kotlin/dev/fritz2/headlessdemo/toast.kt
@@ -1,0 +1,125 @@
+package dev.fritz2.headlessdemo
+
+import dev.fritz2.core.RenderContext
+import dev.fritz2.core.Tag
+import dev.fritz2.headless.components.toast
+import dev.fritz2.headless.components.toastContainer
+import org.w3c.dom.HTMLLIElement
+
+private const val toastContainerDefault = "toast-container-default"
+private const val containerImportant = "toast-container-important"
+
+fun RenderContext.toastDemo() {
+    div {
+        toastContainer(
+            toastContainerDefault,
+            "absolute top-5 right-5 z-10 flex flex-col gap-2 items-start",
+            id = toastContainerDefault
+        )
+
+        toastContainer(
+            containerImportant,
+            "absolute top-5 left-1/2 -translate-x-1/2 z-10 flex flex-col gap-2 items-center",
+            id = containerImportant
+        )
+    }
+
+    div(
+        """absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2
+            | flex flex-col gap-6
+            | bg-white rounded p-4
+        """.trimMargin()
+    ) {
+        p {
+            +"Press a button below to create a new toast:"
+        }
+        div("grid grid-cols-1 md:grid-cols-2 gap-4 max-w-1/2 max-h-1/2") {
+            button(
+                """flex justify-center items-center px-4 py-2.5
+                    | rounded shadow-sm
+                    | border border-transparent
+                    | text-sm font-sans text-white
+                    | bg-primary-400 hover:bg-primary-900
+                    | focus:outline-none focus:ring-4 focus:ring-primary-600""".trimMargin(),
+                id = "btn-toast-default"
+            ) {
+                +"Default"
+
+                clicks handledBy {
+                    showToast(toastContainerDefault) {
+                        +"Regular toast"
+                        className("bg-primary-200")
+                    }
+                }
+            }
+
+            button(
+                """flex justify-center items-center px-4 py-2.5
+                    | rounded shadow-sm
+                    | border border-transparent
+                    | text-sm font-sans text-white
+                    | bg-primary-400 hover:bg-primary-900
+                    | focus:outline-none focus:ring-4 focus:ring-primary-600""".trimMargin(),
+                id = "btn-toast-important"
+            ) {
+                +"Important"
+
+                clicks handledBy {
+                    showToast(containerImportant) {
+                        className("bg-error-100")
+
+                        div("flex flex-row items-center gap-4 text-error-500 mr-2") {
+                            icon("w-6 h-6", content = HeroIcons.exclamation_circle)
+                            div {
+                                div("font-semibold") { +"Important" }
+                                div { +"This toast is rendered in another container" }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+
+private var toastCount = 0
+private fun nextToastId() = "toast-${toastCount++}"
+
+private fun showToast(container: String, initialize: Tag<HTMLLIElement>.() -> Unit) {
+    toast(
+        container,
+        duration = 6000L,
+        """flex flex-row flex-shrink-0 gap-2 justify-center
+            | w-max px-4 py-2.5
+            | rounded shadow-sm
+            | border border-transparent
+            | text-sm font-sans
+        """.trimMargin(),
+        nextToastId()
+    ) {
+        initialize()
+
+        // FIXME: Werden Toast schnell hintereinander geöffnet, werden einige von ihnen bim
+        //  Schließen zwar aus dem ToastStore entfernt, bleiben jedoch als DOM-Leiche übrig.
+        //  Dies könnte an der Kombination aus renderEach und transition liegen; evtl. kann
+        //  ein Element nicht aus dem DOM entfernt werden, solange es animiert wird?
+        //  Vgl.: https://github.com/jwstegemann/fritz2/issues/714
+        /*transition(
+            enter = "transition-all duration-200 ease-in-out",
+            enterStart = "opacity-0",
+            enterEnd = "opacity-100",
+            leave = "transition-all duration-200 ease-in-out",
+            leaveStart = "opacity-100",
+            leaveEnd = "opacity-0"
+        )*/
+
+        button {
+            icon(
+                classes = "w-4 h-4 text-primary-900",
+                content = HeroIcons.x
+            )
+            clicks handledBy close
+        }
+    }
+}

--- a/headless-demo/tests/toast.spec.ts
+++ b/headless-demo/tests/toast.spec.ts
@@ -1,0 +1,85 @@
+import {expect, test} from "@playwright/test";
+
+test.beforeEach(async ({page}) => {
+    await page.goto('#toast')
+});
+
+test.describe('Toast', () => {
+    const ids = [
+        {toggleId: 'btn-toast-default', containerId: 'toast-container-default'},
+        {toggleId: 'btn-toast-important', containerId: 'toast-container-important'}
+    ];
+
+    ids.forEach(({containerId}) => {
+        test(`Container is present (${containerId})`, async ({page}) => {
+            const container = page.locator(`#${containerId}`);
+            await expect(container).toHaveCount(1);
+        });
+    });
+
+    ids.forEach(({toggleId, containerId}) => {
+        test(`Toast visible after creation (toggle: ${toggleId})`, async ({page}) => {
+            const toasts = page.locator(`#${containerId} > *`);
+            await expect(toasts).toHaveCount(0);
+
+            const toggle = page.locator(`#${toggleId}`);
+            await toggle.click();
+            await expect(toasts).toHaveCount(1);
+        });
+    });
+
+    ids.forEach(({toggleId, containerId}) => {
+        test(`Toast closed after duration (toggle: ${toggleId})`, async ({page}) => {
+            const toasts = page.locator(`#${containerId} > *`);
+            await expect(toasts).toHaveCount(0);
+
+            const toggle = page.locator(`#${toggleId}`);
+            await toggle.click();
+            await expect(toasts).toHaveCount(1);
+
+            // Wait for toast to be closed (6000ms + small buffer)
+            await page.waitForTimeout(6500);
+
+            await expect(toasts).toHaveCount(0);
+        });
+    });
+
+    ids.forEach(({toggleId, containerId}) => {
+        test(`Toast closed after pressing close button (toggle: ${toggleId})`, async ({page}) => {
+            const toasts = page.locator(`#${containerId} > *`);
+            await expect(toasts).toHaveCount(0);
+
+            const toggle = page.locator(`#${toggleId}`);
+            await toggle.click();
+            await expect(toasts).toHaveCount(1);
+
+            const closeButton = page.locator(`#${containerId} > li:first-child > button`);
+            await closeButton.click();
+
+            await expect(toasts).toHaveCount(0);
+        });
+    });
+
+    test('Most recent toast closed after pressing escape', async ({page}) => {
+        const toasts = page.locator(`#${ids[0].containerId} > *`);
+        await expect(toasts).toHaveCount(0);
+
+        const toggle = page.locator(`#${ids[0].toggleId}`);
+        await toggle.click();
+        await toggle.click();
+        await expect(toasts).toHaveCount(2);
+
+        const firstToast = page.locator(`#toast-0`);
+        await expect(firstToast).toBeVisible();
+
+        const secondToast = page.locator(`#toast-1`);
+        await expect(secondToast).toBeVisible();
+
+        await page.keyboard.down('Escape');
+        await expect(toasts).toHaveCount(1);
+        await expect(firstToast).toBeVisible();
+
+        await page.keyboard.down('Escape');
+        await expect(toasts).toHaveCount(0);
+    });
+});

--- a/headless/src/jsMain/kotlin/dev/fritz2/headless/components/toast.kt
+++ b/headless/src/jsMain/kotlin/dev/fritz2/headless/components/toast.kt
@@ -1,0 +1,170 @@
+package dev.fritz2.headless.components
+
+import dev.fritz2.core.*
+import dev.fritz2.core.Window
+import dev.fritz2.headless.foundation.*
+import kotlinx.coroutines.*
+import kotlinx.coroutines.flow.filter
+import kotlinx.coroutines.flow.map
+import org.w3c.dom.*
+
+
+private data class ToastSlice(
+    val id: String,
+    val containerName: String,
+    val content: RenderContext.() -> Tag<HTMLElement>
+)
+
+private object ToastStore : RootStore<List<ToastSlice>>(emptyList()) {
+
+    val add = handle<ToastSlice> { toasts, toast -> toasts + toast }
+    val remove = handle<String> { toasts, id -> toasts.filterNot { it.id == id } }
+
+    fun filteredByContainer(containerName: String) = data
+        .map { toasts -> toasts.filter { it.containerName == containerName } }
+
+    init {
+        // Close the most recent toast if escape is pressed:
+        Window.keydowns
+            .map { it to current }
+            .filter { (event, toasts) -> shortcutOf(event.key) == Keys.Escape && toasts.isNotEmpty() }
+            .map { (_, toasts) -> toasts.last().id } handledBy remove
+    }
+}
+
+
+/**
+ * Factory function to create a [toastContainer].
+ *
+ * For more information refer to the
+ * [official documentation](https://www.fritz2.dev/headless/toast/#toastContainer)
+ *
+ * @param name the mandatory name of the container. This ultimately defines the container's identity.
+ */
+fun <E : HTMLElement> RenderContext.toastContainer(
+    name: String,
+    classes: String? = null,
+    id: String? = null,
+    scope: (ScopeContext.() -> Unit) = {},
+    tag: TagFactory<Tag<E>>
+): Tag<E> {
+    addComponentStructureInfo("toast-container ($name)", this.scope, this)
+    return tag(this, classes, id, scope) {
+        attrIfNotSet(Aria.live, "polite")
+        ToastStore.filteredByContainer(name).renderEach(into = this) { fragment ->
+            fragment.content(this)
+        }
+    }
+}
+
+/**
+ * Factory function to create a [toastContainer] with a [HTMLUListElement] as default [Tag].
+ *
+ * For more information refer to the
+ * [official documentation](https://www.fritz2.dev/headless/toast/#toastContainer)
+ *
+ * @param name the mandatory name of the container. This ultimately defines the container's identity.
+ */
+fun RenderContext.toastContainer(
+    name: String,
+    classes: String? = null,
+    id: String? = null,
+    scope: (ScopeContext.() -> Unit) = {},
+): Tag<HTMLUListElement> =
+    toastContainer(name, classes, id, scope, RenderContext::ul)
+
+
+/**
+ * This class provides the building blocks to implement a toast.
+ *
+ * Use [toast] functions to create an instance, set up the needed [Hook]s or [Property]s and refine the
+ * component by using the further factory methods offered by this class.
+ *
+ * For more information refer to the [official documentation](https://www.fritz2.dev/headless/toast/)
+ */
+class Toast<E : HTMLElement> internal constructor(tag: Tag<E>, private val toastId: String) : Tag<E> by tag {
+
+    /**
+     * Handler that dismisses the toast when invoked.
+     */
+    @Suppress("unused")
+    val close: Handler<Unit> = storeOf(Unit).handle { ToastStore.remove(toastId) }
+}
+
+/**
+ * Factory function to create a [Toast].
+ *
+ * API-Sketch:
+ * ```kotlin
+ * toastPosition() // use for each position that should be availble
+ * toast() { // use for each new toast
+ *     toastCloseButton() { close ->
+ *     }
+ * }
+ * ```
+ *
+ * For more information refer to the [official documentation](https://www.fritz2.dev/headless/toast/#toast)
+ *
+ * @param containerName refer to the container the toast should be stored in
+ * @param duration the duration a toast should be displayed on the screen
+ */
+fun <E : HTMLElement> toast(
+    containerName: String,
+    duration: Long = 5000L,
+    classes: String? = null,
+    id: String? = null,
+    scope: (ScopeContext.() -> Unit) = {},
+    tag: TagFactory<Tag<E>>,
+    initialize: Toast<E>.() -> Unit
+) {
+    val toastId = Id.next()
+    val toast = ToastSlice(toastId, containerName) {
+        tag(this, classes, id, scope) {
+            attrIfNotSet("role", Aria.Role.alert)
+            addComponentStructureInfo("parent is toast ($toastId)", this.scope, this)
+            Toast(this, toastId).run(initialize)
+        }
+    }
+
+    MainScope().launch {
+        val currentJob = currentCoroutineContext().job
+        object : WithJob {
+            override val job = currentJob
+        }.run {
+            ToastStore.add(toast)
+
+            // Duration of 0: Keep the toast until closed manually
+            if (duration > 0L) {
+                delay(duration)
+                ToastStore.remove(toast.id)
+            }
+        }
+    }
+}
+
+/**
+ * Factory function to create a [Toast] with an [HTMLLIElement] as default root [Tag].
+ *
+ * API-Sketch:
+ * ```kotlin
+ * toastPosition() // use for each position that should be available
+ * toast() { // use for each new toast
+ *     toastCloseButton() { close ->
+ *     }
+ * }
+ * ```
+ *
+ * For more information refer to the [official documentation](https://www.fritz2.dev/headless/toast/#toast)
+ *
+ * @param containerName refer to the container the toast should be stored in
+ * @param duration the duration a toast should be displayed on the screen
+ */
+fun toast(
+    containerName: String,
+    duration: Long = 5000L,
+    classes: String? = null,
+    id: String? = null,
+    scope: (ScopeContext.() -> Unit) = {},
+    initialize: Toast<HTMLLIElement>.() -> Unit
+): Unit =
+    toast(containerName, duration, classes, id, scope, RenderContext::li, initialize)

--- a/www/src/pages/headless/toast.md
+++ b/www/src/pages/headless/toast.md
@@ -1,0 +1,136 @@
+---
+title: Toast
+description: "A toast is a notification-like component that can be shown in arbitrary locations on the screen for a
+limited amount of time."
+layout: layouts/docs.njk
+permalink: /headless/toast/
+eleventyNavigation:
+    key: toast
+    title: Toast
+    parent: headless
+    order: 115
+teaser: true
+demoHash: toast
+demoHeight: 28rem
+---
+
+## Basic Example
+
+In order to create a ``toast`` you first need to set up a container, that will act as a host for the toasts.
+You can create such a container via the `toastContainer` factory with a *name* as parameter. The name defines the
+identity of the container, with acts as reference for the toasts. You also have to style the container in order to
+define the screen position in which the toasts should appear.
+
+```kotlin
+toastContainer(
+    "default", // name
+    "absolute top-5 right-5 flex flex-col gap-2 items-start"
+)
+```
+
+Toasts are built using the `toast` factory function. It is mandatory to provide the name of the container
+in which the toast should be added. Optionally you can pass a `duration` that defines the time of appearance in
+milliseconds.
+
+```kotlin
+toast("default") {
+    +"Toast"
+}
+```
+
+::: info
+Please note that the functionality of the headless toast component is intentionally limited.
+Consider using another component (e.g. [data collection](/headless/datacollection)) for more complex uses cases like
+filtering or sorting the toast list, or displaying more complex data.
+:::
+
+## Multiple Containers
+
+You can create as many containers as you need. Just call the `toastContainer` factory for each container using
+unique names.
+
+When creating a toast, just refer to the appropriate container name to place the toast.
+
+One scenario may be a notification system that always renders notifications in one corner of the screen whereas another
+one might have to support a number of different places.
+
+```kotlin
+toastContainer("default")
+toastContainer("important")
+
+toast("default") {
+    +"Some basic information"
+}
+
+toast("important") {
+    +"Some more important information"
+}
+```
+
+
+## Automatic closing
+
+The time in milliseconds before the toast closes itself can be overridden via the `duration` parameter of the factory.
+
+By default every toast is closed after a specific time; if no duration is set a default value of `5000` milliseconds 
+is used.
+
+```kotlin
+toast(
+    "default",
+    duration = 10000L
+) {
+    +"Toast"
+}
+```
+
+The toast can be kept indefinitely (until manually closed) by setting the `duration` to `0`.
+
+## Manual closing
+
+Optionally, a toast can be dismissed before the configured duration is over by calling the `close` handler available in
+the configuration context of the toast. A common use case would be a close button.
+
+This feature is also important for toasts with `duration` set to `0`, which will be kept indefinitely.
+
+```kotlin
+toast("default") {
+    +"Toast"
+
+    button {
+        icon(
+            classes = "w-4 h-4 text-primary-900",
+            content = HeroIcons.x
+        )
+        clicks handledBy close // call close handler
+    }
+}
+```
+
+## API
+
+### Summary / Sketch
+
+```kotlin
+toastContainer(name, classes, id, scope, tag) // repeat for each desired location
+
+toast(containerName, duration, classes, id, scope, tag) {
+    val close: Handler<Unit>
+}
+```
+
+### toastContainer
+
+Parameters: `name`, `classes`, `id`, `scope`, `tag`
+
+Default-Tag: `ul`
+
+### toast
+
+Parameters: `containerName`, `duration`, `classes`, `id`, `scope`, `tag`, `initialize`
+
+Default-Tag: `li`
+
+| Scope property | Typ             | Description                   |
+|----------------|-----------------|-------------------------------|
+| `close`        | `Handler<Unit>` | closes the toast when invoked |


### PR DESCRIPTION
This PR adds a headless toast-component.

A toast is a component that can be displayed in specific areas of the screen for both a fixed or indefinite amount of time, similar to notifications.