### PR TITLE
inspector based validation

### DIFF
--- a/core/src/commonMain/kotlin/dev/fritz2/validation/validation.kt
+++ b/core/src/commonMain/kotlin/dev/fritz2/validation/validation.kt
@@ -16,6 +16,48 @@ import kotlin.jvm.JvmInline
  * classes in the `commonMain` section of your Kotlin multiplatform project.
  * So you can write the validation logic once and use them on the *JS* and *JVM* side.
  *
+ * For example:
+ * ```kotlin
+ * data class Person(val name: String, val birthday: LocalDate) {
+ *     companion object {
+ *          // define validator inside of its corresponding domain type
+ *          val validate: Validator<Person, LocalDate, SomeMessage> = validation { inspector, today ->
+ *              inspector.map(Person.name()).let { nameInspector ->
+ *                  if(nameInspector.data.isBlank())
+ *                      add(SomeMessage(nameInspector.path, "Name must not be blank"))
+ *              }
+ *              inspector.map(Person.birthday()).let { birthdayInspector ->
+ *                  if(birthdayInspector.data > today!!)
+ *                      add(SomeMessage(birthdayInspector, path, "Birthday must not be in the future"))
+ *              }
+ *          }
+ *     }
+ * }
+ * ```
+ *
+ * You can also compose validators:
+ * ```kotlin
+ * data class Person(val name: String, val birthday: LocalDate) {
+ *      // take from example above!
+ * }
+ *
+ * data class User(val nickname: String, val person: Person) {
+ *      data class UserMetaData(val nicknameRepo: NicknameRepository, val today: LocalDate)
+ *
+ *      companion object {
+ *          val validate: Validator<User, UserMetaData, SomeMessage> = validation { inspector, meta ->
+ *              inspector.map(User.nickname()).let { nicknameInspector ->
+ *                  if(meta!!.nicknameRepo.exists(nicknameInspector.data))
+ *                      add(SomeMessage(nicknameInspector.path, "Nickname is already in use"))
+ *              }
+ *              // use validator of `Person` type by just calling the validator and passing the mapped inspector
+ *              // and of course the appropriate meta-data!
+ *              addAll(Person.validate(inspector.map(User.person()), meta!!.today))
+ *          }
+ *      }
+ * }
+ * ```
+ *
  * @param D data-model to validate
  * @param T metadata which perhaps is needed in validation process
  */

--- a/core/src/commonMain/kotlin/dev/fritz2/validation/validation.kt
+++ b/core/src/commonMain/kotlin/dev/fritz2/validation/validation.kt
@@ -20,8 +20,9 @@ import kotlin.jvm.JvmInline
  * @param T metadata which perhaps is needed in validation process
  */
 @JvmInline
