### PR TITLE
Simplify Tracker to use Boolean as state

### DIFF
--- a/core/src/jsTest/kotlin/dev/fritz2/tracking/tracking.kt
+++ b/core/src/jsTest/kotlin/dev/fritz2/tracking/tracking.kt
@@ -27,7 +27,7 @@ class TrackingTests {
             val running = tracker()
 
             val longRunningHandler = handle {
-                running.track(transactionText) {
+                running.track() {
                     delay(600)
                     endValue
                 }

--- a/examples/masterdetail/src/jsMain/kotlin/dev/fritz2/examples/masterdetail/masterdetail.kt
+++ b/examples/masterdetail/src/jsMain/kotlin/dev/fritz2/examples/masterdetail/masterdetail.kt
@@ -52,7 +52,7 @@ object DetailStore : RootStore<Person>(Person()) {
     }
 
     val addOrUpdate = handle { person ->
-        running.track("addOrUpdatePerson") {
+        running.track() {
             delay(1500)
             person.copy(saved = true).also { dirtyPerson ->
                 window.localStorage.setItem("${personPrefix}.${dirtyPerson.id}", Person.serialize(dirtyPerson))


### PR DESCRIPTION
Until now, a tracker could distinguish several different transactions that could be passed as a parameter to the `track` function. This rarely needed functionality can be implemented by using multiple trackers (whose `data` streams can be combined if needed). This can significantly simplify the tracker's implementation. 
Specifying a transaction as a parameter of `track` is no longer possible. Appropriately, no `defaultTransaction` can be defined in the factory either. Likewise, the possibility to get a flow, which checks whether a certain transaction is running, by invoking the `Tracker` is omitted. 

Solves #736
