### PR TITLE
Adds convenience execution functions for Unit metadata in validators

### DIFF
--- a/core/src/commonMain/kotlin/dev/fritz2/validation/validation.kt
+++ b/core/src/commonMain/kotlin/dev/fritz2/validation/validation.kt
@@ -68,6 +68,22 @@ value class Validation<D, T, M>(private inline val validate: (Inspector<D>, T) -
 }
 
 /**
+ * Convenience execution function for [Validation] for the case, that the metadata is `Unit`.
+ * In those cases the metadata parameter can be omitted.
+ *
+ * @param inspector The [Inspector] of type [D] that should be used for the validation process
+ */
+operator fun <D, M> Validation<D, Unit, M>.invoke(inspector: Inspector<D>): List<M> = this(inspector, Unit)
+
+/**
+ * Convenience execution function for [Validation] for the case, that the metadata is `Unit`.
+ * In those cases the metadata parameter can be omitted.
+ *
+ * @param data The data of type [D] that should be used for the validation process
+ */
+operator fun <D, M> Validation<D, Unit, M>.invoke(data: D): List<M> = this(data, Unit)
+
+/**
  * Convenience function for creating a [Validation] instance accepting model- and metadata by working on a
  * [MutableList] receiver and using an [Inspector] for getting the right [Inspector.path] from sub-models
  * next to the [Inspector.data].

--- a/core/src/commonTest/kotlin/dev/fritz2/validation/test/validation.kt
+++ b/core/src/commonTest/kotlin/dev/fritz2/validation/test/validation.kt
@@ -3,9 +3,11 @@
 package dev.fritz2.validation.test
 
 import dev.fritz2.core.Lens
+import dev.fritz2.core.inspectorOf
 import dev.fritz2.core.lensOf
 import dev.fritz2.validation.Validation
 import dev.fritz2.validation.ValidationMessage
+import dev.fritz2.validation.invoke
 import dev.fritz2.validation.validation
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -89,10 +91,10 @@ data class Person(
                 if (nameInspector.data.isBlank()) add(Message(nameInspector.path, "Name must not be blank!"))
             }
             inspector.map(birthdayLens).let { birthdayInspector ->
-                if (birthdayInspector.data > meta!!.today)
+                if (birthdayInspector.data > meta.today)
                     add(Message(birthdayInspector.path, "Birthday must not be in the future!"))
             }
-            addAll(Address.validate(inspector.map(addressLens), meta!!.knownCities))
+            addAll(Address.validate(inspector.map(addressLens), meta.knownCities))
         }
     }
 }
@@ -113,7 +115,7 @@ data class Address(
                 if (streetInspector.data.isBlank()) add(Message(streetInspector.path, "Street must not be blank!"))
             }
             inspector.map(cityLens).let { cityInspector ->
-                if (!cities!!.contains(cityInspector.data)) add(Message(cityInspector.path, "City does not exist!"))
+                if (!cities.contains(cityInspector.data)) add(Message(cityInspector.path, "City does not exist!"))
             }
         }
     }
@@ -186,5 +188,11 @@ class ValidationTests {
         assertEquals(".birthday", errors[1].path)
         assertEquals("City does not exist!", errors[2].text)
         assertEquals(".address.city", errors[2].path)
+    }
+
+    @Test
+    fun canOmitMetadataInCaseOfUnitType() {
+        assertEquals(colorValuesAreTooLow, Color.validator(Color(-1, 42 , 42)).first().text)
+        assertEquals(colorValuesAreTooLow, Color.validator(inspectorOf(Color(-1, 42 , 42))).first().text)
     }
 }


### PR DESCRIPTION
For convenience reasons it is now possible to call a validator with metadata type `Unit`without the metadata parameter.

Imagine a `Validator`of type `Validator<SomeDomain, Unit, SomeMessage>`:
```kotlin
data class SomeDomain(...) {
    companion object {
        val validator: Validator<SomeDomain, Unit, SomeMessage> = validation { inspector -> ... }
        //                                   ^^^^
        //                                   no "real" metadata needed
    }
}
val myData: SomeDomain = ...

// now invoke the execution process...

// old
SomeDomain.validator(myData, Unit) // need to pass `Unit`!

// new
SomeDomain.validator(myData) // can omit `Unit`
```
