### PR TITLE
Repair remote auth middleware - prevent endless loop for 403 response

### DIFF
--- a/core/src/jsMain/kotlin/dev/fritz2/remote/auth.kt
+++ b/core/src/jsMain/kotlin/dev/fritz2/remote/auth.kt
@@ -45,9 +45,9 @@ abstract class Authentication<P> : Middleware {
 
     /**
      * List of HTTP-Status-Codes forcing an authentication.
-     * Defaults are 401 (unauthorized) and 403 (forbidden).
+     * Default is 401 (unauthorized).
      */
-    open val statusCodesEnforcingAuthentication: Set<Int> = setOf(401, 403)
+    open val statusCodesEnforcingAuthentication: Set<Int> = setOf(401)
 
     /**
      * Adds the authentication information to all requests by using the given [principal].


### PR DESCRIPTION
The default status code for a failed authentication is reduced to only 401.

### Rational
Before also the 403 was part of the status codes and would trigger the handleResponse interception method and starts a new authentication recursively. This is of course a bad idea, as the *authorization* will not change by the *authentication* process. Therefore the default http status for launching an authentication process should be only 401.

### Migration Guide
If you have some service that really relies on the 403 for the authentication, please adopt to the http semantics and change that to 401 instead.

fixes #700 