### PR TITLE
Fix CSS-Example and text

### DIFF
--- a/www/src/pages/docs/20_Render HTML.md
+++ b/www/src/pages/docs/20_Render HTML.md
@@ -188,7 +188,7 @@ render {
 }
 ```
 
-## Working with CSS-Classes or CSS
+## Working with CSS-Classes
 
 The `class` attribute of a `Tag` for working with CSS style-classes is somewhat special. You can set the static values
 of each `Tag` for `class` and `id` by using the optional parameters of its factory function:
@@ -204,26 +204,15 @@ render {
 Use this one-liner to add styling and meaning to your elements by using semantic CSS class-names. Also, it keeps your
 code clean when using CSS frameworks like Bootstrap, Tailwind etc.
 
-The `inlineStyle` function on the other hand can be used to add css to your elements if you don't want to work with classnames:
-
-```kotlin
-render {
-    p {
-        inlineStyle("color: red")
-        +"this is red text"
-    }
-}
-```
-
-To dynamically change the styling of a rendered element, add dynamic css by assigning a `Flow<String>` to
-the `inlineStyle`-attribute (like with any other attribute). 
+To dynamically change the styling of a rendered element, you can add dynamic classes by assigning a `Flow` of strings to
+the `className`-attribute (like with any other attribute).
 
 ```kotlin
 render {
     val enabled = storeOf(true)
 
     div {
-        inlineStyle(enabled.data.map { // you could also use classnames here, just use the className() attribute instead of inlineStyle
+        className(enabled.data.map {
             if (it) "background-color: lightgreen;"
             else "opacity: 0.5; background-color: lightgrey;"
         })
@@ -232,7 +221,7 @@ render {
 }
 ```
 
-fritz2 also lets you manage multiple static classes in a `List<String>` with the `classList`-attribute.
+The same works for `List<String>`s with the `classList`-attribute.
 
 Additionally, you can build a `Map<String, Boolean>` from your model data that enables and disables single classes
 dynamically:
@@ -250,7 +239,16 @@ render {
 }
 ```
 
+fritz2 also offers a function for setting the inline `style` attribute to your elements:
 
+```kotlin
+render {
+    p {
+        inlineStyle("color: red")
+        +"this is red text"
+    }
+}
+```
 
 To set an initial CSS class (or any other attribute) immediately (for example to avoid flicker effects caused by the delay
 of the first value becoming available on the flow), the respective attribute-method must be called twice.
@@ -266,7 +264,7 @@ className(visibility)
 
 ## Scope
 
-fritz2 offers the option to use a `Scope` to add some information to a tag which can then be received by any
+fritz2 offers the possibility to use a `Scope` to add some information to a tag which can then be received by any
 child-tag of the corresponding DOM-subtree and which will not be rendered out by default. The values in the `Scope` are
 only available for tags inside the context of the tag which sets them.
 

--- a/www/src/pages/docs/20_Render HTML.md
+++ b/www/src/pages/docs/20_Render HTML.md
@@ -221,7 +221,7 @@ render {
 }
 ```
 
-The same works for `List<String>`s with the `classList`-attribute.
+fritz2 also lets you manage multiple classes in a `List<String>` or `Flow<List<String>>` with the `classList`-attribute.
 
 Additionally, you can build a `Map<String, Boolean>` from your model data that enables and disables single classes
 dynamically:
@@ -279,7 +279,7 @@ className(visibility)
 
 ## Scope
 
-fritz2 offers the possibility to use a `Scope` to add some information to a tag which can then be received by any
+fritz2 offers the option to use a `Scope` to add some information to a tag which can then be received by any
 child-tag of the corresponding DOM-subtree and which will not be rendered out by default. The values in the `Scope` are
 only available for tags inside the context of the tag which sets them.
 

--- a/www/src/pages/docs/20_Render HTML.md
+++ b/www/src/pages/docs/20_Render HTML.md
@@ -211,10 +211,10 @@ the `className`-attribute (like with any other attribute).
 render {
     val enabled = storeOf(true)
 
-    div {
+    div("common-css-class") {
         className(enabled.data.map {
-            if (it) "background-color: lightgreen;"
-            else "opacity: 0.5; background-color: lightgrey;"
+            if (it) "enabled-css-class"
+            else "disabled-css-class"
         })
         +"Some important content"
     }
@@ -246,6 +246,21 @@ render {
     p {
         inlineStyle("color: red")
         +"this is red text"
+    }
+}
+```
+
+Of course, it is also possible to dynamically style an element by passing a `Flow` of CSS styles into `inlineStyle`:
+```kotlin
+render {
+    val enabled = storeOf(true)
+
+    div {
+        inlineStyle(enabled.data.map {
+            if (it) "background-color: lightgreen;"
+            else "opacity: 0.5; background-color: lightgrey;"
+        })
+        +"Some important content"
     }
 }
 ```

--- a/www/src/pages/docs/20_Render HTML.md
+++ b/www/src/pages/docs/20_Render HTML.md
@@ -188,7 +188,7 @@ render {
 }
 ```
 
-## Working with CSS-Classes
+## Working with CSS-Classes or CSS
 
 The `class` attribute of a `Tag` for working with CSS style-classes is somewhat special. You can set the static values
 of each `Tag` for `class` and `id` by using the optional parameters of its factory function:
@@ -204,15 +204,26 @@ render {
 Use this one-liner to add styling and meaning to your elements by using semantic CSS class-names. Also, it keeps your
 code clean when using CSS frameworks like Bootstrap, Tailwind etc.
 
-To dynamically change the styling of a rendered element, you can add dynamic classes by assigning a `Flow` of strings to
-the `className`-attribute (like with any other attribute).
+The `inlineStyle` function on the other hand can be used to add css to your elements if you don't want to work with classnames:
+
+```kotlin
+render {
+    p {
+        inlineStyle("color: red")
+        +"this is red text"
+    }
+}
+```
+
+To dynamically change the styling of a rendered element, add dynamic css by assigning a `Flow<String>` to
+the `inlineStyle`-attribute (like with any other attribute). 
 
 ```kotlin
 render {
     val enabled = storeOf(true)
 
     div {
-        className(enabled.data.map {
+        inlineStyle(enabled.data.map { // you could also use classnames here, just use the className() attribute instead of inlineStyle
             if (it) "background-color: lightgreen;"
             else "opacity: 0.5; background-color: lightgrey;"
         })
@@ -221,7 +232,7 @@ render {
 }
 ```
 
-The same works for `List<String>`s with the `classList`-attribute.
+fritz2 also lets you manage multiple static classes in a `List<String>` with the `classList`-attribute.
 
 Additionally, you can build a `Map<String, Boolean>` from your model data that enables and disables single classes
 dynamically:
@@ -239,16 +250,7 @@ render {
 }
 ```
 
-fritz2 also offers a function for setting the inline `style` attribute to your elements:
 
-```kotlin
-render {
-    p {
-        inlineStyle("color: red")
-        +"this is red text"
-    }
-}
-```
 
 To set an initial CSS class (or any other attribute) immediately (for example to avoid flicker effects caused by the delay
 of the first value becoming available on the flow), the respective attribute-method must be called twice.
@@ -264,7 +266,7 @@ className(visibility)
 
 ## Scope
 
-fritz2 offers the possibility to use a `Scope` to add some information to a tag which can then be received by any
+fritz2 offers the option to use a `Scope` to add some information to a tag which can then be received by any
 child-tag of the corresponding DOM-subtree and which will not be rendered out by default. The values in the `Scope` are
 only available for tags inside the context of the tag which sets them.
 


### PR DESCRIPTION
- className was used to apply CSS to a tag which does not work, it needs to be inlineStyle, 
- Fixed some text.