### PR TITLE
Substitute tailwindcss class with vanilla CSS

### DIFF
--- a/headless/src/jsMain/kotlin/dev/fritz2/headless/components/popOver.kt
+++ b/headless/src/jsMain/kotlin/dev/fritz2/headless/components/popOver.kt
@@ -146,7 +146,7 @@ fun <C : HTMLElement> RenderContext.popOver(
     initialize: PopOver<C>.() -> Unit
 ): Tag<C> {
     addComponentStructureInfo("popOver", this@popOver.scope, this)
-    return tag(this, classes(classes, "relative"), id, scope) {
+    return tag(this, classes(classes, PopUpPanel.POPUP_RELATIVE), id, scope) {
         PopOver(this, id).run {
             initialize(this)
             render()

--- a/headless/src/jsMain/kotlin/dev/fritz2/headless/foundation/PopUpPanel.kt
+++ b/headless/src/jsMain/kotlin/dev/fritz2/headless/foundation/PopUpPanel.kt
@@ -31,9 +31,18 @@ abstract class PopUpPanel<C : HTMLElement>(
         private const val POPUP_HIDDEN_FULL = "fritz2-popup-hidden-full"
         private const val POPUP_VISIBLE_FULL = "fritz2-popup-visible-full"
 
+        /**
+         * Use this class for adding the CSS attribute `position=relative` for a component, that uses [PopUpPanel].
+         * Remember that the referenced tag for the popup will need this, so that the popup can align properly.
+         */
+        const val POPUP_RELATIVE = "fritz2-popup-relative"
+
         init {
             addGlobalStyles(
                 listOf(
+                    """.$POPUP_RELATIVE {
+                        position: relative;
+                    }""".trimIndent(),
                     """.popper[data-popper-reference-hidden] {
                 visibility: hidden;
                 pointer-events: none;


### PR DESCRIPTION
There was a small remnant from the headless development within the popover component factory, that uses the `relative` class from tailwindcss - this is obviously wrong, as fritz2 is totally agnostic of CSS frameworks. So it is replaced now by some custom fritz2 prefixed class, that simply sets the `position=relative` too.

fixes #746