### PR TITLE
Improve handling of nullable values in Stores

### DIFF
--- a/core/src/commonMain/kotlin/dev/fritz2/core/lens.kt
+++ b/core/src/commonMain/kotlin/dev/fritz2/core/lens.kt
@@ -86,7 +86,9 @@ typealias IdProvider<T, I> = (T) -> I
 /**
  * Occurs when [Lens] points to non-existing element.
  */
-class CollectionLensGetException : Exception() // is needed to cancel the coroutine correctly/**
+class CollectionLensGetException : Exception() // is needed to cancel the coroutine correctly
+
+/**
  * Occurs when [Lens] tries to update a non-existing element.
  */
 class CollectionLensSetException(message: String) : Exception(message)

--- a/core/src/commonMain/kotlin/dev/fritz2/core/lens.kt
+++ b/core/src/commonMain/kotlin/dev/fritz2/core/lens.kt
@@ -86,9 +86,7 @@ typealias IdProvider<T, I> = (T) -> I
 /**
  * Occurs when [Lens] points to non-existing element.
  */
-class CollectionLensGetException : Exception() // is needed to cancel the coroutine correctly
-
-/**
+class CollectionLensGetException : Exception() // is needed to cancel the coroutine correctly/**
  * Occurs when [Lens] tries to update a non-existing element.
  */
 class CollectionLensSetException(message: String) : Exception(message)
@@ -150,5 +148,35 @@ fun <K, V> lensOf(key: K): Lens<Map<K, V>, V> = object : Lens<Map<K, V>, V> {
     override fun set(parent: Map<K, V>, value: V): Map<K, V> =
         if (parent.containsKey(key)) parent + (key to value)
         else throw CollectionLensSetException("no item found with key='$key'")
+}
 
+/**
+ * For a lens on a non-nullable parent this method creates a lens that can be used on a nullable-parent
+ * Use this method only if you made sure, that it is never called on a null parent.
+ * Otherwise, a [NullPointerException] is thrown.
+ */
+fun <P, T> Lens<P, T>.toNullableLens(): Lens<P?, T> = object : Lens<P?, T> {
+    private val lens = this@toNullableLens
+    override val id: String = lens.id
+
+    override fun get(parent: P?): T =
+        if (parent != null) lens.get(parent)
+        else throw NullPointerException("get called with null parent on not-nullable lens@$id")
+
+    override fun set(parent: P?, value: T): P? =
+        if (parent != null) lens.set(parent, value)
+        else throw NullPointerException("set called with null parent on not-nullable lens@$id")
+}
+
+/**
+ * Creates a lens from a nullable parent to a non-nullable value using a given default-value.
+ * Use this method to apply a default value that will be used in the case that the real value is null.
+ * When setting that value to the default value it will accordingly translate to null.
+ *
+ * @param default value to be used instead of null
+ */
+fun <T> defaultLens(id: String, default: T): Lens<T?, T> = object : Lens<T?, T> {
+    override val id: String = id
+    override fun get(parent: T?): T = parent  ?: default
+    override fun set(parent: T?, value: T): T?  = value.takeUnless { it == default }
 }

--- a/core/src/commonTest/kotlin/dev/fritz2/core/lens.kt
+++ b/core/src/commonTest/kotlin/dev/fritz2/core/lens.kt
@@ -61,4 +61,38 @@ class LensesTests {
         }
     }
 
