### PR TITLE
Simplify `history` feature

### DIFF
--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -1,5 +1,3 @@
-import kotlin.time.seconds
-
 plugins {
     kotlin("multiplatform")
     kotlin("plugin.serialization")
@@ -22,16 +20,16 @@ kotlin {
         // just to have a place to copy it from...
         /*
         runTask {
-            devServer = devServer?.copy(
-                port = 9000,
-                proxy = mapOf(
-                    "/members" to "http://localhost:8080",
-                    "/chat" to mapOf(
+            devServer?.apply {
+                port = 9000
+                proxy?.apply {
+                    put("/members", "http://localhost:8080")
+                    put("/chat", mapOf(
                         "target" to "ws://localhost:8080",
                         "ws" to true
-                    )
-                )
-            )
+                    ))
+                }
+            }
         }
         */
     }

--- a/core/src/jsMain/kotlin/dev/fritz2/history/history.kt
+++ b/core/src/jsMain/kotlin/dev/fritz2/history/history.kt
@@ -21,7 +21,7 @@ fun <T> history(capacity: Int = 0, initialValue: List<T> = emptyList()) =
  * so that each update is automatically stored in history.
  *
  * @receiver [Store] to sync with
- * @param synced should sync with store updates
+ * @param synced if true, the the history will sync with store updates
  * @param capacity max number of entries in history
  * @param initialEntries initial entries in history
  */
@@ -60,7 +60,7 @@ class History<T>(
     val current: List<T> get() = state.value
 
     /**
-     * Push a new [entry] to the history
+     * Pushes a new [entry] to the history
      */
     fun push(entry: T) {
         if(state.value.isEmpty()) state.value = state.value + entry
@@ -70,7 +70,7 @@ class History<T>(
     }
 
     /**
-     * Gets the last entry that has been added
+     * Gets the lastest history-entry that has been added
      * and removes it from the history.
      *
      * @throws [IndexOutOfBoundsException] if called on an empty history.

--- a/core/src/jsMain/kotlin/dev/fritz2/history/history.kt
+++ b/core/src/jsMain/kotlin/dev/fritz2/history/history.kt
@@ -10,11 +10,11 @@ import kotlinx.coroutines.flow.map
 /**
  * factory-method to create a [History]
  *
- * @param maxSize history keeps at most this many last values
+ * @param capacity max number of entries in history
  * @param initialValue initial content of the history
  */
-fun <T> history(maxSize: Int = 0, initialValue: List<T> = emptyList()) =
-    History(maxSize, initialValue)
+fun <T> history(capacity: Int = 0, initialValue: List<T> = emptyList()) =
+    History(capacity, initialValue)
 
 /**
  * factory-method to create a [History] synced with the given [Store],
@@ -22,11 +22,11 @@ fun <T> history(maxSize: Int = 0, initialValue: List<T> = emptyList()) =
  *
  * @receiver [Store] to sync with
  * @param synced should sync with store updates
- * @param maxSize max number of entries in history
+ * @param capacity max number of entries in history
  * @param initialEntries initial entries in history
  */
-fun <D> Store<D>.history(maxSize: Int = 0, initialEntries: List<D> = emptyList(), synced: Boolean = true) =
-    History(maxSize, initialEntries).apply {
+fun <D> Store<D>.history(capacity: Int = 0, initialEntries: List<D> = emptyList(), synced: Boolean = true) =
+    History(capacity, initialEntries).apply {
         if(synced) this@history.data.handledBy { push(it) }
     }
 

--- a/core/src/jsTest/kotlin/dev/fritz2/history/history.kt
+++ b/core/src/jsTest/kotlin/dev/fritz2/history/history.kt
@@ -9,6 +9,7 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.map
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
 
 class HistoryTests {
 
@@ -18,61 +19,62 @@ class HistoryTests {
         val valueId = "value-${Id.next()}"
         val historyId = "history-${Id.next()}"
         val availableId = "available-${Id.next()}"
-        val values = listOf("A", "B", "C", "D")
 
         fun getValue() = document.getElementById(valueId)?.textContent
         fun getHistory() = document.getElementById(historyId)?.textContent
         fun getAvailable() = document.getElementById(availableId)?.textContent?.toBoolean()
 
-        val store = object : RootStore<String>(values[0]) {
-            val hist = history<String>().sync(this)
-
+        val store = object : RootStore<String>("A") {
+            val hist = history()
         }
 
         render {
             div {
                 span(id = valueId) { store.data.renderText() }
-                span(id = historyId) { store.hist.data.map { hist -> hist.joinToString() }.renderText() }
+                span(id = historyId) { store.hist.data.map { it.joinToString() }.renderText() }
                 span(id = availableId) { store.hist.available.asString().renderText() }
             }
         }
 
         delay(100)
-        assertEquals(values[0], getValue())
-        assertEquals("", getHistory())
+        assertEquals("A", getValue())
+        assertEquals("A", getHistory())
         assertEquals(false, getAvailable())
 
-        store.update(values[1])
+        store.update("B")
         delay(100)
-        assertEquals(values[1], getValue())
-        assertEquals(values[0], getHistory())
+        assertEquals("B", getValue())
+        assertEquals("A, B", getHistory())
         assertEquals(true, getAvailable())
 
-        store.update(values[2])
+        store.update("C")
         delay(100)
-        assertEquals(values[2], getValue())
-        assertEquals(values.slice(0..1).reversed().joinToString(), getHistory())
+        assertEquals("C", getValue())
+        assertEquals("A, B, C", getHistory())
+        assertEquals(true, getAvailable())
 
-        store.update(values[3])
+        store.update("D")
         delay(100)
-        assertEquals(values[3], getValue())
-        assertEquals(values.slice(0..2).reversed().joinToString(), getHistory())
-
-        store.update(store.hist.back())
-        delay(100)
-        assertEquals(values[2], getValue())
-        assertEquals(values.slice(0..1).reversed().joinToString(), getHistory())
-
-        assertEquals(store.hist.last(), values[1])
+        assertEquals("D", getValue())
+        assertEquals("A, B, C, D", getHistory())
+        assertEquals(true, getAvailable())
 
         store.update(store.hist.back())
         delay(100)
-        assertEquals(values[1], getValue())
-        assertEquals(values[0], getHistory())
+        assertEquals("C", getValue())
+        assertEquals("A, B, C", getHistory())
+        assertEquals(true, getAvailable())
 
-        store.hist.reset()
+        store.update(store.hist.back())
         delay(100)
-        assertEquals("", getHistory())
+        assertEquals("B", getValue())
+        assertEquals("A, B", getHistory())
+        assertEquals(true, getAvailable())
+
+        store.hist.clear()
+        delay(100)
+        assertEquals("B", getValue())
+        assertEquals("B", getHistory())
         assertEquals(false, getAvailable())
     }
 
@@ -89,14 +91,14 @@ class HistoryTests {
         val histLength = 4
 
         val store = object : RootStore<String>("") {
-            val hist = history<String>(histLength).sync(this)
+            val hist = history(histLength)
 
         }
 
         render {
             div {
                 span(id = valueId) { store.data.renderText() }
-                span(id = historyId) { store.hist.data.map { hist -> hist.joinToString() }.renderText() }
+                span(id = historyId) { store.hist.data.map { it.joinToString() }.renderText() }
             }
         }
 
@@ -111,60 +113,38 @@ class HistoryTests {
         delay(200)
 
         assertEquals(values.last(), getValue())
-        assertEquals(values.takeLast(histLength + 1).reversed().drop(1).joinToString(), getHistory())
+        assertEquals(values.takeLast(histLength + 1).drop(1).joinToString(), getHistory())
+    }
+
+    fun test() {
+        val store = object : RootStore<String>("") {
+            val history = history()
+
+            // your handlers go here (add history.clear() here where suitable)
+
+            val undo = handle {
+                history.back()
+            }
+        }
+
+        render {
+            div("form") {
+                // insert your form here
+
+                button("btn") {
+                    className(store.history.available.map { if (it) "" else "hidden" })
+                    +"Undo"
+                }.clicks handledBy store.undo
+            }
+        }
     }
 
 
     @Test
-    fun testManualHistory() = runTest {
-        
-        val valueId = "value-${Id.next()}"
-        val historyId = "history-${Id.next()}"
-        val values = listOf("A", "B", "C")
-
-        fun getValue() = document.getElementById(valueId)?.textContent
-        fun getHistory() = document.getElementById(historyId)?.textContent
-
-        val histLength = 4
-
-        val store = object : RootStore<String>("") {
-            val hist = history<String>(histLength).sync(this)
-
+    fun testMaxCapacityError() = runTest {
+        assertFailsWith<IllegalArgumentException> {
+            history(4, listOf("a", "b", "c", "d", "e"))
         }
-
-        render {
-            div {
-                span(id = valueId) { store.data.renderText() }
-                span(id = historyId) { store.hist.data.map { hist -> hist.joinToString() }.renderText() }
-            }
-        }
-
-        delay(100)
-        assertEquals("", getValue())
-        assertEquals("", getHistory())
-
-        values.forEach { value ->
-            store.hist.add(value)
-            delay(1)
-        }
-        delay(200)
-
-        assertEquals(values.reversed().joinToString(), getHistory())
-
-        store.update(store.hist.back())
-        delay(100)
-        assertEquals(values[2], getValue())
-        assertEquals(values.slice(0..1).reversed().joinToString(), getHistory())
-
-        store.update(store.hist.back())
-        delay(100)
-        assertEquals(values[1], getValue())
-        assertEquals(values[0], getHistory())
-
-        store.update(store.hist.back())
-        delay(100)
-        assertEquals(values[0], getValue())
-        assertEquals("", getHistory())
     }
 
 

--- a/core/src/jsTest/kotlin/dev/fritz2/history/history.kt
+++ b/core/src/jsTest/kotlin/dev/fritz2/history/history.kt
@@ -116,29 +116,6 @@ class HistoryTests {
         assertEquals(values.takeLast(histLength + 1).drop(1).joinToString(), getHistory())
     }
 
-    fun test() {
-        val store = object : RootStore<String>("") {
-            val history = history()
-
-            // your handlers go here (add history.clear() here where suitable)
-
-            val undo = handle {
-                history.back()
-            }
-        }
-
-        render {
-            div("form") {
-                // insert your form here
-
-                button("btn") {
-                    className(store.history.available.map { if (it) "" else "hidden" })
-                    +"Undo"
-                }.clicks handledBy store.undo
-            }
-        }
-    }
-
 
     @Test
     fun testMaxCapacityError() = runTest {
@@ -146,6 +123,4 @@ class HistoryTests {
             history(4, listOf("a", "b", "c", "d", "e"))
         }
     }
-
-
 }

--- a/headless/build.gradle.kts
+++ b/headless/build.gradle.kts
@@ -17,16 +17,16 @@ kotlin {
         // just to have a place to copy it from...
         /*
         runTask {
-            devServer = devServer?.copy(
-                port = 9000,
-                proxy = mapOf(
-                    "/members" to "http://localhost:8080",
-                    "/chat" to mapOf(
+            devServer?.apply {
+                port = 9000
+                proxy?.apply {
+                    put("/members", "http://localhost:8080")
+                    put("/chat", mapOf(
                         "target" to "ws://localhost:8080",
                         "ws" to true
-                    )
-                )
-            )
+                    ))
+                }
+            }
         }
         */
     }

--- a/www/src/pages/docs/30_State Management.md
+++ b/www/src/pages/docs/30_State Management.md
@@ -339,44 +339,44 @@ fritz2 offers a history service to do so.
 
 ```kotlin
 val store = object : RootStore<String>("") {
-    val history = history<String>().sync(this)
+    val history = history()
 }
 ```
 
-This way you synchronise the history with the updates of your `Store`, so each new value will be added to the history automatically.
+This way you synchronise the history with the updates of your `Store`, 
+so each new value will be added to the history automatically.
 
-Without `sync()`, you have to add new entries to the history manually by calling `history.add(entry)`.
+By calling `history(synced = false)`, you have to add new entries to the history 
+manually by calling `push(entry)` function.
 
-You can access the complete history via its `Flow` as a `List` of entries. For your convenience `history` also offers
+You can access the complete history via its `data` attribute as `Flow<List<T>>` 
+or by using `current` attribute which returns a `List<T>`. For your convenience `history` also offers
 * a `Flow<Boolean>` called `available` representing if entries are available (e.g., to show or hide an undo button)
-* a `last()` method to access the latest entry
 * a `back()` method to get the latest entry and remove it from the history
-* a `reset()` method to clear the history
+* a `clear()` method to clear the history
 
 So for a `Store` with a minimal undo function you just have to write:
-
 ```kotlin
 val store = object : RootStore<String>("") {
-    val history = history<String>().sync(this)
+    val history = history()
 
-    // your handlers go here (add history.reset() here where suitable)
+    // your handlers go here (add history.clear() here where suitable)
 
-    val undo = handle {
-        history.back()
-    }
+    val undo = handle { history.back() }
 }
-
-...
 
 render {
     div("form") {
-        // insert your form here
-
-        button("btn") {
-            className(store.history.available.map { if (it) "" else "hidden" })
-            +"Undo"
-
-            clicks handledBy store.undo
+        input {
+            value(store.data)
+            changes.values() handledBy store.update
+        }
+        store.history.available.render {
+            if(it) {
+                button("btn") {
+                    +"Undo"
+                }.clicks handledBy store.undo
+            }
         }
     }
 }

--- a/www/src/pages/docs/30_State Management.md
+++ b/www/src/pages/docs/30_State Management.md
@@ -343,11 +343,10 @@ val store = object : RootStore<String>("") {
 }
 ```
 
-This way you synchronise the history with the updates of your `Store`, 
+By default you synchronise the history with the updates of your `Store`, 
 so each new value will be added to the history automatically.
 
-By calling `history(synced = false)`, you have to add new entries to the history 
-manually by calling `push(entry)` function.
+Calling `history(synced = false)`, you can control the content of the history by manually adding new entries. Call `push(entry)` to do so.
 
 You can access the complete history via its `data` attribute as `Flow<List<T>>` 
 or by using `current` attribute which returns a `List<T>`. For your convenience `history` also offers
@@ -355,7 +354,7 @@ or by using `current` attribute which returns a `List<T>`. For your convenience 
 * a `back()` method to get the latest entry and remove it from the history
 * a `clear()` method to clear the history
 
-So for a `Store` with a minimal undo function you just have to write:
+For a `Store` with a minimal undo function you just have to write:
 ```kotlin
 val store = object : RootStore<String>("") {
     val history = history()


### PR DESCRIPTION
Simplifying the history feature, which includes the following changes:
* history is synced with `Store` by default
```kotlin
// before
val store = object : RootStore<String>("") {
    val hist = history<String>().sync(this)
}
// now
val store = object : RootStore<String>("") {
    val hist = history() // synced = true
}
```
* renamed `reset()` method to `clear()`
* renamed `add(entry)` method to `push(entry)`
* removed `last()` method, cause with `current: List<T>` every entry is receivable
* changed default `capacity` to `0` (no restriction) instead of `10` entries

fixes #665