### PR TITLE
Validation: Remove explicit nullability from metdata type

### DIFF
--- a/core/src/commonMain/kotlin/dev/fritz2/validation/validation.kt
+++ b/core/src/commonMain/kotlin/dev/fritz2/validation/validation.kt
@@ -5,16 +5,16 @@ import dev.fritz2.core.inspectorOf
 import kotlin.jvm.JvmInline
 
 /**
- * Encapsulates the logic for validating a given data-model and some optional metadata.
+ * Encapsulates the logic for validating a given data-model with metadata.
  *
- * The validation logic itself is expressed by some function that must be passed as [validate] parameter.
- * This function gets the actual model-data [D] and some optional metadata [T] in order to create a [List] of
+ * The validation logic itself is expressed by a function that must be passed as [validate] parameter.
+ * This function takes the actual model-data [D] as well as the metadata [T] in order to create a [List] of
  * validation messages [M]. This value class simply wraps the provided [validate] function in order to make it
  * invocable without any ceremony.
  *
- * It appears to be a good practise, to put the implementation of the passed [validate] function right next to your data
+ * It appears to be a good practice to put the implementation of the passed [validate] function right next to your data
  * classes in the `commonMain` section of your Kotlin multiplatform project.
- * So you can write the validation logic once and use them on the *JS* and *JVM* side.
+ * This way you can write the validation logic once and use them on the *JS* and *JVM* side.
  *
  * For example:
  * ```kotlin
@@ -27,7 +27,7 @@ import kotlin.jvm.JvmInline
  *                      add(SomeMessage(nameInspector.path, "Name must not be blank"))
  *              }
  *              inspector.map(Person.birthday()).let { birthdayInspector ->
- *                  if(birthdayInspector.data > today!!)
+ *                  if(birthdayInspector.data > today)
  *                      add(SomeMessage(birthdayInspector, path, "Birthday must not be in the future"))
  *              }
  *          }
@@ -47,12 +47,12 @@ import kotlin.jvm.JvmInline
  *      companion object {
  *          val validate: Validator<User, UserMetaData, SomeMessage> = validation { inspector, meta ->
  *              inspector.map(User.nickname()).let { nicknameInspector ->
- *                  if(meta!!.nicknameRepo.exists(nicknameInspector.data))
+ *                  if(meta.nicknameRepo.exists(nicknameInspector.data))
  *                      add(SomeMessage(nicknameInspector.path, "Nickname is already in use"))
  *              }
  *              // use validator of `Person` type by just calling the validator and passing the mapped inspector
  *              // and of course the appropriate meta-data!
- *              addAll(Person.validate(inspector.map(User.person()), meta!!.today))
+ *              addAll(Person.validate(inspector.map(User.person()), meta.today))
  *          }
  *      }
  * }

--- a/core/src/commonMain/kotlin/dev/fritz2/validation/validation.kt
+++ b/core/src/commonMain/kotlin/dev/fritz2/validation/validation.kt
@@ -62,9 +62,9 @@ import kotlin.jvm.JvmInline
  * @param T metadata which perhaps is needed in validation process
  */
 @JvmInline
-value class Validation<D, T, M>(private inline val validate: (Inspector<D>, T?) -> List<M>) {
-    operator fun invoke(inspector: Inspector<D>, metadata: T? = null): List<M> = this.validate(inspector, metadata)
-    operator fun invoke(data: D, metadata: T? = null): List<M> = this.validate(inspectorOf(data), metadata)
+value class Validation<D, T, M>(private inline val validate: (Inspector<D>, T) -> List<M>) {
+    operator fun invoke(inspector: Inspector<D>, metadata: T): List<M> = this.validate(inspector, metadata)
+    operator fun invoke(data: D, metadata: T): List<M> = this.validate(inspectorOf(data), metadata)
 }
 
 /**
@@ -72,7 +72,7 @@ value class Validation<D, T, M>(private inline val validate: (Inspector<D>, T?) 
  * [MutableList] receiver and using an [Inspector] for getting the right [Inspector.path] from sub-models
  * next to the [Inspector.data].
  */
-fun <D, T, M> validation(validate: MutableList<M>.(Inspector<D>, T?) -> Unit): Validation<D, T, M> =
+fun <D, T, M> validation(validate: MutableList<M>.(Inspector<D>, T) -> Unit): Validation<D, T, M> =
     Validation { data, metadata ->
         buildList<M> { validate(data, metadata) }
     }

--- a/core/src/commonTest/kotlin/dev/fritz2/validation/test/validation.kt
+++ b/core/src/commonTest/kotlin/dev/fritz2/validation/test/validation.kt
@@ -25,7 +25,7 @@ data class Car(val name: String, val color: Color) {
                 if (nameInspector.data.isBlank())
                     add(Message(nameInspector.path, carNameIsBlank))
             }
-            addAll(Color.validator(inspector.map(colorLens)))
+            addAll(Color.validator(inspector.map(colorLens), Unit))
         }
     }
 }