+    @Test
+    fun testDefaultLens() {
+        val defaultValue = "fritz2"
+        val nonNullValue = "some value"
+        val defaultLens = defaultLens("", defaultValue)
+
+        assertEquals(defaultValue, defaultLens.get(null), "default value not applied on null")
+        assertEquals(nonNullValue, defaultLens.get(nonNullValue), "wrong value on not-null")
+
+        assertEquals(nonNullValue, defaultLens.set(null, nonNullValue), "value not set on null")
+        assertEquals(nonNullValue, defaultLens.set("old Value", nonNullValue), "value not set on null")
+        assertEquals(null, defaultLens.set(nonNullValue, defaultValue), "not set to null on default")
+    }
+
+    @Test
+    fun testNotNullLens() {
+        data class PostalAddress(val street: String, val co: String?)
+
+        val streetLens = lens("street", PostalAddress::street) { p, v -> p.copy(street = v) }
+        val someStreet = "some street"
+        val newValue = "new value"
+        val someCo = "some co"
+
+        val addressWithCo = PostalAddress(someStreet, someCo)
+
+        val notNullLens: Lens<PostalAddress?, String> = streetLens.toNullableLens()
+
+        assertEquals(someStreet, notNullLens.get(addressWithCo), "not null lens does get value on non null parent")
+        assertFailsWith(NullPointerException::class, "not null lens does not throw exception when get on null parent") { notNullLens.get(null) }
+
+        assertEquals(newValue, notNullLens.set(addressWithCo, newValue)?.street, "not null lens does set value on non null parent")
+        assertFailsWith(NullPointerException::class, "not null lens does not throw exception when set on null parent") { notNullLens.set(null, newValue)?.street }
+    }
+
 }

