### PR TITLE
Generate extension functions for Lens-Chaining to enable some fluent-style-API

### DIFF
--- a/lenses-annotation-processor/src/jvmTest/kotlin/dev/fritz2/lens/LensesProcessorTests.kt
+++ b/lenses-annotation-processor/src/jvmTest/kotlin/dev/fritz2/lens/LensesProcessorTests.kt
@@ -86,11 +86,15 @@ class LensesProcessorTests {
                 |    { p, v -> p.copy(bar = v)}
                 |  )
                 |
+                |public fun <PARENT> Lens<PARENT, Foo>.bar(): Lens<PARENT, Int> = this + Foo.bar()
+                |
                 |public fun Foo.Companion.foo(): Lens<Foo, String> = lensOf(
                 |    "foo",
                 |    { it.foo },
                 |    { p, v -> p.copy(foo = v)}
                 |  )
+                |
+                |public fun <PARENT> Lens<PARENT, Foo>.foo(): Lens<PARENT, String> = this + Foo.foo()
                 |
                 |public fun Foo.Companion.fooBar(): Lens<Foo, MyType> = lensOf(
                 |    "fooBar",
@@ -98,11 +102,15 @@ class LensesProcessorTests {
                 |    { p, v -> p.copy(fooBar = v)}
                 |  )
                 |
+                |public fun <PARENT> Lens<PARENT, Foo>.fooBar(): Lens<PARENT, MyType> = this + Foo.fooBar()
+                |
                 |public fun Foo.Companion.baz(): Lens<Foo, MyGenericType<Int>> = lensOf(
                 |    "baz",
                 |    { it.baz },
                 |    { p, v -> p.copy(baz = v)}
                 |  )
+                |
+                |public fun <PARENT> Lens<PARENT, Foo>.baz(): Lens<PARENT, MyGenericType<Int>> = this + Foo.baz()
                 """.trimMargin()
             )
         }
@@ -151,6 +159,8 @@ class LensesProcessorTests {
                 |    { it.bar },
                 |    { p, v -> p.copy(bar = v)}
                 |  )
+                |
+                |public fun <PARENT> Lens<PARENT, Foo>.bar(): Lens<PARENT, Int> = this + Foo.bar()
                 """.trimMargin()
             )
             softly.assertThat(
@@ -169,6 +179,8 @@ class LensesProcessorTests {
                 |    { it.bar },
                 |    { p, v -> p.copy(bar = v)}
                 |  )
+                |
+                |public fun <PARENT> Lens<PARENT, Bar>.bar(): Lens<PARENT, Int> = this + Bar.bar()
                 """.trimMargin()
             )
         }
@@ -210,6 +222,8 @@ class LensesProcessorTests {
                 |    { it.bar },
                 |    { p, v -> p.copy(bar = v)}
                 |  )
+                |
+                |public fun <PARENT> Lens<PARENT, Foo>.bar(): Lens<PARENT, Int> = this + Foo.bar()
                 """.trimMargin()
             )
         }
@@ -331,6 +345,8 @@ class LensesProcessorTests {
                 |    { it.bar },
                 |    { p, v -> p.copy(bar = v)}
                 |  )
+                |
+                |public fun <PARENT> Lens<PARENT, Foo>.bar(): Lens<PARENT, Int> = this + Foo.bar()
                 """.trimMargin()
             )
         }
@@ -376,6 +392,8 @@ class LensesProcessorTests {
                 |    { it.bar },
                 |    { p, v -> p.copy(bar = v)}
                 |  )
+                |
+                |public fun <PARENT, T> Lens<PARENT, Foo<T>>.bar(): Lens<PARENT, T> = this + Foo<T>.bar()
                 """.trimMargin()
             )
             softly.assertThat(
@@ -394,11 +412,16 @@ class LensesProcessorTests {
                 |    { p, v -> p.copy(foo = v)}
                 |  )
                 |
+                |public fun <PARENT, T, E> Lens<PARENT, Bar<T, E>>.foo(): Lens<PARENT, T> = this + Bar<T, E>.foo()
+                |
                 |public fun <T, E> Bar.Companion.fooBar(): Lens<Bar<T, E>, E> = lensOf(
                 |    "fooBar",
                 |    { it.fooBar },
                 |    { p, v -> p.copy(fooBar = v)}
                 |  )
+                |
+                |public fun <PARENT, T, E> Lens<PARENT, Bar<T, E>>.fooBar(): Lens<PARENT, E> = this +
+                |    Bar<T, E>.fooBar()
                 """.trimMargin()
             )
         }
@@ -442,6 +465,8 @@ class LensesProcessorTests {
                 |    { it.item },
                 |    { p, v -> p.copy(item = v)}
                 |  )
+                |
+                |public fun <PARENT, T> Lens<PARENT, Data<T>>.item(): Lens<PARENT, T?> = this + Data<T>.item()
                 """.trimMargin()
             )
         }

--- a/www/src/pages/docs/50_StoreMapping.md
+++ b/www/src/pages/docs/50_StoreMapping.md
@@ -308,11 +308,39 @@ val streetOfPerson = address + street
 
 // apply the combined lens to an example object:
 val person = Person(Address("Lerchenweg"))
-formattedBirthday.get(person) // -> "Lerchenweg"
-formattedBirthday.set("Rosenstraße") // Person(address = Address("Rosenstraße"))
+streetOfPerson.get(person) // -> "Lerchenweg"
+streetOfPerson.set("Rosenstraße") // Person(address = Address("Rosenstraße"))
 ```
 
-This feature is i.a. very useful for formatting values like you will learn about in the next section.
+Let us recap, how this example would work with automatic generated lenses:
+```kotlin
+@Lenses
+data class Address(val street: String) { companion object }
+
+@Lenses
+data class Person(val address: Address) { companion object }
+
+val streetOfPerson = Person.address() + Address.street()
+```
+
+This works, but the syntax is quite cumbersome; especially for deeper nested models!
+
+This is why our automatic `@Lenses`-annotation-processor has a dedicated support for deeper nested models as well and
+creates extension functions for all lenses, so you can *chain* the calls in a fluent way:
+
+```kotlin
+@Lenses
+data class Address(val street: String) { companion object }
+
+@Lenses
+data class Person(val address: Address) { companion object }
+
+val streetOfPerson = Person.address().street()
+```
+This fluent API looks much terser and cleaner compared to the canonical one above. Beware that under the hood nothing
+special happens! The generated code simply uses the `plus` operator the same way you can do so manually.
+
+Combining lenses is i.a. very useful for formatting values like you will learn about in the next section.
 
 ### Formatting Values
 

--- a/www/src/pages/docs/50_StoreMapping.md
+++ b/www/src/pages/docs/50_StoreMapping.md
@@ -312,7 +312,7 @@ streetOfPerson.get(person) // -> "Lerchenweg"
 streetOfPerson.set("Rosenstraße") // Person(address = Address("Rosenstraße"))
 ```
 
-Let us recap, how this example would work with automatic generated lenses:
+Let us recap, how this example would work with automatically generated lenses:
 ```kotlin
 @Lenses
 data class Address(val street: String) { companion object }


### PR DESCRIPTION
In order to make the combination of automatically generated lenses by the `@Lenses`-annotation more user friendly, this PR introduces a new feature: The annotation processor now creates also extension functions to enable the fluently chaining of lenses like this:

With this PR you can use:
`Model.foo().bar()`

instead of

`Model.foo() + Foo.bar()`

For more examples and explanation have a look at the [corresponding section](https://www.fritz2.dev/docs/storemapping/#combining-lenses) of the fritz2 documentation.

fixes #497