### PR TITLE
Fix default data bindings

### DIFF
--- a/headless-demo/src/jsMain/kotlin/dev/fritz2/headlessdemo/tooltip.kt
+++ b/headless-demo/src/jsMain/kotlin/dev/fritz2/headlessdemo/tooltip.kt
@@ -4,7 +4,7 @@ package dev.fritz2.headlessdemo
 import dev.fritz2.core.RenderContext
 import dev.fritz2.core.placeholder
 import dev.fritz2.core.type
-import tooltip
+import dev.fritz2.headless.components.tooltip
 
 
 fun RenderContext.tooltipButton(idPrefix: String) {

--- a/headless/src/jsMain/kotlin/dev/fritz2/headless/components/checkboxGroup.kt
+++ b/headless/src/jsMain/kotlin/dev/fritz2/headless/components/checkboxGroup.kt
@@ -28,20 +28,16 @@ class CheckboxGroup<C : HTMLElement, T>(tag: Tag<C>, private val explicitId: Str
 
     val value = DatabindingProperty<List<T>>()
 
-    val componentId: String by lazy {
-        explicitId ?: value.id ?: Id.next().also {
-            if (value.value == null) {
-                value(storeOf(emptyList()))
-                warnAboutMissingDatabinding("value", COMPONENT_NAME, it, "a flow of empty list")
-            }
-        }
-    }
+    val componentId: String by lazy { explicitId ?: value.id ?: Id.next() }
 
     fun render() {
         attr("id", componentId)
         attr("role", Aria.Role.group)
         attr(Aria.invalid, "true".whenever(value.hasError))
         label?.let { attr(Aria.labelledby, it.id) }
+        if (!value.isSet) {
+            warnAboutMissingDatabinding("value", COMPONENT_NAME, componentId, domNode)
+        }
     }
 
     /**

--- a/headless/src/jsMain/kotlin/dev/fritz2/headless/components/dataCollection.kt
+++ b/headless/src/jsMain/kotlin/dev/fritz2/headless/components/dataCollection.kt
@@ -338,7 +338,7 @@ class DataCollection<T, C : HTMLElement>(tag: Tag<C>) : Tag<C> by tag {
                 }
             }.shareIn(MainScope() + job, SharingStarted.Eagerly, 1)
         } else flowOf<List<T>>(emptyList()).also {
-            warnAboutMissingDatabinding("data", COMPONENT_NAME, componentId, "a flow of an empty list")
+            warnAboutMissingDatabinding("data", COMPONENT_NAME, componentId, this@DataCollection.domNode)
         }
 
         val items = filteredItems.flatMapLatest { filtered ->

--- a/headless/src/jsMain/kotlin/dev/fritz2/headless/components/listbox.kt
+++ b/headless/src/jsMain/kotlin/dev/fritz2/headless/components/listbox.kt
@@ -27,14 +27,7 @@ class Listbox<T, C : HTMLElement>(tag: Tag<C>, id: String?) : Tag<C> by tag, Ope
     }
 
     val value = DatabindingProperty<T>()
-    val componentId: String by lazy {
-        id ?: value.id ?: Id.next().also {
-            if (value.value == null) {
-                value(data = emptyFlow())
-                warnAboutMissingDatabinding("value", COMPONENT_NAME, it, "an empty flow")
-            }
-        }
-    }
+    val componentId: String by lazy { id ?: value.id ?: Id.next() }
 
     private var button: Tag<HTMLElement>? = null
 
@@ -60,9 +53,11 @@ class Listbox<T, C : HTMLElement>(tag: Tag<C>, id: String?) : Tag<C> by tag, Ope
 
     fun render() {
         attr("id", componentId)
-
         opened.drop(1).filter { !it } handledBy {
             button?.setFocus()
+        }
+        if (!value.isSet) {
+            warnAboutMissingDatabinding("value", COMPONENT_NAME, componentId, domNode)
         }
     }
 

--- a/headless/src/jsMain/kotlin/dev/fritz2/headless/components/radioGroup.kt
+++ b/headless/src/jsMain/kotlin/dev/fritz2/headless/components/radioGroup.kt
@@ -54,7 +54,7 @@ class RadioGroup<C : HTMLElement, T>(tag: Tag<C>, private val explicitId: String
                 })
         }
         if (!value.isSet) {
-            warnAboutMissingDatabinding("value", Switch.COMPONENT_NAME, componentId, domNode)
+            warnAboutMissingDatabinding("value", COMPONENT_NAME, componentId, domNode)
         }
     }
 

--- a/headless/src/jsMain/kotlin/dev/fritz2/headless/components/radioGroup.kt
+++ b/headless/src/jsMain/kotlin/dev/fritz2/headless/components/radioGroup.kt
@@ -28,21 +28,14 @@ class RadioGroup<C : HTMLElement, T>(tag: Tag<C>, private val explicitId: String
     private var options: MutableList<T> = mutableListOf()
 
     val value = DatabindingProperty<T>()
-    val componentId: String by lazy {
-        explicitId ?: value.id ?: Id.next().also {
-            if (value.value == null) {
-                value(data = emptyFlow())
-                warnAboutMissingDatabinding("value", COMPONENT_NAME, it, "an empty flow")
-            }
-        }
-    }
+    val componentId: String by lazy { explicitId ?: value.id ?: Id.next() }
 
     fun render() {
         attr("id", componentId)
         attr("role", Aria.Role.radiogroup)
         attr(Aria.invalid, "true".whenever(value.hasError))
         label?.let { attr(Aria.labelledby, it.id) }
-        if (withKeyboardNavigation == true) {
+        if (withKeyboardNavigation) {
             value.handler?.invoke(
                 value.data.flatMapLatest { option ->
                     keydowns.mapNotNull { event ->
@@ -59,6 +52,9 @@ class RadioGroup<C : HTMLElement, T>(tag: Tag<C>, private val explicitId: String
                         }
                     }
                 })
+        }
+        if (!value.isSet) {
+            warnAboutMissingDatabinding("value", Switch.COMPONENT_NAME, componentId, domNode)
         }
     }
 

--- a/headless/src/jsMain/kotlin/dev/fritz2/headless/components/switch.kt
+++ b/headless/src/jsMain/kotlin/dev/fritz2/headless/components/switch.kt
@@ -22,13 +22,7 @@ abstract class AbstractSwitch<C : HTMLElement>(
     Tag<C> by tag {
 
     val value = DatabindingProperty<Boolean>()
-    val enabled: Flow<Boolean> by lazy {
-        if (value.value == null) {
-            value(storeOf(false))
-            warnAboutMissingDatabinding("value", componentName, componentId, "a boolean store")
-        }
-        value.data
-    }
+    val enabled: Flow<Boolean> by lazy { value.data }
 
     val componentId: String by lazy { explicitId ?: value.id ?: Id.next() }
 
@@ -124,6 +118,9 @@ class SwitchWithLabel<C : HTMLElement>(tag: Tag<C>, id: String?) :
                     else descriptions.map { it.id }.joinToString(" ")
                 }
             )
+        }
+        if (!value.isSet) {
+            warnAboutMissingDatabinding("value", COMPONENT_NAME, componentId, domNode)
         }
     }
 
@@ -316,6 +313,9 @@ class Switch<C : HTMLElement>(tag: Tag<C>, explicitId: String?) :
                 if (messages.isNotEmpty()) validationMessages?.id else null
             }
         )
+        if (!value.isSet) {
+            warnAboutMissingDatabinding("value", COMPONENT_NAME, componentId, domNode)
+        }
     }
 }
 

--- a/headless/src/jsMain/kotlin/dev/fritz2/headless/components/textfields.kt
+++ b/headless/src/jsMain/kotlin/dev/fritz2/headless/components/textfields.kt
@@ -21,14 +21,8 @@ abstract class Textfield<C : HTMLElement>(tag: Tag<C>, id: String?, private val 
 
     val value = DatabindingProperty<String>()
 
-    val componentId: String by lazy {
-        id ?: value.id ?: Id.next().also {
-            if (value.value == null) {
-                value(storeOf(""))
-                warnAboutMissingDatabinding("value", componentName, it, "a store of string")
-            }
-        }
-    }
+    val componentId: String by lazy { id ?: value.id ?: Id.next() }
+
     protected val fieldId by lazy { "$componentId-field" }
 
     protected var label: Tag<HTMLElement>? = null
@@ -47,6 +41,9 @@ abstract class Textfield<C : HTMLElement>(tag: Tag<C>, id: String?, private val 
                     else descriptions.map { it.id }.joinToString(" ")
                 }
             )
+        }
+        if (!value.isSet) {
+            warnAboutMissingDatabinding("value", componentName, componentId, domNode)
         }
     }
 

--- a/headless/src/jsMain/kotlin/dev/fritz2/headless/components/tooltip.kt
+++ b/headless/src/jsMain/kotlin/dev/fritz2/headless/components/tooltip.kt
@@ -1,3 +1,5 @@
+package dev.fritz2.headless.components
+
 import dev.fritz2.core.RenderContext
 import dev.fritz2.core.ScopeContext
 import dev.fritz2.core.Tag

--- a/headless/src/jsMain/kotlin/dev/fritz2/headless/foundation/DatabindingProperty.kt
+++ b/headless/src/jsMain/kotlin/dev/fritz2/headless/foundation/DatabindingProperty.kt
@@ -6,8 +6,10 @@ import dev.fritz2.headless.validation.ComponentValidationMessage
 import dev.fritz2.validation.messages
 import dev.fritz2.validation.valid
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.emptyFlow
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.map
+import org.w3c.dom.HTMLElement
 
 /**
  * This property keeps track of the external data-binding of some component.
@@ -43,7 +45,7 @@ class DatabindingProperty<T> : Property<DatabindingProperty.DataBinding<T>>() {
     val id: String?
         get() = value?.id
 
-    val data: Flow<T> by lazy { value!!.data }
+    val data: Flow<T> by lazy { value?.data ?: emptyFlow() }
 
     val handler: ((Flow<T>) -> Unit)? by lazy { value?.handler }
 
@@ -75,15 +77,15 @@ internal fun warnAboutMissingDatabinding(
     propertyName: String,
     componentName: String,
     componentId: String,
-    fallbackPhrase: String
+    domNode: HTMLElement,
 ) {
     console.warn(
         buildString {
-            append("fritz2: Missing data-binding for `$propertyName` property of $componentName component ")
-            append("with id `$componentId`. Setting $fallbackPhrase as fallback.")
-            appendLine()
-            append("You should really consider to provide some data-binding, as for now you might neither see any ")
-            append("initial data, nor won't be able to access any resulting data.")
-        }
+            appendLine("[fritz2] missing data binding")
+            append("Property '$propertyName' of component '$componentName#$componentId' is required but was not set. ")
+            append("Initializing the property with emptyFlow() instead. ")
+            append("Consider setting the data binding as the component might not work as expected otherwise.")
+        },
+        domNode
     )
 }

--- a/headless/src/jsMain/kotlin/dev/fritz2/headless/foundation/Property.kt
+++ b/headless/src/jsMain/kotlin/dev/fritz2/headless/foundation/Property.kt
@@ -35,7 +35,7 @@ package dev.fritz2.headless.foundation
  *  [use] method.
  */
 abstract class Property<T> {
-    var value: T? = null
+    open var value: T? = null
         protected set
 
     val isSet: Boolean


### PR DESCRIPTION
As explained in #698, default data bindings weren't set in some cases. This PR fixes this issue by adding an `emptyFlow()`  as fallback for the `DatabindingProperty`s `data` property. This prevents the NPE at runtime and makes it still possible to check for an unset data binding inside the headless component itself via the `isSet` property.

All components affected by this issue now check for the unset data binding and write a warning in the browser console in case it was not set. The warning now also contains the components actual DOM node for convenience, since Firefox and Chrome make it possible to jump to the element inside the UI by clicking on the object in the warning. This should make it easier to spot the component with the unset data binding.

The PR also fixes an issue with the `tooltip`, the source file had no package specified and was not part of the `dev.fritz2.headless.components` namespace.