### PR TITLE
Query parameters for GET

### DIFF
--- a/core/src/jsTest/kotlin/dev/fritz2/remote/http.kt
+++ b/core/src/jsTest/kotlin/dev/fritz2/remote/http.kt
@@ -38,6 +38,18 @@ class RemoteTests {
 
 
     @Test
+    fun testQueryParameters() = runTest {
+        val parameters = mapOf(
+            "q" to "hello",
+            "orderBy" to "name",
+        )
+        val remote = testHttpServer(testEndpoint)
+        val url = remote.get("get", parameters).request.url
+        assertTrue(url.endsWith("?q=hello&orderBy=name"))
+    }
+
+
+    @Test
     fun testBasicAuth() = runTest {
         val remote = testHttpServer(testEndpoint)
         val user = "test"


### PR DESCRIPTION
- `queryParameters` function which encodes a map of strings into the right form,
- additional optional argument to `get`, since query parameters often appear in such requests.