@@ -128,14 +128,14 @@ class ValidationTests {
         val c3 = Car("car2", Color(256, 256, 256))
         val c4 = Car(" ", Color(256, -1, 120))
 
-        assertEquals(carNameIsBlank, Car.validator(c1).first().text)
-        assertEquals(".name", Car.validator(c1).first().path)
-        assertEquals(colorValuesAreTooLow, Car.validator.invoke(c2).first().text)
-        assertEquals(".color.r", Car.validator.invoke(c2).first().path)
-        assertEquals(".color.g", Car.validator.invoke(c2)[1].path)
-        assertEquals(".color.b", Car.validator.invoke(c2)[2].path)
-        assertEquals(colorValuesAreTooHigh, Car.validator(c3).first().text)
-        assertEquals(3, Car.validator(c4).size, "number of messages not right")
+        assertEquals(carNameIsBlank, Car.validator(c1, Unit).first().text)
+        assertEquals(".name", Car.validator(c1, Unit).first().path)
+        assertEquals(colorValuesAreTooLow, Car.validator.invoke(c2, Unit).first().text)
+        assertEquals(".color.r", Car.validator.invoke(c2, Unit).first().path)
+        assertEquals(".color.g", Car.validator.invoke(c2, Unit)[1].path)
+        assertEquals(".color.b", Car.validator.invoke(c2, Unit)[2].path)
+        assertEquals(colorValuesAreTooHigh, Car.validator(c3, Unit).first().text)
+        assertEquals(3, Car.validator(c4, Unit).size, "number of messages not right")
     }
 
     @Test
@@ -148,19 +148,19 @@ class ValidationTests {
         val colorWithTooHighG = Color(42, 256, 42)
         val colorWithTooHighB = Color(42, 42, 256)
 
-        assertEquals(colorValuesAreTooLow, Color.validator(colorWithTooLowR).first().text)
-        assertEquals(".r", Color.validator(colorWithTooLowR).first().path)
-        assertEquals(colorValuesAreTooLow, Color.validator(colorWithTooLowG).first().text)
-        assertEquals(".g", Color.validator(colorWithTooLowG).first().path)
-        assertEquals(colorValuesAreTooLow, Color.validator(colorWithTooLowB).first().text)
-        assertEquals(".b", Color.validator(colorWithTooLowB).first().path)
+        assertEquals(colorValuesAreTooLow, Color.validator(colorWithTooLowR, Unit).first().text)
+        assertEquals(".r", Color.validator(colorWithTooLowR, Unit).first().path)
+        assertEquals(colorValuesAreTooLow, Color.validator(colorWithTooLowG, Unit).first().text)
+        assertEquals(".g", Color.validator(colorWithTooLowG, Unit).first().path)
+        assertEquals(colorValuesAreTooLow, Color.validator(colorWithTooLowB, Unit).first().text)
+        assertEquals(".b", Color.validator(colorWithTooLowB, Unit).first().path)
 
-        assertEquals(colorValuesAreTooHigh, Color.validator(colorWithTooHighR).first().text)
-        assertEquals(".r", Color.validator(colorWithTooHighR).first().path)
-        assertEquals(colorValuesAreTooHigh, Color.validator(colorWithTooHighG).first().text)
-        assertEquals(".g", Color.validator(colorWithTooHighG).first().path)
-        assertEquals(colorValuesAreTooHigh, Color.validator(colorWithTooHighB).first().text)
-        assertEquals(".b", Color.validator(colorWithTooHighB).first().path)
+        assertEquals(colorValuesAreTooHigh, Color.validator(colorWithTooHighR, Unit).first().text)
+        assertEquals(".r", Color.validator(colorWithTooHighR, Unit).first().path)
+        assertEquals(colorValuesAreTooHigh, Color.validator(colorWithTooHighG, Unit).first().text)
+        assertEquals(".g", Color.validator(colorWithTooHighG, Unit).first().path)
+        assertEquals(colorValuesAreTooHigh, Color.validator(colorWithTooHighB, Unit).first().text)
+        assertEquals(".b", Color.validator(colorWithTooHighB, Unit).first().path)
     }
 
     @Test

