### PR TITLE
Add `Inspector.mapNull()` method and fix `Store.mapNull()` path

### DIFF
--- a/core/src/commonMain/kotlin/dev/fritz2/core/inspector.kt
+++ b/core/src/commonMain/kotlin/dev/fritz2/core/inspector.kt
@@ -58,6 +58,17 @@ class SubInspector<P, T>(
 }
 
 /**
+ * Creates a new [Inspector] from a _nullable_ parent inspector that either contains the original value or a given
+ * [default] value if the original value was `null`.
+ *
+ * The resulting inspector behaves similarly to a `Store` created via `Store.mapNull`.
+ * This means that the resulting [Inspector.path] will be the same as if `mapNull`
+ * was called on an equivalent store of the same value.
+ */
+fun <D> Inspector<D?>.mapNull(default: D): Inspector<D> =
+    SubInspector(this, defaultLens("", default))
+
+/**
  * Creates a new [Inspector] containing the element for the given [element] and [idProvider]
  * from the original [Inspector]'s [List].
  *
@@ -84,17 +95,6 @@ fun <D, I> Inspector<List<D>>.inspectEach(idProvider: IdProvider<D, I>, action: 
  */
 fun <D> Inspector<List<D>>.mapByIndex(index: Int): Inspector<D> =
     SubInspector(this, lensForElement(index))
-
-/**
- * Creates a new [Inspector] from a _nullable_ parent inspector that either contains the original value or a given
- * [default] value if the original value was `null`.
- *
- * The resulting inspector behaves similarly to a `Store` created via `Store.mapNull`.
- * This means that the resulting [Inspector.path] will be the same as if `mapNull` was called on an equivalent Store of
- * the same value.
- */
-fun <D> Inspector<D?>.mapNull(default: D): Inspector<D> =
-    SubInspector(this, defaultLens("", default))
 
 /**
  * Performs the given [action] on each [Inspector].

--- a/core/src/commonMain/kotlin/dev/fritz2/core/inspector.kt
+++ b/core/src/commonMain/kotlin/dev/fritz2/core/inspector.kt
@@ -86,6 +86,17 @@ fun <D> Inspector<List<D>>.mapByIndex(index: Int): Inspector<D> =
     SubInspector(this, lensForElement(index))
 
 /**
+ * Creates a new [Inspector] from a _nullable_ parent inspector that either contains the original value or a given
+ * [default] value if the original value was `null`.
+ *
+ * The resulting inspector behaves similarly to a `Store` created via `Store.mapNull`.
+ * This means that the resulting [Inspector.path] will be the same as if `mapNull` was called on an equivalent Store of
+ * the same value.
+ */
+fun <D> Inspector<D?>.mapNull(default: D): Inspector<D> =
+    SubInspector(this, defaultLens("", default))
+
+/**
  * Performs the given [action] on each [Inspector].
  *
  * @param action function which gets applied to all [Inspector]s

--- a/core/src/commonMain/kotlin/dev/fritz2/core/lens.kt
+++ b/core/src/commonMain/kotlin/dev/fritz2/core/lens.kt
@@ -175,6 +175,6 @@ fun <K, V> lensForElement(key: K): Lens<Map<K, V>, V> = object : Lens<Map<K, V>,
  */
 internal fun <T> defaultLens(id: String, default: T): Lens<T?, T> = object : Lens<T?, T> {
     override val id: String = id
-    override fun get(parent: T?): T = parent  ?: default
+    override fun get(parent: T?): T = parent ?: default
     override fun set(parent: T?, value: T): T?  = value.takeUnless { it == default }
 }

