### PR TITLE
New utility `render`-functions for `RenderContext`

### DIFF
--- a/www/src/pages/docs/30_Render HTML.md
+++ b/www/src/pages/docs/30_Render HTML.md
@@ -255,6 +255,9 @@ Based upon the `data`-property, which provides a `Flow` of the store's generic d
 | Render-Function            | Additional parameters | Description                                                                                                                   | Default Tag |    
 |----------------------------|-----------------------|-------------------------------------------------------------------------------------------------------------------------------|-------------|
 | `Flow<T>.render`           | -                     | Creates a mount-point providing the whole store's data value `T` inside `content` expression                                  | `div`       |
+| `Flow<T>.renderIf`         | predicate             | Creates a mount-point providing the whole store's data value `T` inside `content` expression when `predicate` is `true`       | `div`       |
+| `Flow<T>.renderNotNull`    | -                     | Creates a mount-point providing the whole store's data value `T` inside `content` expression when `T` is not `null`           | `div`       |
+| `Flow<T>.renderIs`         | klass                 | Creates a mount-point providing the whole store's data value `T` inside `content` expression when `T` is of type `klass`      | `div`       |
 | `Flow<String>.renderText`  | -                     | Creates a mount-point creating a text-node                                                                                    | `span`      |
 | `Flow<List<T>>.renderEach` | -                     | Creates a mount-point optimizing changes by `T.equals`. Provides a `T` inside the `content` expression. Use for value objects | `div`       |
 | `Flow<List<T>>.renderEach` | idProvider            | Creates a mount-point optimizing changes by `idProvider`. Provides a `T` inside the `content` expression. Use for entities    | `div`       |


### PR DESCRIPTION
This PR and PR #783 added new utility `render`-functions inside `RenderContext`.

The `renderIf(predicate: (V) -> Boolean)` function only renders the given `content`, when the given `predicate` returns `true` for the value inside the `Flow<V>`.
```kotlin
val store = storeOf<String>("foo")
render {
    store.data.renderIf(String::isNotBlank) {
        p { +it }
    }
}
```

The `renderNotNull()` function only renders the given `content`, when the value inside the `Flow<V?>` is not null.
```kotlin
val store = storeOf<String?>(null)
render {
    store.data.renderNotNull {
        p { +it }
    }
}
```

The `renderIs(klass: KClass<W>)` function only renders the given `content`, when the value inside the `Flow<V>` is a type of `klass`.
```kotlin
interface I
class A: I
class B: I

val store = storeOf<I>(A())
render {
    store.data.renderIs(A::class) {
        p { +"A" }
    }
}
```

Extends the PR #783 from @serras. Thanks for your work!