### PR TITLE
Semove setFocus from PopUpPanel

### DIFF
--- a/headless-demo/playwright.config.ts
+++ b/headless-demo/playwright.config.ts
@@ -34,9 +34,9 @@ const config: PlaywrightTestConfig = {
     /* Maximum time each action such as `click()` can take. Defaults to 0 (no limit). */
     actionTimeout: 0,
     /* Base URL to use in actions like `await page.goto('/')`. */
-    //baseURL: 'https://next.fritz2.dev/headless-demo/',
+    baseURL: 'https://next.fritz2.dev/headless-demo/',
     /* Uncomment this to test local running demos as testing base */
-    baseURL: 'http://localhost:8080/',
+    //baseURL: 'http://localhost:8080/',
 
     /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
     trace: 'on-first-retry',

--- a/headless-demo/src/jsMain/kotlin/dev/fritz2/headlessdemo/components/popOver.kt
+++ b/headless-demo/src/jsMain/kotlin/dev/fritz2/headlessdemo/components/popOver.kt
@@ -4,8 +4,7 @@ package dev.fritz2.headlessdemo.components
 import dev.fritz2.core.RenderContext
 import dev.fritz2.core.transition
 import dev.fritz2.headless.components.popOver
-import dev.fritz2.headless.foundation.utils.floatingui.core.middleware.autoPlacement
-import dev.fritz2.headless.foundation.utils.floatingui.utils.Placement
+import dev.fritz2.headless.foundation.utils.floatingui.core.middleware.offset
 import dev.fritz2.headless.foundation.utils.floatingui.utils.PlacementValues
 import kotlinx.coroutines.flow.map
 
@@ -51,6 +50,7 @@ fun RenderContext.popOverDemo() {
             """.trimMargin()
         ) {
             placement = PlacementValues.bottomStart
+            addMiddleware(offset(5))
 
             transition(
                 opened,

--- a/headless-demo/tests/components/modal.spec.ts
+++ b/headless-demo/tests/components/modal.spec.ts
@@ -78,7 +78,7 @@ test.describe('To check if', () => {
     
     });
     
-    test.only(`by pressing Enter on button and pressing again Enter on Open will reopen the modal`, async ({page}) => {
+    test(`by pressing Enter on button and pressing again Enter on Open will reopen the modal`, async ({page}) => {
         const buttonStay = page.locator(`#button-stay`);
         const buttonCancel = page.locator(`#button-cancel`);
         const buttonClose = page.locator(`#button-close`);

--- a/headless/src/jsMain/kotlin/dev/fritz2/headless/foundation/PopUpPanel.kt
+++ b/headless/src/jsMain/kotlin/dev/fritz2/headless/foundation/PopUpPanel.kt
@@ -275,7 +275,6 @@ abstract class PopUpPanel<C : HTMLElement>(
                     computePosition()
                     popupDiv.domNode.className = POPUP_VISIBLE_CLASSES
                     this@PopUpPanel.waitForAnimation()
-                    setFocus()
                 } else {
                     this@PopUpPanel.waitForAnimation()
                     popupDiv.domNode.className = POPUP_HIDDEN_CLASSES


### PR DESCRIPTION
PopUpPanel is not focusable by default. In Chrome setFocus does nothing here, but in Firefox the current focus gets lost, when setFocus is called on a not-focusable element.