### PR TITLE
Exposing `Store` interface  instead of internal `RootStore` and `SubStore`

### DIFF
--- a/core/src/jsMain/kotlin/dev/fritz2/core/substores.kt
+++ b/core/src/jsMain/kotlin/dev/fritz2/core/substores.kt
@@ -6,8 +6,7 @@ import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.map
 
 /**
- * A [Store] that is derived from your [RootStore] or another [SubStore] that represents a part of the data-model of its parent.
- * Use the .sub-factory-method on the parent [Store] to create it.
+ * A [Store] that is derived from a parent [Store] mapping its data in both ways by a given [Lens].
  */
 class SubStore<P, D>(
     val parent: Store<P>,
@@ -37,7 +36,8 @@ class SubStore<P, D>(
         get() = lens.get(parent.current)
 
     /**
-     * Since a [SubStore] is just a view on a [RootStore] holding the real value, it forwards the [Update] to it, using it's [Lens] to transform it.
+     * Since a [SubStore] is just a view on a [parent] [Store] holding the real value,
+     * it forwards the [Update] to it, using it's [Lens] to transform it.
      */
     override suspend fun enqueue(update: Update<D>) {
         parent.enqueue { lens.apply(it, update) }
@@ -49,7 +49,7 @@ class SubStore<P, D>(
     override val update = handle<D> { _, newValue -> newValue }
 
     /**
-     * the current value of the [SubStore] is derived from the data of it's parent using the given [Lens].
+     * the current value of the [Store] is derived from the data of it's parent using the given [Lens].
      */
     override val data: Flow<D> = parent.data.map {
         lens.get(it)
@@ -62,49 +62,49 @@ class SubStore<P, D>(
 }
 
 /**
- * creates a [SubStore] using a [RootStore] as parent using a given [IdProvider].
+ * Creates a new [Store] containing the element for the given [element] and [idProvider] from the original [Store]'s [List].
  *
  * @param element current instance of the entity to focus on
- * @param id to identify the same entity (i.e. when it's content changed)
+ * @param idProvider to identify the same entity (i.e. when it's content changed)
  */
-fun <D, I> Store<List<D>>.sub(element: D, id: IdProvider<D, I>): SubStore<List<D>, D> =
-    SubStore(this, lensOf(element, id))
+fun <D, I> Store<List<D>>.sub(element: D, idProvider: IdProvider<D, I>): Store<D> =
+    SubStore(this, lensOf(element, idProvider))
 
 /**
- * creates a [SubStore] using a [RootStore] as parent using the [index] in the list
- * (do not use this, if you want to manipulate the list itself (add or move elements, filter, etc.).
+ * Creates a new [Store] containing the element for the given [index] from the original [Store]'s [List]
  *
  * @param index position in the list to point to
  */
-fun <D> Store<List<D>>.sub(index: Int): SubStore<List<D>, D> =
+fun <D> Store<List<D>>.sub(index: Int): Store<D> =
     SubStore(this, lensOf(index))
 
 /**
- * creates a [SubStore] using a [RootStore] as parent using the [key] in the map
- * (do not use this, if you want to manipulate the map itself (add or move elements, filter, etc.).
+ * Creates a new [Store] containing the corresponding value for the given [key] from the original [Store]'s [Map].
  *
  * @param key in the map to point to
  */
-fun <K, V> Store<Map<K, V>>.sub(key: K): SubStore<Map<K, V>, V> =
+fun <K, V> Store<Map<K, V>>.sub(key: K): Store<V> =
     SubStore(this, lensOf(key))
 
 /**
- * on a [Store] of nullable data this creates a [SubStore] with a nullable parent and non-nullable value.
+ * on a [Store] of nullable data this creates a [Store] with a nullable parent and non-nullable value.
  * It can be called using a [Lens] on a non-nullable parent (that can be created by using the @[Lenses]-annotation),
- * but you have to ensure, that the resulting [SubStore] is never used, when it's parent's value is null.
+ * but you have to ensure, that the resulting [Store] is never used, when it's parent's value is null.
  * Otherwise, a [NullPointerException] is thrown.
  *
- * @param lens [Lens] to use to create the [SubStore]
+ * @param lens [Lens] to use to create the [Store]
  */
-fun <P, T> Store<P?>.sub(lens: Lens<P & Any, T>): SubStore<P?, T> = sub(lens.toNullableLens())
+fun <P, T> Store<P?>.sub(lens: Lens<P & Any, T>): Store<T> =
+    sub(lens.toNullableLens())
 
 /**
- * on a [Store] of nullable data this creates a [SubStore] with a nullable parent and non-nullable value.
+ * on a [Store] of nullable data this creates a [Store] with a nullable parent and non-nullable value.
  * It can be called using a [Lens] on a non-nullable parent (that can be created by using the @[Lenses]-annotation),
- * but you have to provide a [default] value. When updating the value of the resulting [SubStore] to this [default] value,
- * null is used instead updating the parent. When this [SubStore]'s value would be null according to it's parent's
+ * but you have to provide a [default] value. When updating the value of the resulting [Store] to this [default] value,
+ * null is used instead updating the parent. When this [Store]'s value would be null according to it's parent's
  * value, the [default] value will be used instead.
  *
  * @param default value to translate null to and from
  */
-fun <T> Store<T?>.orDefault(default: T): SubStore<T?, T> = sub(defaultLens(this.id, default))
+fun <T> Store<T?>.orDefault(default: T): Store<T> =
+    sub(defaultLens(this.id, default))

--- a/core/src/jsMain/kotlin/dev/fritz2/routing/routing.kt
+++ b/core/src/jsMain/kotlin/dev/fritz2/routing/routing.kt
@@ -1,7 +1,6 @@
 package dev.fritz2.routing
 
 import dev.fritz2.core.Store
-import dev.fritz2.core.SubStore
 import dev.fritz2.core.Update
 import dev.fritz2.core.lensOf
 import kotlinx.browser.window
@@ -122,12 +121,12 @@ open class MapRouter(defaultRoute: Map<String, String> = emptyMap()) :
     open fun select(key: String, orElse: String): Flow<String> = this.data.map { m -> m[key] ?: orElse }
 
     /**
-     * Selects with the given [key] a [SubStore] of the value.
+     * Creates a new [Store] containing the corresponding value for the given [key].
      *
      * @param key for getting the value from the parameter [Map]
-     * @return [SubStore] of the resulting value
+     * @return [Store] containing the corresponding value
      */
-    open fun sub(key: String): SubStore<Map<String, String>, String> = this.sub(lensOf(key))
+    open fun sub(key: String): Store<String> = this.sub(lensOf(key))
 }
 
 /**

--- a/core/src/jsMain/kotlin/dev/fritz2/validation/validation.kt
+++ b/core/src/jsMain/kotlin/dev/fritz2/validation/validation.kt
@@ -10,7 +10,7 @@ import kotlinx.coroutines.flow.*
 
 
 /**
- * A [ValidatingStore] is a [RootStore] which also contains a [Validation] for its model and by default applies it
+ * A [ValidatingStore] is a [Store] which also contains a [Validation] for its model and by default applies it
  * to every update.
  *
  * This store is intentionally configured to validate the data on each update, that is why the [validateAfterUpdate]
@@ -28,7 +28,7 @@ import kotlinx.coroutines.flow.*
  * @param initialData first current value of this [Store]
  * @param validation [Validation] function to use at the data on this [Store].
  * @param validateAfterUpdate flag to decide if a new value gets automatically validated after setting it to the [Store].
- * @param id id of this [Store]. Ids of [SubStore]s will be concatenated.
+ * @param id id of this [Store]. Ids of parent [Store]s will be concatenated.
  */
 open class ValidatingStore<D, T, M>(
     initialData: D,
@@ -95,7 +95,7 @@ fun <D, T, M> storeOf(
     initialData: D,
     validation: Validation<D, T, M>,
     id: String = Id.next()
-) = ValidatingStore(initialData, validation, true, id)
+): ValidatingStore<D, T, M> = ValidatingStore(initialData, validation, true, id)
 
 /**
  * Finds all corresponding [ValidationMessage]s to this [Store].

--- a/headless-demo/src/jsMain/kotlin/dev/fritz2/headlessdemo/dataCollection.kt
+++ b/headless-demo/src/jsMain/kotlin/dev/fritz2/headlessdemo/dataCollection.kt
@@ -13,7 +13,7 @@ import org.w3c.dom.HTMLButtonElement
 import org.w3c.dom.HTMLDivElement
 import org.w3c.dom.HTMLTableRowElement
 
-fun RenderContext.filterInput(id: String, filterStore: RootStore<String>) {
+fun RenderContext.filterInput(id: String, filterStore: Store<String>) {
     inputField("relative my-4 grow", id) {
         value(filterStore)
         div("absolute inset-y-0 left-0 pl-2.5 flex items-center pointer-events-none") {
@@ -193,7 +193,7 @@ fun RenderContext.dataTableDemo(amount: Int) {
 fun RenderContext.gridListDemo(amount: Int) {
     val persons = FakePersons(amount)
     val storedPersons = storeOf(persons)
-    val selectionStore = object : RootStore<List<Person>>(persons.take(2)) {}
+    val selectionStore = storeOf(persons.take(2))
     val filterStore = storeOf("", id = "gridList-filter")
     val storedFilteredSize = storeOf(0)
 

--- a/headless/src/jsMain/kotlin/dev/fritz2/headless/components/dataCollection.kt
+++ b/headless/src/jsMain/kotlin/dev/fritz2/headless/components/dataCollection.kt
@@ -190,7 +190,7 @@ class DataCollection<T, C : HTMLElement>(tag: Tag<C>) : Tag<C> by tag {
             list.indexOfFirst { id(it) == id(item) }
         } ?: list.indexOf(item)
 
-    private val sorting = object : RootStore<SortingOrder<T>?>(null) {}
+    private val sorting = storeOf<SortingOrder<T>?>(null)
     val sortBy = sorting.update
     val toggleSorting = sorting.handle<Sorting<T>> { old, newSorting ->
         if (old?.sorting == newSorting) {
@@ -205,7 +205,7 @@ class DataCollection<T, C : HTMLElement>(tag: Tag<C>) : Tag<C> by tag {
         }
     }
 
-    private val filtering = object : RootStore<((List<T>) -> List<T>)?>(null) {}
+    private val filtering = storeOf<((List<T>) -> List<T>)?>(null)
     val filterBy = filtering.update
     fun filterByText(toString: (T) -> String = { it.toString() }) = filtering.handle<String> { _, text ->
         { it.filter { toString(it).lowercase().contains(text.lowercase()) } }
@@ -353,7 +353,7 @@ class DataCollection<T, C : HTMLElement>(tag: Tag<C>) : Tag<C> by tag {
             }
         }.shareIn(MainScope() + job, SharingStarted.Eagerly, 1)
 
-        private val activeItem = object : RootStore<Pair<T, Boolean>?>(null) {}
+        private val activeItem = storeOf<Pair<T, Boolean>?>(null)
 
         fun render() {
             attr("tabindex", "0")

--- a/www/src/pages/docs/30_State Management.md
+++ b/www/src/pages/docs/30_State Management.md
@@ -171,7 +171,7 @@ render {
     }
 }
 ```
-Of course, you can also use a `RootStore<T>` with a complex model which contains all data that you need in one place.
+Of course, you can also use a `Store<T>` with a complex model which contains all data that you need in one place.
 
 You can also bind a `Flow` to an attribute:
 ```kotlin
@@ -225,7 +225,7 @@ You can use this handler to conveniently implement _two-way-databinding_ by usin
 of an `input`-`Tag`, for example:
 
 ```kotlin
-val store = storeOf("") // store: RootStore<String>
+val store: Store<String> = storeOf("")
 
 render {
     input {
@@ -295,8 +295,8 @@ render {
 }
 ```
 
-In real world, you will often come across nullable attributes of complex entities. Then you can often call `orDefault`
-directly on the `SubStore` you create to use with your form elements:
+In real world, you will often come across nullable attributes of complex entities. Then you can call `orDefault`
+directly on the `Store` you create to use with your form elements:
 
 ```kotlin
 @Lenses
@@ -498,7 +498,8 @@ fritz2 also offers the method `lens()` for a short-and-sweet-experience:
 val nameLens = lens("name", { it.name }, { person, value -> person.copy(name = value) })
 ```
 
-No magic there. The first parameter sets an id for the `Lens`. When using `Lens`es with `SubStore`s, the `id` will be used to generate a valid html-id representing the path through your model.
+No magic there. The first parameter sets an id for the `Lens`. When using `Lens`es with `Store`s, 
+the `id` will be used to generate a valid HTML `id` representing the path through your model.
 This can be used to identify your elements semantically (for automated ui-tests for example).
 
 If you have deep nested structures or a lot of them, you may want to automate this behavior.
@@ -529,10 +530,10 @@ to see how to set it up.
 This will also help you define a multiplatform project for sharing your model and validation code between
 the browser and backend.
 
-### Destructuring complex Models with `SubStore`s and `Lense`s
+### Destructuring complex Models with child `Store`s and `Lense`s
 
-Having a `Lens` available which points to some specific property makes it very easy to get a `SubStore` for that
-property from a `Store` of the parent entity:
+Having a `Lens` available which points to some specific property makes it very easy to get a `Store` for that
+property from an original `Store` of the parent entity:
 
 ```kotlin
 // given the following nested data classes...
@@ -552,16 +553,16 @@ val personStore = storeOf(Person(Name("first name", "last name"), "more text"))
 val nameStore = personStore.sub(Person.name())
 ```
 
-Now you can use your `nameStore` exactly like any other `Store` to set up _two-way-databinding_, call `sub(...)`
-again to access the properties of `Name`. If a `SubStore` contains a `List`,
-you can of course iterate over it by using `renderEach {}`.
+Now you can use your `nameStore` exactly like any other `Store` to set up _two-way data binding_, call `sub(...)`
+again to access the properties of `Name`. If a `Store` contains a `List`,
+you can of course iterate over it by using `renderEach()`.
 It's fully recursive from here on down to the deepest nested parts of your model.
 
-You can also add `Handler`s to your `SubStore`s by simply calling the `handle`-method:
+You can also add `Handler`s to your `Store`s by simply calling the `handle` method:
 
 ```kotlin
-val booleanSubStore = parentStore.sub(someLens)
-val switch = booleanSubStore.handle { model: Boolean -> 
+val booleanChildStore = parentStore.sub(someLens)
+val switch = booleanChildStore.handle { model: Boolean -> 
     !model
 }
 
@@ -573,7 +574,7 @@ render {
 }
 ````
 
-To keep your code well-structured, it is recommended to implement complex logic at your `RootStore` or inherit it by using interfaces.
+To keep your code well-structured, it is recommended to implement complex logic at your `Store` or inherit it by using interfaces.
 However, the code above is a decent solution for small (convenience-)handlers.
 
 ### Calling `sub` on a `Store` with nullable content
@@ -591,7 +592,7 @@ val applicationStore = storeOf<Person>(null)
 //...
 
 applicationStore.data.render { person ->
-    if (person != null) { // if person is null you would get NullPointerExceptions reading or updating its SubStores
+    if (person != null) { // if person is null you would get NullPointerExceptions reading or updating its Stores
         val nameStore = customerStore.sub(Person.name())
         input {
             value(nameStore.data)
@@ -636,9 +637,9 @@ object Formats {
 }
 ```
 
-When you have created a special `Lens` for your own data type like `Formats.date`, you can then use it to create a new `SubStore`:
+When you have created a special `Lens` for your own data type like `Formats.date`, you can then use it to create a new `Store`:
 concatenate your Lenses before using them in the `sub()` method e.g. `sub(Person.birthday() + Fromat.dateLens)` or
-call the method `sub()` on the `SubStore` of your custom type `P` with your formatting `Lens` e.g `sub(Format.dateLens)`.
+call the method `sub()` on the `Store` of your custom type `P` with your formatting `Lens` e.g `sub(Format.dateLens)`.
 
 Here is the code from the [validation example](https://examples.fritz2.dev/validation/build/distributions/index.html)
 which uses the special `Lens` in the `Formats` object specified above for the `com.soywiz.klock.Date` type:
@@ -659,9 +660,9 @@ input("form-control", id = birthday.id) {
     changes.values() handledBy birthday.update
 }
 ```
-The resulting `SubStore` is a `Store<String>`.
+The resulting store is a `Store<String>`.
 
-You can of course reuse your custom formatting `Lens` for every `SubStore` of the same type (in this case `com.soywiz.klock.Date`).
+You can of course reuse your custom formatting `Lens` for every `Store` of the same type (in this case `com.soywiz.klock.Date`).
 
 ## Improve Rendering
 
@@ -748,21 +749,21 @@ passing an `IdProvider`.
 An `IdProvider` is a function mapping an entity to a unique id of arbitrary type. In this example, we just use the
 `id`-attribute of the `ToDo`.
 
-Then create a `SubStore` for a given entity conveniently by calling `sub(someEntity, properIdProvider)` on
-a `Store<List<*>>`. Of course you can do this yourself by mapping the flows if you work on a `Flow<List<*>>` and
-have no `Store` available or don't want to utilize fritz2's `Lens`es:
+Then create a `Store` for a given entity conveniently by calling `sub(someEntity, properIdProvider)` on
+a `Store<List<T>>`. Of course, you can do this yourself by mapping the flows if you work on a `Flow<List<T>>` and
+have no `Store` available or don't want to utilize `Lens`es:
 
 ```kotlin
 val completed = toDoListStore.data.map { it.find { t -> t.id == toDo.id } ?: false }
 ```
 
-Regardless if you use a `SubStore` or your mapped `Flow`: be aware that in the example above nothing will happen to
+Regardless if you use a `Store` or your mapped `Flow`: be aware that in the example above nothing will happen to
 your DOM, when the text of a `ToDo` changes, but it is still at the same position in the list. fritz2 determines
 that still the same entity (identified by the `IdProvider`) is at the same place in the list and therefore the `li`
 as a whole won't be re-rendered, but just the `class`-attribute (which is mounted to its own mountpoint depending
 on you `completed`-flow). This might be exactly what you want, but it depends on your use-case.
 
-You can easily do two-way-databinding inside `renderEach` using a `SubStore` created for a particular entity as seen
+You can easily do two-way data binding inside `renderEach()` using a `Store` created for a particular entity as seen
 above. This of course only makes sense in combination with an `IdProvider`:
 
 ```kotlin
@@ -785,8 +786,8 @@ fun main() {
 }
 ```
 
-If you need two-way-databinding directly on a `Store`'s `data` without any intermediate operations
-(filters, maps, etc.), call `renderEach(IdProvider)` directly on the `Store`. This will provide the `SubStore` as
+If you need two-way data binding directly on a `Store`'s `data` without any intermediate operations
+(filters, maps, etc.), call `renderEach(IdProvider)` directly on the `Store`. This will provide the `Store` as
 the render-lambda's parameter for each element.
 
 Now you know how to handle all kinds of data and structures in your `Store`s.

--- a/www/src/pages/docs/50_Routing.md
+++ b/www/src/pages/docs/50_Routing.md
@@ -64,7 +64,7 @@ val router = routerOf(mapOf("page" to "welcome", "foo" to "bar"))
 
 render {
     section {
-        // use a SubStore for two-way data-binding
+        // use a child Store for two-way data-binding
         val foo = router.sub("foo")
         foo.update("bars")
 
@@ -90,7 +90,7 @@ and the rest of the route
 * `fun select(key: String, orElse: String): Flow<String>` extracts the value for a given `key` when available otherwise 
 it returns `orElse`
 
-Or as you can see, you can also use the well-known `sub()` function by providing a `key` to get a `SubStore` 
+Or as you can see, you can also use the well-known `sub()` function by providing a `key` to get a new `Store` 
 to render its data and to handle updates.
 
 If you want to use your own special `Route` instead, try this:

--- a/www/src/pages/recipes/Recipes.md.bak
+++ b/www/src/pages/recipes/Recipes.md.bak
@@ -11,7 +11,7 @@ eleventyNavigation:
     classes: "font-bold capitalize"
 ---
 
-## Automatische Syncronisierung
+## Automatische Synchronisierung
 Um bei einem neuen Wert in einen Store automatisch einen bestimmten Handler zu übergeben (Syncronisation), 
 reicht es auf dem `data`-flow ein `drop(1)` aufzurufen, um den `initalData` Wert zu ignorieren.
 ````kotlin

--- a/www/src/pages/recipes/Recipes.md.bak
+++ b/www/src/pages/recipes/Recipes.md.bak
@@ -15,8 +15,8 @@ eleventyNavigation:
 Um bei einem neuen Wert in einen Store automatisch einen bestimmten Handler zu übergeben (Syncronisation), 
 reicht es auf dem `data`-flow ein `drop(1)` aufzurufen, um den `initalData` Wert zu ignorieren.
 ````kotlin
-val storeToSyncFrom: RootStore<A>
-val storeToSyncTo: RootStore<B>
+val storeToSyncFrom: Store<A>
+val storeToSyncTo: Store<B>
         
 storeToSyncFrom.data.drop(1) handledBy storeToSyncTo.handle { b, a ->
     //...


### PR DESCRIPTION
Exposing only the public `Store<T>` type in fritz2's API, instead of the internal types `RootStore` or `SubStore` for simplifying the use of derived stores.
```kotlin
// before
val person: RootStore<Person> = storeOf(Person(...))
val name: SubStore<Person, String> = person.sub(Person.name())

// now
val person: Store<Person> = storeOf(Person(...))
val name: Store<String> = person.sub(Person.name())
```