-value class Validation<D, T, M>(private inline val validate: (D, T?) -> List<M>) {
-    operator fun invoke(data: D, metadata: T? = null): List<M> = this.validate(data, metadata)
+value class Validation<D, T, M>(private inline val validate: (Inspector<D>, T?) -> List<M>) {
+    operator fun invoke(inspector: Inspector<D>, metadata: T? = null): List<M> = this.validate(inspector, metadata)
+    operator fun invoke(data: D, metadata: T? = null): List<M> = this.validate(inspectorOf(data), metadata)
 }
 
 /**
@@ -31,7 +32,7 @@ value class Validation<D, T, M>(private inline val validate: (D, T?) -> List<M>)
  */
 fun <D, T, M> validation(validate: MutableList<M>.(Inspector<D>, T?) -> Unit): Validation<D, T, M> =
     Validation { data, metadata ->
-        buildList<M> { validate(inspectorOf(data), metadata) }
+        buildList<M> { validate(data, metadata) }
     }
 
 /**
@@ -41,7 +42,7 @@ fun <D, T, M> validation(validate: MutableList<M>.(Inspector<D>, T?) -> Unit): V
  */
 fun <D, M> validation(validate: MutableList<M>.(Inspector<D>) -> Unit): Validation<D, Unit, M> =
     Validation { data, _ ->
-        buildList<M> { validate(inspectorOf(data)) }
+        buildList<M> { validate(data) }
     }
 
 /**

--- a/core/src/commonTest/kotlin/dev/fritz2/validation/test/validation.kt
+++ b/core/src/commonTest/kotlin/dev/fritz2/validation/test/validation.kt
@@ -2,35 +2,122 @@
 // do not change until it is fixed by Jetbrains
 package dev.fritz2.validation.test
 
+import dev.fritz2.core.Lens
+import dev.fritz2.core.lensOf
+import dev.fritz2.validation.Validation
 import dev.fritz2.validation.ValidationMessage
 import dev.fritz2.validation.validation
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
+class Message(override val path: String, val text: String) : ValidationMessage {
+    override val isError: Boolean = true
+}
+
 data class Car(val name: String, val color: Color) {
     companion object {
-        val validator = validation<Car, Message> { inspector ->
-            if (inspector.data.name.isBlank())
-                add(Message(".name", carNameIsBlank))
+        // We cannot use @Lenses annotation in fritz2.core itself, so we must craft this by hand!
+        val nameLens: Lens<Car, String> = lensOf("name", Car::name) { parent, value -> parent.copy(name = value) }
+        val colorLens: Lens<Car, Color> = lensOf("color", Car::color) { parent, value -> parent.copy(color = value) }
 
-            if (inspector.data.color.r < 0 || inspector.data.color.g < 0 || inspector.data.color.b < 0)
-                add(Message(".color", colorValuesAreTooLow))
-
-            if (inspector.data.color.r > 255 || inspector.data.color.g > 255 || inspector.data.color.b > 255)
-                add(Message(".color", colorValuesAreTooHigh))
+        val validator: Validation<Car, Unit, Message> = validation { inspector ->
+            inspector.map(nameLens).let { nameInspector ->
+                if (nameInspector.data.isBlank())
+                    add(Message(nameInspector.path, carNameIsBlank))
+            }
+            addAll(Color.validator(inspector.map(colorLens)))
         }
     }
 }
 
-data class Color(val r: Int, val g: Int, val b: Int)
+data class Color(val r: Int, val g: Int, val b: Int) {
+    companion object {
+        // We cannot use @Lenses annotation in fritz2.core itself, so we must craft this by hand!
+        val rLens: Lens<Color, Int> = lensOf("r", Color::r) { parent, value -> parent.copy(r = value) }
+        val gLens: Lens<Color, Int> = lensOf("g", Color::g) { parent, value -> parent.copy(g = value) }
+        val bLens: Lens<Color, Int> = lensOf("b", Color::b) { parent, value -> parent.copy(b = value) }
 
-class Message(override val path: String, val text: String) : ValidationMessage {
-    override val isError: Boolean = true
+        val validator: Validation<Color, Unit, Message> = validation { inspector ->
+            listOf(rLens, gLens, bLens).forEach { fieldLens ->
+                inspector.map(fieldLens).let { fieldInspector ->
+                    if (fieldInspector.data < 0) add(Message(fieldInspector.path, colorValuesAreTooLow))
+                    if (fieldInspector.data > 255) add(Message(fieldInspector.path, colorValuesAreTooHigh))
+                }
+            }
+        }
+    }
 }
 
 val carNameIsBlank = "car name can not be blank"
 val colorValuesAreTooLow = "color members are lower then 0"
 val colorValuesAreTooHigh = "color members are greater then 255"
+
+// Would be some type from a dedicated date-library of course!
+data class LocalDate(val year: Int, val month: Int, val day: Int) {
+    operator fun compareTo(other: LocalDate): Int = when {
+        year < other.year -> -1
+        year > other.year -> 1
+        else -> when {
+            month < other.month -> -1
+            month > other.month -> 1
+            else -> when {
+                day < other.day -> -1
+                day > other.day -> 1
+                else -> 0
+            }
+        }
+    }
+}
+
+data class Person(
+    val name: String,
+    val birthday: LocalDate,
+    val address: Address
+) {
+    data class ValidationMetaData(val today: LocalDate, val knownCities: Set<String>)
+
+    companion object {
+        // We cannot use @Lenses annotation in fritz2.core itself, so we must craft this by hand!
+        val nameLens: Lens<Person, String> = lensOf("name", Person::name) { parent, value -> parent.copy(name = value) }
+        val birthdayLens: Lens<Person, LocalDate> =
+            lensOf("birthday", Person::birthday) { parent, value -> parent.copy(birthday = value) }
+        val addressLens: Lens<Person, Address> =
+            lensOf("address", Person::address) { parent, value -> parent.copy(address = value) }
+
+        val validate: Validation<Person, ValidationMetaData, Message> = validation { inspector, meta ->
+            inspector.map(nameLens).let { nameInspector ->
+                if (nameInspector.data.isBlank()) add(Message(nameInspector.path, "Name must not be blank!"))
+            }
+            inspector.map(birthdayLens).let { birthdayInspector ->
+                if (birthdayInspector.data > meta!!.today)
+                    add(Message(birthdayInspector.path, "Birthday must not be in the future!"))
+            }
+            addAll(Address.validate(inspector.map(addressLens), meta!!.knownCities))
+        }
+    }
+}
+
+data class Address(
+    val street: String,
+    val city: String
+) {
+    companion object {
+        // We cannot use @Lenses annotation in fritz2.core itself, so we must craft this by hand!
+        val streetLens: Lens<Address, String> =
+            lensOf("street", Address::street) { parent, value -> parent.copy(street = value) }
+        val cityLens: Lens<Address, String> =
+            lensOf("city", Address::city) { parent, value -> parent.copy(city = value) }
+
+        val validate: Validation<Address, Set<String>, Message> = validation { inspector, cities ->
+            inspector.map(streetLens).let { streetInspector ->
+                if (streetInspector.data.isBlank()) add(Message(streetInspector.path, "Street must not be blank!"))
+            }
+            inspector.map(cityLens).let { cityInspector ->
+                if (!cities!!.contains(cityInspector.data)) add(Message(cityInspector.path, "City does not exist!"))
+            }
+        }
+    }
+}
 
 class ValidationTests {
 
@@ -42,8 +129,62 @@ class ValidationTests {
         val c4 = Car(" ", Color(256, -1, 120))
 
         assertEquals(carNameIsBlank, Car.validator(c1).first().text)
+        assertEquals(".name", Car.validator(c1).first().path)
         assertEquals(colorValuesAreTooLow, Car.validator.invoke(c2).first().text)
+        assertEquals(".color.r", Car.validator.invoke(c2).first().path)
+        assertEquals(".color.g", Car.validator.invoke(c2)[1].path)
+        assertEquals(".color.b", Car.validator.invoke(c2)[2].path)
         assertEquals(colorValuesAreTooHigh, Car.validator(c3).first().text)
         assertEquals(3, Car.validator(c4).size, "number of messages not right")
+    }
+
+    @Test
+    fun canUseComposedValidatorAlone() {
+        val colorWithTooLowR = Color(-1, 42, 42)
+        val colorWithTooLowG = Color(42, -1, 42)
+        val colorWithTooLowB = Color(42, 42, -1)
+
+        val colorWithTooHighR = Color(256, 42, 42)
+        val colorWithTooHighG = Color(42, 256, 42)
+        val colorWithTooHighB = Color(42, 42, 256)
+
+        assertEquals(colorValuesAreTooLow, Color.validator(colorWithTooLowR).first().text)
+        assertEquals(".r", Color.validator(colorWithTooLowR).first().path)
+        assertEquals(colorValuesAreTooLow, Color.validator(colorWithTooLowG).first().text)
+        assertEquals(".g", Color.validator(colorWithTooLowG).first().path)
+        assertEquals(colorValuesAreTooLow, Color.validator(colorWithTooLowB).first().text)
+        assertEquals(".b", Color.validator(colorWithTooLowB).first().path)
+
+        assertEquals(colorValuesAreTooHigh, Color.validator(colorWithTooHighR).first().text)
+        assertEquals(".r", Color.validator(colorWithTooHighR).first().path)
+        assertEquals(colorValuesAreTooHigh, Color.validator(colorWithTooHighG).first().text)
+        assertEquals(".g", Color.validator(colorWithTooHighG).first().path)
+        assertEquals(colorValuesAreTooHigh, Color.validator(colorWithTooHighB).first().text)
+        assertEquals(".b", Color.validator(colorWithTooHighB).first().path)
+    }
+
+    @Test
+    fun canUseMetaDataWithComposedValidation() {
+        val fritz = Person(
+            "", // must not be empty!
+            LocalDate(1712, 1, 24),
+            Address("Am Schloss", "Potsdam") // city not in known cities list, see below
+        )
+
+        val errors = Person.validate(
+            fritz,
+            Person.ValidationMetaData(
+                LocalDate(1700, 1, 1), // set "today" into the past
+                setOf("Berlin", "Hamburg", "Braunschweig") // remember: no Potsdam inside
+            )
+        )
+
+        assertEquals(3, errors.size, "Amount of error messages is false!")
+        assertEquals("Name must not be blank!", errors.first().text)
+        assertEquals(".name", errors.first().path)
+        assertEquals("Birthday must not be in the future!", errors[1].text)
+        assertEquals(".birthday", errors[1].path)
+        assertEquals("City does not exist!", errors[2].text)
+        assertEquals(".address.city", errors[2].path)
     }
 }

--- a/core/src/jsMain/kotlin/dev/fritz2/validation/validation.kt
+++ b/core/src/jsMain/kotlin/dev/fritz2/validation/validation.kt
@@ -60,7 +60,7 @@ open class ValidatingStore<D, T, M>(
     /**
      * Validates the given [data] by using the optional [metadata] to update the
      * [messages] list and returning them.
-     * Use this method from inside your [Handler]s to publish
+     * Use this method from inside your [dev.fritz2.core.Handler]s to publish
      * the new state of the validation result via the [messages] flow.
      *
      * @param data data to validate
@@ -99,12 +99,15 @@ fun <D, T, M> storeOf(
 
 /**
  * Finds all corresponding [ValidationMessage]s to this [Store].
+ *
+ * Be aware that the  filtering is based upon the correct usage of [Store.path]'s field. This can be reliably achieved
+ * by using [dev.fritz2.core.Inspector]s and their mappings for creating the correct path values.
  */
 fun <M: ValidationMessage> Store<*>.messages(): Flow<List<M>>? =
     when(this) {
         is ValidatingStore<*, *, *> -> {
             try {
-                this.messages.map { it.unsafeCast<List<M>>().filter { m -> m.path == this.path } }
+                this.messages.map { it.unsafeCast<List<M>>() }
             } catch (e: Exception) { null }
         }
         is SubStore<*, *> -> {
@@ -114,7 +117,7 @@ fun <M: ValidationMessage> Store<*>.messages(): Flow<List<M>>? =
             }
             if(store is ValidatingStore<*, *, *>) {
                 try {
-                    store.messages.map { it.unsafeCast<List<M>>().filter { m -> m.path == this.path } }
+                    store.messages.map { it.unsafeCast<List<M>>().filter { m -> m.path.startsWith(this.path) } }
                 } catch (e: Exception) { null }
             } else null
         }

--- a/core/src/jsTest/kotlin/dev/fritz2/validation/validation.kt
+++ b/core/src/jsTest/kotlin/dev/fritz2/validation/validation.kt
@@ -1,7 +1,6 @@
 package dev.fritz2.validation
 
 import dev.fritz2.core.Id
-import dev.fritz2.core.lensOf
 import dev.fritz2.core.render
 import dev.fritz2.runTest
 import dev.fritz2.validation.test.*
@@ -16,7 +15,7 @@ class ValidationJSTests {
 
     @Test
     fun testValidation() = runTest {
-        
+
         val carName = "ok"
         val c1 = Car("car1", Color(-1, -1, -1))
         val c2 = Car("car2", Color(256, 256, 256))
@@ -54,7 +53,7 @@ class ValidationJSTests {
         delay(100)
 
         assertEquals(c1.name, divData.innerText, "c1: car name has not changed")
-        assertEquals(1, divMessages.childElementCount, "c1: there is not 1 message")
+        assertEquals(3, divMessages.childElementCount, "c1: there is not 3 message")
         assertEquals(
             colorValuesAreTooLow,
             divMessages.firstElementChild?.textContent,
@@ -65,7 +64,7 @@ class ValidationJSTests {
         delay(100)
 
         assertEquals(c2.name, divData.innerText, "c2: car name has changed")
-        assertEquals(1, divMessages.childElementCount, "c2: there is not 1 message")
+        assertEquals(3, divMessages.childElementCount, "c2: there is not 3 message")
         assertEquals(
             colorValuesAreTooHigh,
             divMessages.firstElementChild?.textContent,
@@ -81,46 +80,91 @@ class ValidationJSTests {
 
     @Test
     fun testSubStoreValidation() = runTest {
-        
+
         val store: ValidatingStore<Car, Unit, Message> =
             storeOf(Car("car", Color(120, 120, 120)), Car.validator)
-        val colorLens = lensOf("color", Car::color) { car, color -> car.copy(color = color) }
-        val colorStore = store.map(colorLens)
+        val colorStore = store.map(Car.colorLens)
+        val rColorStore = colorStore.map(Color.rLens)
+        val gColorStore = colorStore.map(Color.gLens)
+        val bColorStore = colorStore.map(Color.bLens)
 
         val idData = "data-${Id.next()}"
-        val idMessages = "messages-${Id.next()}"
+        val idMessagesIntermediateLevel = "messages-${Id.next()}"
+        val idPathIntermediateLevel = "messages-path-${Id.next()}"
+        val idMessagesR = "messages-r-${Id.next()}"
+        val idMessagesG = "messages-g-${Id.next()}"
+        val idMessagesB = "messages-b-${Id.next()}"
 
         render {
             div {
                 div(id = idData) {
                     colorStore.data.map { "${it.r}, ${it.g}, ${it.b}" }.renderText()
                 }
-                div(id = idMessages) {
-                    colorStore.messages<Message>()?.renderEach(Message::text, into = this) {
+                div(id = idMessagesIntermediateLevel) {
+                    colorStore.messages<Message>()?.renderEach(Message::path, into = this) {
                         p {
                             +it.text
+                        }
+                    }
+                }
+                div(id = idPathIntermediateLevel) {
+                    colorStore.messages<Message>()?.map { messages -> messages.all { it.path.startsWith(".color") } }
+                        ?.renderText(into = this)
+                }
+                div(id = idMessagesR) {
+                    rColorStore.messages<Message>()?.renderEach(Message::path, into = this) {
+                        p {
+                            +it.path
+                        }
+                    }
+                }
+                div(id = idMessagesG) {
+                    gColorStore.messages<Message>()?.renderEach(Message::path, into = this) {
+                        p {
+                            +it.path
+                        }
+                    }
+                }
+                div(id = idMessagesB) {
+                    bColorStore.messages<Message>()?.renderEach(Message::path, into = this) {
+                        p {
+                            +it.path
                         }
                     }
                 }
             }
         }
 
+        // Test Intermediate Level (color-Field of Car)
         delay(100)
         val divData = document.getElementById(idData) as HTMLDivElement
-        val divMessages = document.getElementById(idMessages) as HTMLDivElement
+        val divMessagesIntermediateLevel = document.getElementById(idMessagesIntermediateLevel) as HTMLDivElement
+        val divPathIntermediateLevel = document.getElementById(idPathIntermediateLevel) as HTMLDivElement
+        val divMessagesR = document.getElementById(idMessagesR) as HTMLDivElement
+        val divMessagesG = document.getElementById(idMessagesG) as HTMLDivElement
+        val divMessagesB = document.getElementById(idMessagesB) as HTMLDivElement
 
         assertEquals("120, 120, 120", divData.textContent, "initial car color is wrong")
-        assertEquals(0, divMessages.childElementCount, "there are messages")
+        assertEquals(0, divMessagesIntermediateLevel.childElementCount, "there are messages")
 
         store.update(Car("car1", Color(-1, -1, -1)))
         delay(100)
 
-        assertEquals("-1, -1, -1", divData.innerText, "c1: car color has not changed")
-        assertEquals(1, divMessages.childElementCount, "c1: there is not 1 message")
+        assertEquals("-1, -1, -1", divData.textContent, "c1: car color has not changed")
+        assertEquals(3, divMessagesIntermediateLevel.childElementCount, "c1: there is not 3 message")
         assertEquals(
             colorValuesAreTooLow,
-            divMessages.firstElementChild?.textContent,
+            divMessagesIntermediateLevel.firstElementChild?.textContent,
             "c1: there is not a expected message"
         )
+        assertEquals("true", divPathIntermediateLevel.textContent, "paths start not all with .color")
+
+        // Test Leave Nodes (fields of Color)
+        assertEquals(1, divMessagesR.childElementCount, "r-Field error message not present")
+        assertEquals(".color.r", divMessagesR.textContent)
+        assertEquals(1, divMessagesG.childElementCount, "g-Field error message not present")
+        assertEquals(".color.g", divMessagesG.textContent)
+        assertEquals(1, divMessagesB.childElementCount, "b-Field error message not present")
+        assertEquals(".color.b", divMessagesB.textContent)
     }
 }


### PR DESCRIPTION
### Motivation
Real world domain objects are in most cases forms a deep object hierarchy by composing dedicated types in a sensefull way, for example some `Person` consists of fields like `name` or `birthday` but also complex fields like some `Address`, which itself represents some domain aspect with basic fields.

As validation is most of the time tied to its corresponding domain type, the validators mirror the same hierarchy as the domain classes. Thus they must be composable in the same way, the domain types are composed.

This was prior to this PR not supported by the 1.0-RC releases!

### Solution

The API of the `Validation` type changes just a little: The `validate` lambda expression now provides no longer a (domain) type `D`, but an `Inspector<D>`! There are now two `invoke` functions that take as first parameter an `Inspector<D>` and as before just a `D`, which then constructs the inspector itself. So one can use the latter for the (external) call of a validation with the domain object itself and the former for calling a validator from inside another validator!

**Remark:** If you have used the recommended `validation`-factory functions, there will be no API breaking at all, as those already have used the `Inspector<D>`. So it is very unlikely that this change will break existing code!

### Example

The following composition now works:
```kotlin
// if you use the `headless` components, prefer to use the `ComponentValidationMessage` instead of handcrafting your own!
data class Message(override val path: String, val text: String) : ValidationMessage {
    override val isError: Boolean = true
}

@Lenses
data class Person(
    val name: String,
    val birthday: LocalDate,
    val address: Address // integrate complex sub-model, with its own business rules
) {

    data class ValidationMetaData(val today: LocalDate, val knownCities: Set<String>)

    companion object {
        val validate: Validation<Person, ValidationMetaData, Message> = validation { inspector, meta ->
            inspector.map(Person.name()).let { nameInspector ->
                if (nameInspector.data.isBlank()) add(Message(nameInspector.path, "Name must not be blank!"))
            }
            inspector.map(Person.birthday()).let { birthdayInspector ->
                if (birthdayInspector.data > meta!!.today)
                    add(Message(birthdayInspector.path, "Birthday must not be in the future!"))
            }
            // call validator of `Address`-sub-model and pass mapped inspector into it as data source and for
            // creating correct paths!
            // Voilà: Validator Composition achieved!
            addAll(Address.validate(inspector.map(Person.address()), meta!!.knownCities))
        }
    }
}

@Lenses
data class Address(
    val street: String,
    val city: String
) {
    companion object {
        // enforce business rules for the `Address` domain
        val validate: Validation<Address, Set<String>, Message> = validation { inspector, cities ->
            inspector.map(Address.street()).let { streetInspector ->
                if (streetInspector.data.isBlank()) add(Message(streetInspector.path, "Street must not be blank!"))
            }
            inspector.map(Address.city()).let { cityInspector ->
                if (!cities!!.contains(cityInspector.data)) add(Message(cityInspector.path, "City does not exist!"))
            }
        }
    }
}

// and then use those:
val fritz = Person(
    "", // must not be empty!
    LocalDate(1712, 1, 24),
    Address("Am Schloss", "Potsdam") // city not in known cities list, see below
)

val errors = Person.validate(
    fritz,
    Person.ValidationMetaData(
        LocalDate(1700, 1, 1), // set "today" into the past
        setOf("Berlin", "Hamburg", "Braunschweig") // remember: no Potsdam inside
    )
)

// three errors would appear:
// Message(".name", "Name must not be blank!")
// Message(".birthday", "Birthday must not be in the future!")
// Message(".address.city", "City does not exist!")
```

### Migration Guide

If you have used the `Validation.invoke` method directly, then prefer to switch to the dedicated `validation`-factories!
Inside your validation code just remove the `inspectorOf(data)` line, that you hopefully will find and change the name of the parameter to `inspector`.

If you have not used any inspector based validation code, you simple must change the field access in such way:
```kotlin
// inside validation code:
// old
data.someField

// new
inspector.data.someField
```

Also try to replace handcrafted `path` parameters of the `Message` objects by relying on the `inspector` object:
```kotlin
// old
add(SomeMessage(".someField", ...))

// new
add(SomeMessage(inspector.path, ...))
``` 

fixes #760