--- a/core/src/commonTest/kotlin/dev/fritz2/core/inspector.kt
+++ b/core/src/commonTest/kotlin/dev/fritz2/core/inspector.kt
@@ -9,10 +9,11 @@ class InspectorTests {
 
     val streetLens = lensOf(Address::street.name, Address::street) { p, v -> p.copy(street = v) }
 
-    data class Person(val name: String, val address: Address, val id: String = Id.next())
+    data class Person(val name: String, val address: Address, val telephone: String? = null, val id: String = Id.next())
 
     val nameLens = lensOf(Person::name.name, Person::name) { p, v -> p.copy(name = v) }
     val addressLens = lensOf(Person::address.name, Person::address) { p, v -> p.copy(address = v) }
+    val telephoneLens = lensOf(Person::telephone.name, Person::telephone) { p, v -> p.copy(telephone = v) }
 
     @Test
     fun testInspectorPaths() {
@@ -34,6 +35,21 @@ class InspectorTests {
         val streetInspector = addressInspector.map(streetLens)
         assertEquals(".address.street", streetInspector.path, "sub sub model id not correct")
         assertEquals(rootData.address.street, streetInspector.data, "sub sub model data not correct")
+    }
+
+    @Test
+    fun testMapNull() {
+        val personA = Person("Hans", Address("Musterstreet 3"), "0138584/943")
+        val inspectorA = inspectorOf(personA).map(telephoneLens).mapNull("")
+
+        assertEquals(".telephone", inspectorA.path)
+        assertEquals(personA.telephone, inspectorA.data)
+
+        val personB = Person("Peter", Address("Musterstreet 5"))
+        val inspectorB = inspectorOf(personB).map(telephoneLens).mapNull("no-num")
+
+        assertEquals(".telephone", inspectorB.path)
+        assertEquals("no-num", inspectorB.data)
     }
 
     @Test

--- a/core/src/jsMain/kotlin/dev/fritz2/core/substores.kt
+++ b/core/src/jsMain/kotlin/dev/fritz2/core/substores.kt
@@ -107,4 +107,4 @@ fun <P, T> Store<P?>.map(lens: Lens<P & Any, T>): Store<T> =
  * @param default value to translate null to and from
  */
 fun <T> Store<T?>.mapNull(default: T): Store<T> =
-    map(defaultLens(id, default))
+    map(defaultLens("", default))

--- a/core/src/jsMain/kotlin/dev/fritz2/core/substores.kt
+++ b/core/src/jsMain/kotlin/dev/fritz2/core/substores.kt
@@ -98,9 +98,10 @@ fun <P, T> Store<P?>.map(lens: Lens<P & Any, T>): Store<T> =
     map(lens.withNullParent())
 
 /**
- * on a [Store] of nullable data this creates a [Store] with a nullable parent and non-nullable value.
- * It can be called using a [Lens] on a non-nullable parent (that can be created by using the @[Lenses]-annotation),
- * but you have to provide a [default] value. When updating the value of the resulting [Store] to this [default] value,
+ * Creates a new [Store] from a _nullable_ parent store that either contains the original value or a given
+ * [default] value if the original value was `null`.
+ *
+ * When updating the value of the resulting [Store] to this [default] value,
  * null is used instead updating the parent. When this [Store]'s value would be null according to it's parent's
  * value, the [default] value will be used instead.
  *

--- a/core/src/jsTest/kotlin/dev/fritz2/core/inspector.kt
+++ b/core/src/jsTest/kotlin/dev/fritz2/core/inspector.kt
@@ -1,0 +1,37 @@
+package dev.fritz2.core
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class NullableInspectorTests {
+
+    @Test
+    fun testMapNullResultsInSpecifiedDefaultValueWhenCalledOnNullContainingInspector() {
+        val rootInspector = inspectorOf<String?>(null)
+        val expected = "Foo"
+
+        val resultInspector = rootInspector.mapNull(expected)
+        val resultValue = resultInspector.data
+
+        assertEquals(
+            expected,
+            resultValue,
+            "Data of the derived Inspector must equal the expected value."
+        )
+    }
+
+    @Test
+    fun testPathsAreEqualForStoresAndInspectorsWhenDerivedViaMapNull() {
+        val rootInspector = inspectorOf<String?>(null)
+        val rootStore = storeOf<String?>(null)
+
+        val nonNullableInspector = rootInspector.mapNull("Test")
+        val nonNullableStore = rootStore.mapNull("Test")
+
+        assertEquals(
+            nonNullableStore.path,
+            nonNullableInspector.path,
+            "Sub inspector and sub Store paths must be the same."
+        )
+    }
+}

--- a/core/src/jsTest/kotlin/dev/fritz2/core/store.kt
+++ b/core/src/jsTest/kotlin/dev/fritz2/core/store.kt
@@ -219,4 +219,19 @@ class StoreTests {
         assertEquals(intermediateException, errorHandlerResult, "exception in map not caught")
         checkUpdate("store not updating after intermediate exception")
     }
+
+    @Test
+    fun testMapNullResultsInSpecifiedDefaultValueWhenCalledOnNullContainingStore() {
+        val rootStore = storeOf<String?>(null)
+        val expected = "Foo"
+
+        val resultStore = rootStore.mapNull(expected)
+        val resultValue = resultStore.current
+
+        assertEquals(
+            expected,
+            resultValue,
+            "Data of the derived Store must equal the expected value."
+        )
+    }
 }


### PR DESCRIPTION
This PR adds an `Inspector.mapNull()` extension function that works like `Store.mapNull()`.
Just like on a Store, a default value is passed to the method that is used by the resulting store when the parent's value is `null`.

Additionally, the behavior of `Store.mapNull()` has been changed so that the path of the derived Store is the same as in the parent Store. This is the correct behavior as a Store created via `mapNull()` does not technically map to another hierarchical level of the data model. As a result, `mapNull()` works the same on both Stores and Inspectors, making the validation process more straight-forward. Previously, the Store's id has been appended to the path upon derivation.

This PR might potentially be API breaking as the behavior of `Store.mapNull()` regarding the resulting path changes.

Closes #769 