### PR TITLE
Add some small improvements to the examples

### DIFF
--- a/examples/routing/src/jsMain/kotlin/dev/fritz2/examples/routing/routing.kt
+++ b/examples/routing/src/jsMain/kotlin/dev/fritz2/examples/routing/routing.kt
@@ -2,6 +2,7 @@ package dev.fritz2.examples.routing
 
 import dev.fritz2.core.*
 import dev.fritz2.routing.routerOf
+import kotlinx.browser.window
 import kotlinx.coroutines.flow.map
 
 object Pages {
@@ -25,7 +26,7 @@ fun main() {
             nav("navbar navbar-expand-lg navbar-light bg-light") {
                 a("navbar-brand") {
                     +"Routing"
-                    href("/")
+                    href(with (window.location) { origin + pathname })
                 }
                 button("navbar-toggler") {
                     attr("data-toggle", "collapse")

--- a/examples/webcomponent/src/jsMain/resources/index.html
+++ b/examples/webcomponent/src/jsMain/resources/index.html
@@ -51,7 +51,7 @@
                 "label": "index.html"
             },
             {
-                "path": "webcomponent/src/jsMain/resources/weathercard.css",
+                "path": "/examples/webcomponent/src/jsMain/resources/weathercard.css",
                 "type": "css",
                 "label": "weathercard.css"
             }

--- a/www/src/pages/examples.njk
+++ b/www/src/pages/examples.njk
@@ -11,39 +11,19 @@ eleventyNavigation:
     icon: color-swatch
     classes: "font-bold capitalize"
 ---
-<div class="text-center px-4 sm:px-6 lg:px-8 py-12 mx-auto max-w-md sm:max-w-3xl lg:max-w-7xl">
-    <div class="grid grid-cols-1 gap-12 sm:grid-cols-2 lg:grid-cols-3">
-    {% for example in examples.internal %}
-        <a href="/examples{{ example.route }}" target="_blank" class="pt-6 bg-gray-800 hover:bg-gray-600 rounded-lg">
-            <div class="flow-root px-6 pb-8">
-                <div class="-mt-10">
-                    <div>
-                          <span class="inline-flex items-center justify-center p-3 bg-gradient-to-r from-bg-start to-bg-end rounded-md shadow-lg">
-                            <span class="h-6 w-6 text-white">
-                                {% heroicon "outline", example.icon %}
-                            </span>
-                          </span>
-                    </div>
-                    <h3 class="mt-5 text-lg font-medium text-white tracking-tight">{{ example.title }}</h3>
-                    <p class="mt-5 text-base text-gray-400">
-                        {{ example.description }}
-                    </p>
-                </div>
-            </div>
-        </a>
-    {% endfor %}
-    </div>
-    <div class="mt-12 grid grid-cols-1 gap-8 sm:grid-cols-2 lg:grid-cols-3">
-        {% for example in examples.external %}
-            <a href="{{ example.route }}" target="_blank" class="pt-6  bg-gray-800 hover:bg-gray-600 rounded-lg">
+<div class="text-center px-4 sm:px-6 lg:px-8 py-12 grow overflow-y-auto overscroll-none">
+    <div class="mx-auto max-w-md sm:max-w-3xl lg:max-w-7xl">
+        <div class="grid grid-cols-1 gap-12 sm:grid-cols-2 lg:grid-cols-3">
+        {% for example in examples.internal %}
+            <a href="/examples{{ example.route }}" target="_blank" class="pt-6 bg-gray-800 hover:bg-gray-700 rounded-lg">
                 <div class="flow-root px-6 pb-8">
                     <div class="-mt-10">
                         <div>
-                          <span class="inline-flex items-center justify-center p-3 bg-gradient-to-r from-bg-start to-bg-end rounded-md shadow-lg">
-                            <span class="h-6 w-6 text-white">
-                                {% heroicon "outline", example.icon %}
-                            </span>
-                          </span>
+                              <span class="inline-flex items-center justify-center p-3 bg-gradient-to-r from-bg-start to-bg-end rounded-md shadow-lg">
+                                <span class="h-6 w-6 text-white">
+                                    {% heroicon "outline", example.icon %}
+                                </span>
+                              </span>
                         </div>
                         <h3 class="mt-5 text-lg font-medium text-white tracking-tight">{{ example.title }}</h3>
                         <p class="mt-5 text-base text-gray-400">
@@ -53,6 +33,28 @@ eleventyNavigation:
                 </div>
             </a>
         {% endfor %}
+        </div>
+        <div class="mt-12 grid grid-cols-1 gap-8 sm:grid-cols-2 lg:grid-cols-3">
+            {% for example in examples.external %}
+                <a href="{{ example.route }}" target="_blank" class="pt-6  bg-gray-800 hover:bg-gray-700 rounded-lg">
+                    <div class="flow-root px-6 pb-8">
+                        <div class="-mt-10">
+                            <div>
+                              <span class="inline-flex items-center justify-center p-3 bg-gradient-to-r from-bg-start to-bg-end rounded-md shadow-lg">
+                                <span class="h-6 w-6 text-white">
+                                    {% heroicon "outline", example.icon %}
+                                </span>
+                              </span>
+                            </div>
+                            <h3 class="mt-5 text-lg font-medium text-white tracking-tight">{{ example.title }}</h3>
+                            <p class="mt-5 text-base text-gray-400">
+                                {{ example.description }}
+                            </p>
+                        </div>
+                    </div>
+                </a>
+            {% endfor %}
+        </div>
     </div>
 </div>
 


### PR DESCRIPTION
This PR contains some small fixes for the examples pages:
- the [overview page](https://next.fritz2.dev/examples) now has a small margin at the bottom and the scrollbar is correctly positioned
- a broken link to a GitHub embedded file was fixed
- a more sensible default URL was added to the first link of the [routing example](https://next.fritz2.dev/examples/routing) (now links to itself instead of the fritz2 homepage