### PR TITLE
Fix navigation issue in `Router`

### DIFF
--- a/core/src/jsMain/kotlin/dev/fritz2/routing/routing.kt
+++ b/core/src/jsMain/kotlin/dev/fritz2/routing/routing.kt
@@ -80,15 +80,16 @@ open class Router<T>(
     }
 
     init {
-        if (window.location.hash.isBlank()) {
-            window.location.hash = prefix + defaultRoute.serialize(defaultRoute.default)
-        } else {
+        if (window.location.hash.removePrefix(prefix).isNotBlank()) {
             state.value = defaultRoute.deserialize(window.location.hash.removePrefix(prefix))
         }
-
         val listener: (Event) -> Unit = {
             it.preventDefault()
-            state.value = defaultRoute.deserialize(window.location.hash.removePrefix(prefix))
+            if (window.location.hash.removePrefix(prefix).isNotBlank()) {
+                state.value = defaultRoute.deserialize(window.location.hash.removePrefix(prefix))
+            } else {
+                state.value = defaultRoute.default
+            }
         }
         window.addEventListener("hashchange", listener)
     }

--- a/core/src/jsTest/kotlin/dev/fritz2/routing/routing.kt
+++ b/core/src/jsTest/kotlin/dev/fritz2/routing/routing.kt
@@ -172,4 +172,49 @@ class RoutingTests {
 
         assertEquals("abc 123", divElement().textContent, "expected second page")
     }
+
+    @Test
+    fun testHashChangeViaJSInRouter() = runTest {
+
+        window.location.hash = ""
+
+        val router = routerOf(mapOf("page" to "a"))
+        val divId = "div-${Id.next()}"
+
+        render {
+            router.data.render { route ->
+                when(route["page"]) {
+                    "a" -> div(id = divId) {
+                        +"a"
+                    }
+                    "b" -> div(id = divId) {
+                        +"b"
+                    }
+                    else -> div(id = divId) {
+                        +"404"
+                    }
+                }
+            }
+        }
+        fun divElement() = document.getElementById(divId) as HTMLDivElement
+
+        delay(250)
+        assertEquals("a", divElement().textContent, "expected default page")
+
+        window.location.hash = "#page=b"
+        delay(250)
+        assertEquals("b", divElement().textContent, "expected second page")
+
+        window.location.hash = "#page=awdfaw"
+        delay(250)
+        assertEquals("404", divElement().textContent, "expected 404 page")
+
+        window.location.hash = "#unknown=awdawd"
+        delay(250)
+        assertEquals("404", divElement().textContent, "expected 404 page")
+
+        window.location.hash = ""
+        delay(250)
+        assertEquals("a", divElement().textContent, "expected default page again")
+    }
 }


### PR DESCRIPTION
This PR fixes an issue in `Router` class where on page load the default route is used when no `window.location.hash` is set in the URL. This is not correct in cases where later on the `window.location.hash` gets cleared via JS. In this cases the router does not navigate automatically to the default route, which is not consistent.