### PR TITLE
Serialization module

### DIFF
--- a/serialization/build.gradle.kts
+++ b/serialization/build.gradle.kts
@@ -10,7 +10,7 @@ kotlin {
         val jsMain by getting {
             dependencies {
                 api(project(":core"))
-                implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:${rootProject.extra["serializationVersion"]}")
+                api("org.jetbrains.kotlinx:kotlinx-serialization-json:${rootProject.extra["serializationVersion"]}")
             }
         }
     }

--- a/serialization/build.gradle.kts
+++ b/serialization/build.gradle.kts
@@ -1,0 +1,19 @@
+plugins {
+    kotlin("multiplatform")
+    kotlin("plugin.serialization")
+}
+
+kotlin {
+    jvm()
+    js(BOTH).browser { }
+    sourceSets {
+        val jsMain by getting {
+            dependencies {
+                api(project(":core"))
+                implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:${rootProject.extra["serializationVersion"]}")
+            }
+        }
+    }
+}
+
+apply(from = "$rootDir/publishing.gradle.kts")

--- a/serialization/src/jsMain/kotlin/dev/fritz2/remote/serialization.kt
+++ b/serialization/src/jsMain/kotlin/dev/fritz2/remote/serialization.kt
@@ -2,9 +2,9 @@ package dev.fritz2.remote
 
 import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.KSerializer
-import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.decodeFromDynamic
+import kotlinx.serialization.json.encodeToDynamic
 
 @PublishedApi internal val lenientJson = Json {
     ignoreUnknownKeys = true
@@ -17,10 +17,11 @@ import kotlinx.serialization.json.decodeFromDynamic
  * @param value information to be encoded
  * @param json (optional) JSON serialization configuration
  */
+@ExperimentalSerializationApi
 inline fun <reified T> Request.bodyJson(
     value: T,
     json: Json = lenientJson,
-): Request = body(json.encodeToString(value))
+): Request = body(JSON.stringify(json.encodeToDynamic(value)))
 
 /**
  * Encodes the given value as the body of the request.
@@ -29,11 +30,12 @@ inline fun <reified T> Request.bodyJson(
  * @param serializer serializer from `kotlinx-serialization`
  * @param json (optional) JSON serialization configuration
  */
+@ExperimentalSerializationApi
 fun <T> Request.bodyJson(
     value: T,
     serializer: KSerializer<T>,
     json: Json = lenientJson,
-): Request = body(json.encodeToString(serializer, value))
+): Request = body(JSON.stringify(json.encodeToDynamic(serializer, value)))
 
 /**
  * Decodes the information in the response from the JSON representation.

--- a/serialization/src/jsMain/kotlin/dev/fritz2/remote/serialization.kt
+++ b/serialization/src/jsMain/kotlin/dev/fritz2/remote/serialization.kt
@@ -1,3 +1,41 @@
+/**
+ * # Module fritz2-serialization
+ *
+ * This module contains a few helper functions for easy interoperability
+ * with [`kotlinx.serialization`](https://kotlinlang.org/api/kotlinx.serialization/).
+ *
+ * The example in the [documentation](https://www.fritz2.dev/docs/http/)
+ * could be simplified as follows.
+ *
+ * ```kotlin
+ * @Serializable
+ * data class Planet(val name: String)
+ *
+ * val swapiStore = object : RootStore<String>("") {
+ *
+ *     private val api = http("https://swapi.dev/api")
+ *         .acceptJson()
+ *         .contentType("application/json")
+ *
+ *     val planetName = handle<Int> { _, num ->
+ *         val resp = api.get("planets/$num")
+ *         require(resp.ok)
+ *         resp.decoded<Planet>().name
+ *     }
+ * }
+ * ```
+ *
+ * **Note**:
+ * for performance reasons this module does **not** convert values
+ * to string using
+ * [`encodeToString`](https://kotlinlang.org/api/kotlinx.serialization/kotlinx-serialization-core/kotlinx.serialization/encode-to-string.html)
+ * and [`decodeFromString`](https://kotlinlang.org/api/kotlinx.serialization/kotlinx-serialization-core/kotlinx.serialization/decode-from-string.html).
+ * Values are instead turned into "native" JavaScript objects using
+ * [`encodeToDynamic`](https://kotlinlang.org/api/kotlinx.serialization/kotlinx-serialization-json/kotlinx.serialization.json/encode-to-dynamic.html)
+ * and [`decodeFromDynamic`](https://kotlinlang.org/api/kotlinx.serialization/kotlinx-serialization-json/kotlinx.serialization.json/decode-from-dynamic.html),
+ * which work natively with the Fetch API used by `dev.fritz2.remote`.
+ */
+
 package dev.fritz2.remote
 
 import kotlinx.serialization.ExperimentalSerializationApi

--- a/serialization/src/jsMain/kotlin/dev/fritz2/remote/serialization.kt
+++ b/serialization/src/jsMain/kotlin/dev/fritz2/remote/serialization.kt
@@ -1,0 +1,58 @@
+package dev.fritz2.remote
+
+import kotlinx.serialization.ExperimentalSerializationApi
+import kotlinx.serialization.KSerializer
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.decodeFromDynamic
+
+@PublishedApi internal val lenientJson = Json {
+    ignoreUnknownKeys = true
+    isLenient = true
+}
+
+/**
+ * Encodes the given value as the body of the request.
+ *
+ * @param value information to be encoded
+ * @param json (optional) JSON serialization configuration
+ */
+inline fun <reified T> Request.bodyJson(
+    value: T,
+    json: Json = lenientJson,
+): Request = body(json.encodeToString(value))
+
+/**
+ * Encodes the given value as the body of the request.
+ *
+ * @param value information to be encoded
+ * @param serializer serializer from `kotlinx-serialization`
+ * @param json (optional) JSON serialization configuration
+ */
+fun <T> Request.bodyJson(
+    value: T,
+    serializer: KSerializer<T>,
+    json: Json = lenientJson,
+): Request = body(json.encodeToString(serializer, value))
+
+/**
+ * Decodes the information in the response from the JSON representation.
+ *
+ * @param json (optional) JSON serialization configuration
+ */
+@ExperimentalSerializationApi
+suspend inline fun <reified T> Response.decoded(
+    json: Json = lenientJson,
+): T = json.decodeFromDynamic<T>(this.json())
+
+/**
+ * Decodes the information in the response from the JSON representation.
+ *
+ * @param serializer serializer from `kotlinx-serialization`
+ * @param json (optional) JSON serialization configuration
+ */
+@ExperimentalSerializationApi
+suspend fun <T> Response.decoded(
+    serializer: KSerializer<T>,
+    json: Json = lenientJson,
+): T = json.decodeFromDynamic(serializer, this.json())

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -13,6 +13,7 @@ include(
     "headless",
     "headless-demo",
     "snippets",
+    "serialization",
     // examples:
     ":examples:gettingstarted",
     ":examples:nestedmodel",


### PR DESCRIPTION
This (small) module includes a few functions which come in handy when working with fritz2's `http` module alongside `kotlinx-serialization`.