### PR TITLE
Fixes List Index related Bug in Headless DataCollection

### DIFF
--- a/headless/src/jsMain/kotlin/dev/fritz2/headless/components/dataCollection.kt
+++ b/headless/src/jsMain/kotlin/dev/fritz2/headless/components/dataCollection.kt
@@ -370,10 +370,10 @@ class DataCollection<T, C : HTMLElement>(tag: Tag<C>) : Tag<C> by tag {
                     val index = indexOfItem(list, current?.first)
                     keydowns.mapNotNull { event ->
                         when (shortcutOf(event)) {
-                            Keys.ArrowUp -> list[max(index - 1, 0)]
-                            Keys.ArrowDown -> list[min(index + 1, list.size - 1)]
-                            Keys.Home -> list[0]
-                            Keys.End -> list[list.size - 1]
+                            Keys.ArrowUp -> list.getOrNull(max(index - 1, 0))
+                            Keys.ArrowDown -> list.getOrNull(min(index + 1, list.size - 1))
+                            Keys.Home -> list.firstOrNull()
+                            Keys.End -> list.lastOrNull()
                             else -> null
                         }?.let {
                             event.preventDefault()


### PR DESCRIPTION
If some user action emits navigation events for up, down, home or end keys to an empty data-collection, an `IndexError` was thrown. This is now fixed.
