### PR TITLE
#782 Fix reactively nested beforeUnmount Calls

### DIFF
--- a/core/src/jsMain/kotlin/dev/fritz2/core/rendercontext.kt
+++ b/core/src/jsMain/kotlin/dev/fritz2/core/rendercontext.kt
@@ -30,8 +30,8 @@ interface RenderContext : WithJob, WithScope {
         val mountContext = MountContext(Job(job), target)
 
         mountSimple(job, this) {
-            mountContext.job.cancelChildren()
             mountContext.runBeforeUnmounts()
+            mountContext.job.cancelChildren()
             target.domNode.clear()
             content(mountContext, it)
             mountContext.runAfterMounts()
@@ -120,7 +120,7 @@ interface RenderContext : WithJob, WithScope {
             }.map { (old, new) ->
                 Myer.diff(old, new, idProvider).map { patch ->
                     patch.map(job) { value, newJob ->
-                        val mountPoint = BuildContext(newJob, scope)
+                        val mountPoint = BuildContext(newJob, this, scope)
                         content(mountPoint, value).also {
                             mountPoints[it.domNode] = mountPoint
                         }
@@ -128,6 +128,8 @@ interface RenderContext : WithJob, WithScope {
                 }
             }
         }
+
+
     }
 
     /**

--- a/core/src/jsTest/kotlin/dev/fritz2/core/mount.kt
+++ b/core/src/jsTest/kotlin/dev/fritz2/core/mount.kt
@@ -148,7 +148,7 @@ class MountTests {
                         +it.toString()
 
                         mountPoint()?.afterMount(this) { _, _ ->
-                            mounts += 1;
+                            mounts += 1
                         }
                         beforeUnmount { _, _ ->
                             unmounts += 1
@@ -212,7 +212,6 @@ class MountTests {
             }
         }
 
-
         /**
          * Checks, whether the amount of afterMount/beforeUnmount-Calls match the excepted values for the given action
          */
@@ -247,7 +246,6 @@ class MountTests {
             assertEquals(listUnmounts, listUnmountsCounter, "$title - listUnmounts wrong")
         }
 
-
         check(
             "Initial",
             outerMount = 1,
@@ -255,29 +253,21 @@ class MountTests {
             listMounts = 1,
         ) {}
 
-
-
         check(
             "Add to listStore",
             listMounts = 1
         ) { listStore.update(listOf("123", "234")) }
-
-
 
         check(
             "Remove from listStore",
             listUnmounts = 1
         ) { listStore.update(listOf("123")) }
 
-
-
         check(
             "Update InnerStore",
             innerMounts = 1, innerUnmounts = 1,
             listMounts = 1, listUnmounts = 1
         ) { innerStore.update(1) }
-
-
 
         check(
             "Update OuterStore",
@@ -297,10 +287,7 @@ class MountTests {
             innerMounts = 1, innerUnmounts = 1,
             listMounts = 2, listUnmounts = 2
         ) { outerStore.update(2) }
-
-
     }
-
 
     @Test
     fun testLifecycleOnGlobalRender() = runTest {
@@ -310,7 +297,7 @@ class MountTests {
         render {
             div {
                 afterMount { _, _ ->
-                    mounts += 1;
+                    mounts += 1
                 }
             }
         }


### PR DESCRIPTION
The lifecycle function `beforeUnmount` did not work properly in some reactively nested scenarios.

In a simple example with one `Store` and a corresponding `Store<*>.render` it is working without problems, but when nesting render-blocks, it is only called for the outer `MountPoint`.

Example:
```kotlin
val outerStore = storeOf(Id.next())
val innerStore = storeOf(Id.next())

input {
    type("Button")
    value("Update Outer Store")
}.clicks.map { Id.next() } handledBy outerStore.update
input {
    type("Button")
    value("Update Inner Store")
}.clicks.map { Id.next() } handledBy innerStore.update

outerStore.data.render {
    p { +it }
    afterMount { _, _ -> console.log("outer afterMount") }
    beforeUnmount { _, _ -> console.log("outer beforeUnmount") }

    innerStore.data.render {
        p { +it }
        afterMount { _, _ -> console.log("inner afterMount") }
        beforeUnmount { _, _ -> console.log("inner beforeUnmount") } // this gets not called, if `outerStore` changes
    }
}
```
If i click the first button (Update Outer Store) i get following logs:

```text
    outer beforeUnmount
    inner afterMount
    outer afterMount
```

`afterMount` is called for both, but `beforeUnmount` is only called for the outer MountPoint. This was a bug, as `beforeUnmount` must be called recursively on all levels beneath some changing `MountPoint`!

This PR fixes the issue so it should now work properly in all nesting scenarios.

As PoC also some internal workaround in the [portalling](https://www.fritz2.dev/headless/#portalling)-engine has now been refactored towards a more idiomatic approach using `beforeUnpount`.

fixes #782