### PR TITLE
Fixes an issue with overlapping validation messages of mapped stores


### DIFF
--- a/core/src/commonTest/kotlin/dev/fritz2/validation/test/validation.kt
+++ b/core/src/commonTest/kotlin/dev/fritz2/validation/test/validation.kt
@@ -89,10 +89,10 @@ data class Person(
                 if (nameInspector.data.isBlank()) add(Message(nameInspector.path, "Name must not be blank!"))
             }
             inspector.map(birthdayLens).let { birthdayInspector ->
-                if (birthdayInspector.data > meta!!.today)
+                if (birthdayInspector.data > meta.today)
                     add(Message(birthdayInspector.path, "Birthday must not be in the future!"))
             }
-            addAll(Address.validate(inspector.map(addressLens), meta!!.knownCities))
+            addAll(Address.validate(inspector.map(addressLens), meta.knownCities))
         }
     }
 }
@@ -113,7 +113,7 @@ data class Address(
                 if (streetInspector.data.isBlank()) add(Message(streetInspector.path, "Street must not be blank!"))
             }
             inspector.map(cityLens).let { cityInspector ->
-                if (!cities!!.contains(cityInspector.data)) add(Message(cityInspector.path, "City does not exist!"))
+                if (!cities.contains(cityInspector.data)) add(Message(cityInspector.path, "City does not exist!"))
             }
         }
     }

--- a/core/src/jsTest/kotlin/dev/fritz2/validation/validation.kt
+++ b/core/src/jsTest/kotlin/dev/fritz2/validation/validation.kt
@@ -193,7 +193,7 @@ data class Foo(val foo: String, val foobar: String, val bar: Bar) {
         val validate: Validation<Foo, Unit, Message> = validation { inspector ->
             add(Message(inspector.map(fooLens).path, "foo ist falsch"))
             add(Message(inspector.map(foobarLens).path, "foobar ist falsch"))
-            addAll(Bar.validate(inspector.map(barLens)))
+            addAll(Bar.validate(inspector.map(barLens), Unit))
         }
     }
 }

--- a/examples/tictactoe/src/commonMain/kotlin/dev/fritz2/examples/tictactoe/logic.kt
+++ b/examples/tictactoe/src/commonMain/kotlin/dev/fritz2/examples/tictactoe/logic.kt
@@ -13,7 +13,7 @@ class Engine {
     companion object {
         private val endingValidator: Validation<Field, GameState, GameEndMessage> = validation { inspector, gameState ->
             if (inspector.data.any { it.isInWinningGroup }) {
-                add(GameEndMessage(inspector.path, "Player ${gameState?.player} has won!", "alert-success"))
+                add(GameEndMessage(inspector.path, "Player ${gameState.player} has won!", "alert-success"))
             } else if (GameState.isFull(inspector.data)) {
                 add(GameEndMessage(inspector.path, "This is a draw!", "alert-info"))
             }


### PR DESCRIPTION
The filtering of mapped validation messages used to test only the prefix. This could lead to false assigned messages, if a field name of some lens is exactly the prefix of another one. So messages for the field `foo` would also appear in a mapped store of field `foobar` as both share the same prefix.

This is now fixed, as the prefix check now excludes leave nodes.