--- a/core/src/jsMain/kotlin/dev/fritz2/core/store.kt
+++ b/core/src/jsMain/kotlin/dev/fritz2/core/store.kt
@@ -175,15 +175,3 @@ open class RootStore<D>(
  * @param id id of this store. Ids of [SubStore]s will be concatenated.
  */
 fun <D> storeOf(initialData: D, id: String = Id.next()) = RootStore(initialData, id)
-
-/**
- * on a [Store] of nullable data this creates a [SubStore] with a nullable parent and non-nullable value.
- * It can be called using a [Lens] on a non-nullable parent (that can be created by using the @Lenses-annotation),
- * but you have to provide a default value. When updating the value of the resulting [SubStore] to this default value,
- * null is used instead updating the parent. When this [SubStore]'s value would be null according to it's parent's
- * value, the default value will be used insteal.
- *
- * @param lens [Lens] to use to create the [SubStore]
- * @param default value to translate null to and from
- */
-fun <T> Store<T?>.orDefault(default: T): SubStore<T?, T> = sub(defaultLens(this.id, default))

--- a/core/src/jsMain/kotlin/dev/fritz2/core/store.kt
+++ b/core/src/jsMain/kotlin/dev/fritz2/core/store.kt
@@ -175,3 +175,15 @@ open class RootStore<D>(
  * @param id id of this store. Ids of [SubStore]s will be concatenated.
  */
 fun <D> storeOf(initialData: D, id: String = Id.next()) = RootStore(initialData, id)
+
+/**
+ * on a [Store] of nullable data this creates a [SubStore] with a nullable parent and non-nullable value.
+ * It can be called using a [Lens] on a non-nullable parent (that can be created by using the @Lenses-annotation),
+ * but you have to provide a default value. When updating the value of the resulting [SubStore] to this default value,
+ * null is used instead updating the parent. When this [SubStore]'s value would be null according to it's parent's
+ * value, the default value will be used insteal.
+ *
+ * @param lens [Lens] to use to create the [SubStore]
+ * @param default value to translate null to and from
+ */
+fun <T> Store<T?>.orDefault(default: T): SubStore<T?, T> = sub(defaultLens(this.id, default))

--- a/core/src/jsMain/kotlin/dev/fritz2/core/substores.kt
+++ b/core/src/jsMain/kotlin/dev/fritz2/core/substores.kt
@@ -94,3 +94,13 @@ fun <K, V> Store<Map<K, V>>.sub(key: K): SubStore<Map<K, V>, V> {
     val lens = lensOf<K, V>(key)
     return SubStore(this, lens)
 }
+/**
+ * on a [Store] of nullable data this creates a [SubStore] with a nullable parent and non-nullable value.
+ * It can be called using a [Lens] on a non-nullable parent (that can be created by using the @Lenses-annotation),
+ * but you have to ensure, that the resulting [SubStore] is never used, when it's parent's value is null.
+ * Otherwise, a [NullPointerException] is thrown.
+ *
+ * @param lens [Lens] to use to create the [SubStore]
+ */
+fun <P, T> Store<P?>.sub(lens: Lens<P & Any,T>): SubStore<P?, T> = sub(lens.toNullableLens())
+

--- a/core/src/jsMain/kotlin/dev/fritz2/core/substores.kt
+++ b/core/src/jsMain/kotlin/dev/fritz2/core/substores.kt
@@ -61,17 +61,14 @@ class SubStore<P, D>(
 
 }
 
-
 /**
  * creates a [SubStore] using a [RootStore] as parent using a given [IdProvider].
  *
  * @param element current instance of the entity to focus on
  * @param id to identify the same entity (i.e. when it's content changed)
  */
-fun <D, I> Store<List<D>>.sub(element: D, id: IdProvider<D, I>): SubStore<List<D>, D> {
-    val lens = lensOf(element, id)
-    return SubStore(this, lens)
-}
+fun <D, I> Store<List<D>>.sub(element: D, id: IdProvider<D, I>): SubStore<List<D>, D> =
+    SubStore(this, lensOf(element, id))
 
 /**
  * creates a [SubStore] using a [RootStore] as parent using the [index] in the list
@@ -79,10 +76,8 @@ fun <D, I> Store<List<D>>.sub(element: D, id: IdProvider<D, I>): SubStore<List<D
  *
  * @param index position in the list to point to
  */
-fun <D> Store<List<D>>.sub(index: Int): SubStore<List<D>, D> {
-    val lens = lensOf<D>(index)
-    return SubStore(this, lens)
-}
+fun <D> Store<List<D>>.sub(index: Int): SubStore<List<D>, D> =
+    SubStore(this, lensOf(index))
 
 /**
  * creates a [SubStore] using a [RootStore] as parent using the [key] in the map
@@ -90,17 +85,26 @@ fun <D> Store<List<D>>.sub(index: Int): SubStore<List<D>, D> {
  *
  * @param key in the map to point to
  */
-fun <K, V> Store<Map<K, V>>.sub(key: K): SubStore<Map<K, V>, V> {
-    val lens = lensOf<K, V>(key)
-    return SubStore(this, lens)
-}
+fun <K, V> Store<Map<K, V>>.sub(key: K): SubStore<Map<K, V>, V> =
+    SubStore(this, lensOf(key))
+
 /**
  * on a [Store] of nullable data this creates a [SubStore] with a nullable parent and non-nullable value.
- * It can be called using a [Lens] on a non-nullable parent (that can be created by using the @Lenses-annotation),
+ * It can be called using a [Lens] on a non-nullable parent (that can be created by using the @[Lenses]-annotation),
  * but you have to ensure, that the resulting [SubStore] is never used, when it's parent's value is null.
  * Otherwise, a [NullPointerException] is thrown.
  *
  * @param lens [Lens] to use to create the [SubStore]
  */
-fun <P, T> Store<P?>.sub(lens: Lens<P & Any,T>): SubStore<P?, T> = sub(lens.toNullableLens())
+fun <P, T> Store<P?>.sub(lens: Lens<P & Any, T>): SubStore<P?, T> = sub(lens.toNullableLens())
 
+/**
+ * on a [Store] of nullable data this creates a [SubStore] with a nullable parent and non-nullable value.
+ * It can be called using a [Lens] on a non-nullable parent (that can be created by using the @[Lenses]-annotation),
+ * but you have to provide a [default] value. When updating the value of the resulting [SubStore] to this [default] value,
+ * null is used instead updating the parent. When this [SubStore]'s value would be null according to it's parent's
+ * value, the [default] value will be used instead.
+ *
+ * @param default value to translate null to and from
+ */
+fun <T> Store<T?>.orDefault(default: T): SubStore<T?, T> = sub(defaultLens(this.id, default))

--- a/core/src/jsTest/kotlin/dev/fritz2/core/nullable.kt.kt
+++ b/core/src/jsTest/kotlin/dev/fritz2/core/nullable.kt.kt
@@ -1,0 +1,267 @@
+package dev.fritz2.core
+
+import dev.fritz2.runTest
+import kotlinx.browser.document
+import kotlinx.coroutines.delay
+import org.w3c.dom.HTMLButtonElement
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+
+class NullableTests {
+    data class Customer(val mail: String?, val name: String)
+
+    private val mailLens: Lens<Customer, String?> = lens("mail", Customer::mail) { p, v -> p.copy(mail = v) }
+
+    private val someName = "some name"
+    private val someMail = "some mail"
+    private val defaultMail = "default mail"
+
+    val customerWithoutMail = Customer(null, someName)
+    val customerWithMail = Customer(someMail, someName)
+
+
+    @Test
+    fun nullableStoreWithDefault() = runTest {
+        val defaultValue = "fritz2"
+        val nonNullValue = "some Value"
+
+        val store = storeOf<String?>(null)
+        val defaultStore = store.orDefault(defaultValue)
+
+        val valueWithDefaultId = Id.next()
+        val valueWithoutDefaultId = Id.next()
+
+        fun renderedValueWithDefault() = document.getElementById(valueWithDefaultId)?.textContent
+        fun renderedValueWithoutDefault() = document.getElementById(valueWithoutDefaultId)?.textContent
+
+        render {
+            p(id = valueWithoutDefaultId) { store.data.renderText() }
+            p(id = valueWithDefaultId) { defaultStore.data.renderText() }
+        }
+
+        delay(100)
+
+        assertEquals("${null}", renderedValueWithoutDefault(), "wrong initial value")
+        assertEquals(defaultValue, renderedValueWithDefault(), "default initially not applied")
+
+        defaultStore.update(nonNullValue)
+        delay(100)
+        assertEquals(nonNullValue, renderedValueWithDefault(), "update does not work")
+
+        defaultStore.update(defaultValue)
+        delay(100)
+        assertEquals("${null}", renderedValueWithoutDefault(), "default not respected on update")
+        assertEquals(defaultValue, renderedValueWithDefault(), "default not respected on update")
+    }
+
+    @Test
+    fun nullableAttributeWithoutDefaultOnNonNullableStore() = runTest {
+        val store = storeOf(customerWithoutMail)
+        val subStore = store.sub(mailLens)
+
+        val valueId = Id.next()
+
+        fun renderedValue() = document.getElementById(valueId)?.textContent
+
+        render {
+            p(id = valueId) { subStore.data.renderText() }
+        }
+
+        delay(100)
+
+        assertEquals("${null}", renderedValue(), "wrong initial value")
+
+        subStore.update(someMail)
+        delay(100)
+        assertEquals(someMail, renderedValue(), "update does not work")
+
+        subStore.update(null)
+        delay(100)
+        assertEquals("${null}", renderedValue(), "update to null does not work")
+    }
+
+
+    @Test
+    fun nullableAttributeWithDefaultOnNonNullableStore() = runTest {
+        val store = storeOf(customerWithoutMail)
+        val subStore = store.sub(mailLens)
+        val subStoreWithDefault = subStore.orDefault(defaultMail)
+
+        val valueId = Id.next()
+        val valueWithDefaultId = Id.next()
+
+        fun renderedValue() = document.getElementById(valueId)?.textContent
+        fun renderedValueWithDefault() = document.getElementById(valueWithDefaultId)?.textContent
+
+        render {
+            p(id = valueId) { subStore.data.renderText() }
+            p(id = valueWithDefaultId) { subStoreWithDefault.data.renderText() }
+        }
+
+        delay(100)
+
+        assertEquals(defaultMail, renderedValueWithDefault(), "wrong initial value with default")
+        assertEquals("${null}", renderedValue(), "wrong initial value")
+
+        subStoreWithDefault.update(someMail)
+        delay(100)
+        assertEquals(someMail, renderedValueWithDefault(), "update does not work with default")
+        assertEquals(someMail, renderedValue(), "update does not work")
+
+        subStoreWithDefault.update(defaultMail)
+        delay(100)
+        assertEquals("${null}", renderedValue(), "update to null does not work")
+        assertEquals(defaultMail, renderedValueWithDefault(), "update to default-value does not work")
+    }
+
+    @Test
+    fun nullableAttributeWithoutDefaultOnNullableStoreWithoutDefault() = runTest {
+        val customerStore = storeOf<Customer?>(null)
+
+        val customerValueId = Id.next()
+        val mailValueId = Id.next()
+        val setMailId = Id.next()
+        val removeMailId = Id.next()
+
+        fun renderedCustomerValue() = document.getElementById(customerValueId)?.textContent
+        fun renderedMailValue() = document.getElementById(mailValueId)?.textContent
+
+        render {
+            p(id = customerValueId) { customerStore.data.renderText() }
+
+            customerStore.data.render {
+                if (it != null) {
+                    val mailStore = customerStore.sub(mailLens)
+                    p(id = mailValueId) { mailStore.data.renderText() }
+
+                    button(id = setMailId) {
+                        clicks handledBy mailStore.handle { someMail }
+                    }
+
+                    button(id = removeMailId) {
+                        clicks handledBy mailStore.handle { null }
+                    }
+                }
+            }
+        }
+
+        delay(100)
+
+        assertEquals("${null}", renderedCustomerValue(), "wrong initial customer value")
+        assertEquals(null, renderedMailValue(), "wrong initial mail value")
+
+        customerStore.update(customerWithMail)
+        delay(100)
+
+        assertEquals("$customerWithMail", renderedCustomerValue(), "wrong customer with mail after update")
+        assertEquals(someMail, renderedMailValue(), "wrong mail value for customer with mail after update")
+
+        customerStore.update(customerWithoutMail)
+        delay(100)
+
+        assertEquals("$customerWithoutMail", renderedCustomerValue(), "wrong customer without mail after update")
+        assertEquals("${null}", renderedMailValue(), "wrong mail value for customer without mail after update")
+
+        val setButton = document.getElementById(setMailId)
+        assertNotNull(setButton, "customer content not rendered although not null")
+        (setButton as HTMLButtonElement).click()
+
+        delay(100)
+
+        assertEquals("$customerWithMail", renderedCustomerValue(), "wrong customer with mail after update")
+        assertEquals(someMail, renderedMailValue(), "wrong mail value for customer with mail after update")
+
+
+        val removeButton = document.getElementById(removeMailId)
+        assertNotNull(removeButton, "customer content not rendered although not null")
+        (removeButton as HTMLButtonElement).click()
+
+        delay(100)
+
+        assertEquals("$customerWithoutMail", renderedCustomerValue(), "wrong customer without mail after remove")
+        assertEquals("${null}", renderedMailValue(), "wrong mail value for customer without mail after remove")
+    }
+
+    @Test
+    fun nullableAttributeWithoutDefaultOnNullableStoreWithDefault() = runTest {
+        val customerStore = storeOf<Customer?>(null)
+
+        val customerValueId = Id.next()
+        val mailValueId = Id.next()
+        val mailValueWithDefaultId = Id.next()
+
+        val setMailId = Id.next()
+        val removeMailId = Id.next()
+
+        fun renderedCustomerValue() = document.getElementById(customerValueId)?.textContent
+        fun renderedMailValue() = document.getElementById(mailValueId)?.textContent
+        fun renderedMailValueWithDefault() = document.getElementById(mailValueWithDefaultId)?.textContent
+
+        render {
+            p(id = customerValueId) { customerStore.data.renderText() }
+
+            customerStore.data.render {
+                if (it != null) {
+                    val mailStore = customerStore.sub(mailLens)
+                    p(id = mailValueId) { mailStore.data.renderText() }
+
+                    val mailStoreWithDefault = mailStore.orDefault(defaultMail)
+                    p(id = mailValueWithDefaultId) { mailStoreWithDefault.data.renderText() }
+
+                    button(id = setMailId) {
+                        clicks handledBy mailStoreWithDefault.handle { someMail }
+                    }
+
+                    button(id = removeMailId) {
+                        clicks handledBy mailStoreWithDefault.handle { defaultMail }
+                    }
+                }
+            }
+        }
+
+        delay(100)
+
+        assertEquals("${null}", renderedCustomerValue(), "wrong initial customer value")
+        assertEquals(null, renderedMailValue(), "wrong initial mail value")
+
+        customerStore.update(customerWithMail)
+        delay(100)
+
+        assertEquals("$customerWithMail", renderedCustomerValue(), "wrong customer with mail after update")
+        assertEquals(someMail, renderedMailValue(), "wrong mail value for customer with mail after update")
+        assertEquals(someMail, renderedMailValueWithDefault(), "wrong mail value with default for customer with mail after update")
+
+        customerStore.update(customerWithoutMail)
+        delay(100)
+
+        assertEquals("$customerWithoutMail", renderedCustomerValue(), "wrong customer without mail after update")
+        assertEquals("${null}", renderedMailValue(), "wrong mail value for customer without mail after update")
+        assertEquals(defaultMail, renderedMailValueWithDefault(), "wrong mail value with default for customer without mail after update")
+
+        val setButton = document.getElementById(setMailId)
+        assertNotNull(setButton, "customer content not rendered although not null")
+        (setButton as HTMLButtonElement).click()
+
+        delay(100)
+
+        assertEquals("$customerWithMail", renderedCustomerValue(), "wrong customer with mail after update")
+        assertEquals(someMail, renderedMailValue(), "wrong mail value for customer with mail after update")
+        assertEquals(someMail, renderedMailValueWithDefault(), "wrong mail value with default for customer with mail after update")
+
+
+        val removeButton = document.getElementById(removeMailId)
+        assertNotNull(removeButton, "customer content not rendered although not null")
+        (removeButton as HTMLButtonElement).click()
+
+        delay(100)
+
+        assertEquals("$customerWithoutMail", renderedCustomerValue(), "wrong customer without mail after remove")
+        assertEquals("${null}", renderedMailValue(), "wrong mail value for customer without mail after remove")
+        assertEquals(defaultMail, renderedMailValueWithDefault(), "wrong mail value with default or customer without mail after remove")
+    }
+
+}
+
+
+

--- a/core/src/jsTest/kotlin/dev/fritz2/core/substores.kt
+++ b/core/src/jsTest/kotlin/dev/fritz2/core/substores.kt
@@ -23,7 +23,7 @@ class SubStoreTests {
 
     @Test
     fun testSubStore() = runTest {
-        
+
         val person = Person("Foo", Address("Bar Street 3", PostalCode(9999)))
         val store = object : RootStore<Person>(person) {}
 
@@ -78,7 +78,7 @@ class SubStoreTests {
 
     @Test
     fun testSubStoreWithFormat() = runTest {
-        
+
         val person = Person("Foo", Address("Bar Street 3", PostalCode(9999)))
         val store = object : RootStore<Person>(person, id = "person") {}
 

--- a/headless-demo/src/jsMain/kotlin/dev/fritz2/headlessdemo/dataCollection.kt
+++ b/headless-demo/src/jsMain/kotlin/dev/fritz2/headlessdemo/dataCollection.kt
@@ -110,10 +110,10 @@ fun RenderContext.dataTableDemo(amount: Int) {
             | sm:rounded overflow-auto focus:outline-none""".trimMargin(),
         id = "dataTable"
     ) {
-//        data(storedPersons.data, Person::id)
+        data(storedPersons.data, Person::id)
 
 //        selection.single(selectionStore)
-//        selection.multi(selectionStore)
+        selection.multi(selectionStore)
 
         filterStore.data handledBy filterByText()
 

--- a/headless-demo/src/jsMain/kotlin/dev/fritz2/headlessdemo/dataCollection.kt
+++ b/headless-demo/src/jsMain/kotlin/dev/fritz2/headlessdemo/dataCollection.kt
@@ -110,10 +110,10 @@ fun RenderContext.dataTableDemo(amount: Int) {
             | sm:rounded overflow-auto focus:outline-none""".trimMargin(),
         id = "dataTable"
     ) {
-        data(storedPersons.data, Person::id)
+//        data(storedPersons.data, Person::id)
 
 //        selection.single(selectionStore)
-        selection.multi(selectionStore)
+//        selection.multi(selectionStore)
 
         filterStore.data handledBy filterByText()
 

--- a/www/src/pages/docs/30_State Management.md
+++ b/www/src/pages/docs/30_State Management.md
@@ -16,7 +16,8 @@ fritz2 heavily depends on flows, introduced by [kotlinx.coroutines](https://gith
 A `Flow` is a time discrete stream of values.
 
 Like a collection, you can use `Flow`s to represent multiple values, but unlike other collections like `List`s, for example,
-the values are retrieved one by one. fritz2 relies on `Flow`s to represent values that change over time and lets you react to them (your data-model for example) .
+the values are retrieved one by one. fritz2 relies on `Flow`s to represent values that change over time and lets you react 
+to them (your data-model for example) .
 
 A `Flow` is built from a source which creates the values. This source could be your model or the events raised by an element,
 for example. On the other end of the `Flow`, a simple function called for each element collects the values one by one.
@@ -275,9 +276,11 @@ By using the ad-hoc `handledBy` function here your store gets not updated after 
 
 ### Handling nullable values in `Store`s
 
-If you have a `Store` with a nullable content, you can use `orDefault` to derive a non-nullable `Store` from it, that transparently translates a `null`-value from its parent `Store` to the given default-value and vice versa.
+If you have a `Store` with a nullable content, you can use `orDefault` to derive a non-nullable `Store` from it,
+that transparently translates a `null`-value from its parent `Store` to the given default-value and vice versa.
 
-In the following case, when you enter some text in the input and remove it again, you will have a value of `null` in your `nameStore`:
+In the following case, when you enter some text in the input and remove it again,
+you will have a value of `null` in your `nameStore`:
 
 ```kotlin
 val nameStore = storeOf<String?>(null)
@@ -292,7 +295,8 @@ render {
 }
 ```
 
-In real world, you will often come across nullable attributes of complex entities. Then you can often call `orDefault` directly on the `SubStore` you create to use with your form elements:
+In real world, you will often come across nullable attributes of complex entities. Then you can often call `orDefault`
+directly on the `SubStore` you create to use with your form elements:
 
 ```kotlin
 @Lenses
@@ -305,7 +309,6 @@ val applicationStore = storeOf(Person(null))
 //...
 
 val nameStore = applicationStore.sub(Person.name()).orDefault("")
-
 ```
 
 ## Connecting stores to each other

--- a/www/src/pages/docs/30_State Management.md
+++ b/www/src/pages/docs/30_State Management.md
@@ -272,6 +272,42 @@ val store = object : RootStore<String>("initial") {
 ```
 By using the ad-hoc `handledBy` function here your store gets not updated after new data arrives.
 
+
+### Handling nullable values in `Store`s
+
+If you have a `Store` with a nullable content, you can use `orDefault` to derive a non-nullable `Store` from it, that transparently translates a `null`-value from its parent `Store` to the given default-value and vice versa.
+
+In the following case, when you enter some text in the input and remove it again, you will have a value of `null` in your `nameStore`:
+
+```kotlin
+val nameStore = storeOf<String?>(null)
+
+render {
+    input {
+        nameStore.orDefault("").also { formStore ->
+            value(formStore.data)
+            changes.values() handledBy formStore.update
+        }
+    }
+}
+```
+
+In real world, you will often come across nullable attributes of complex entities. Then you can often call `orDefault` directly on the `SubStore` you create to use with your form elements:
+
+```kotlin
+@Lenses
+data class Person(val name: String?)
+
+//...
+
+val applicationStore = storeOf(Person(null))
+
+//...
+
+val nameStore = applicationStore.sub(Person.name()).orDefault("")
+
+```
+
 ## Connecting stores to each other
 
 Most real-world applications contain multiple stores which need to be linked to properly react to model changes.
@@ -490,6 +526,8 @@ to see how to set it up.
 This will also help you define a multiplatform project for sharing your model and validation code between
 the browser and backend.
 
+### Destructuring complex Models with `SubStore`s and `Lense`s
+
 Having a `Lens` available which points to some specific property makes it very easy to get a `SubStore` for that
 property from a `Store` of the parent entity:
 
@@ -534,6 +572,34 @@ render {
 
 To keep your code well-structured, it is recommended to implement complex logic at your `RootStore` or inherit it by using interfaces.
 However, the code above is a decent solution for small (convenience-)handlers.
+
+### Calling `sub` on a `Store` with nullable content
+
+To call `sub` on a nullable `Store` only makes sense, when you have checked, that its value is not null:
+
+```kotlin
+@Lenses
+data class Person(val name: String)
+
+//...
+
+val applicationStore = storeOf<Person>(null)
+
+//...
+
+applicationStore.data.render { person ->
+    if (person != null) { // if person is null you would get NullPointerExceptions reading or updating its SubStores
+        val nameStore = customerStore.sub(Person.name())
+        input {
+            value(nameStore.data)
+            changes.values() handledBy nameStore.update
+        }
+    }
+    else {
+        p { + "no customer selected" }
+    }
+}
+```
 
 ## Formatting Values
 


### PR DESCRIPTION
### Handling nullable values in `Store`s

If you have a `Store` with a nullable content, you can use `orDefault` to derive a non-nullable `Store` from it, that transparently translates a `null`-value from its parent `Store` to the given default-value and vice versa.

In the following case, when you enter some text in the input and remove it again, you will have a value of `null` in your `nameStore`:

```kotlin
val nameStore = storeOf<String?>(null)

render {
    input {
        nameStore.orDefault("").also { formStore ->
            value(formStore.data)
            changes.values() handledBy formStore.update
        }
    }
}
```

In real world, you will often come across nullable attributes of complex entities. Then you can often call `orDefault` directly on the `SubStore` you create to use with your form elements: 

```kotlin
@Lenses
data class Person(val name: String?)

//...

val applicationStore = storeOf(Person(null))

//...

val nameStore = applicationStore.sub(Person.name()).orDefault("")

```

### Calling `sub` on a `Store` with nullable content

To call `sub` on a nullable `Store` only makes sense, when you have checked, that its value is not null:

```kotlin
@Lenses
data class Person(val name: String)

//...

val applicationStore = storeOf<Person>(null)

//...

applicationStore.data.render { person ->
    if (person != null) { // if person is null you would get NullPointerExceptions reading or updating its SubStores
        val nameStore = customerStore.sub(Person.name())
        input {
            value(nameStore.data)
            changes.values() handledBy nameStore.update
        }
    }
    else {
        p { + "no customer selected" }
    }
}
```