--- a/core/src/jsMain/kotlin/dev/fritz2/validation/validation.kt
+++ b/core/src/jsMain/kotlin/dev/fritz2/validation/validation.kt
@@ -66,6 +66,7 @@ open class ValidatingStore<D, T, M>(
 
     /**
      * Validates the given [data] using the given [metadata], updates the [messages] list and returns them.
+     * If no metadata is specified, [metadataDefault] is used.
      *
      * Use this method from inside your [Handler]s to publish
      * the new state of the validation result via the [messages] flow.
@@ -75,23 +76,8 @@ open class ValidatingStore<D, T, M>(
      * @return [List] of messages
      */
     @Suppress("MemberVisibilityCanBePrivate")
-    protected fun validate(data: D, metadata: T): List<M> =
+    protected fun validate(data: D, metadata: T = metadataDefault): List<M> =
         validation(data, metadata).also { validationMessages.value = it }
-
-    /**
-     * Validates the given [data] using the specified [metadataDefault], updates the [messages] list and returns them.
-     *
-     * Use this method from inside your [Handler]s to publish
-     * the new state of the validation result via the [messages] flow.
-     *
-     * Please note: This method is applicable to stores without metadata only
-     * (metadata of type `Unit`).
-     *
-     * @param data data to validate
-     * @return [List] of messages
-     */
-    @Suppress("MemberVisibilityCanBePrivate")
-    protected fun validate(data: D): List<M> = validate(data, metadataDefault)
 
     init {
         if (validateAfterUpdate) data.drop(1) handledBy { newValue ->

--- a/examples/validation/src/jsMain/kotlin/dev/fritz2/examples/validation/validation.kt
+++ b/examples/validation/src/jsMain/kotlin/dev/fritz2/examples/validation/validation.kt
@@ -1,8 +1,7 @@
 package dev.fritz2.examples.validation
 
 import dev.fritz2.core.*
-import dev.fritz2.validation.ValidatingStore
-import dev.fritz2.validation.valid
+import dev.fritz2.validation.*
 import kotlinx.browser.document
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.map
@@ -18,7 +17,7 @@ object PersonListStore : RootStore<List<Person>>(emptyList()) {
 }
 
 object PersonStore : ValidatingStore<Person, Unit, Message>(
-    Person(), personValidator, id = Person.id, validateAfterUpdate = false
+    Person(), personValidator, metadataDefault = Unit, id = Person.id
 ) {
     val save = handle { person ->
         if (validate(person, Unit).valid) {


### PR DESCRIPTION
This PR changes the `Validation`'s metadata type to not be explicitly be nullable. Nullable types are still allowed, however.
The `ValidatingStore` API has been changed accordingly.

> **Important:** PR #761 needs to be merged before this one

## `Validation`

### Before

```kotlin
@JvmInline
value class Validation<D, T, M>(private inline val validate: (Inspector<D>, T?) -> List<M>) {
    operator fun invoke(inspector: Inspector<D>, metadata: T? = null): List<M> = this.validate(inspector, metadata)
    operator fun invoke(data: D, metadata: T? = null): List<M> = this.validate(inspectorOf(data), metadata)
}
```

### Now

```kotlin
@JvmInline
value class Validation<D, T, M>(private inline val validate: (Inspector<D>, T) -> List<M>) {
//                                                                         ^^^
//                                                  Metadata type is no longer explicitly nullable.
//                                                  Thus, it must always be specified.
//
    operator fun invoke(inspector: Inspector<D>, metadata: T): List<M> = this.validate(inspector, metadata)
    operator fun invoke(data: D, metadata: T): List<M> = this.validate(inspectorOf(data), metadata)
}
```

## `ValidatingStore`

### Before

```kotlin
open class ValidatingStore<D, T, M>(
    initialData: D,
    private val validation: Validation<D, T, M>,
    val validateAfterUpdate: Boolean = true,
    override val id: String = Id.next()
) : RootStore<D>(initialData, id) {
    // ...
   
   protected fun validate(data: D, metadata: T? = null): List<M> = /* ... */
}
```

### Now

```kotlin
open class ValidatingStore<D, T, M>(
    initialData: D,
    private val validation: Validation<D, T, M>,
    private val metadataDefault: T,
//  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
//  New parameter `metadataDefault`: Since the metadata must now be present at
//  all times, a default value needs to bespecified for the automatic validation
//  to work. During manual validation (via `validate(..)`), the metadata can still
//  be passed in as before.
    private val validateAfterUpdate: Boolean = true,
    override val id: String = Id.next()
) : RootStore<D>(initialData, id) {
    // ...
   
   protected fun validate(data: D, metadata: T): List<M> = /* ... */
//                                 ^^^^^^^^^^^
//                                 Metadata now has to be specified at all times
}
```

Additionally, the convenience factory `storeOf(...)` has been overloaded so `ValidatingStore<D, Unit, M>`s can be created without the need to specify `Unit` as the default metadata value manually.


## Migration

- `Validation<D, T, M>.invoke(...)` now always requires metadata to be present. Add the missing metadata if necessary.
- The `Validation<D, T, M>` constructor now requires the paramer `metadataDefault` to be present. Add the missing metadats default if necessary.

---

Closes #759 