### PR TITLE
Removes portal stylings

### DIFF
--- a/headless-demo/src/jsMain/kotlin/dev/fritz2/headlessdemo/components/listbox.kt
+++ b/headless-demo/src/jsMain/kotlin/dev/fritz2/headlessdemo/components/listbox.kt
@@ -48,7 +48,7 @@ fun RenderContext.listboxDemo() {
             }
 
             listboxItems(
-                """w-full max-h-60 py-1 overflow-auto origin-top  
+                """w-full max-h-60 py-1 overflow-auto origin-top z-30
                     | bg-white rounded shadow-md divide-y divide-gray-100
                     | ring-1 ring-primary-600 ring-opacity-5 
                     | focus:outline-none""".trimMargin(),

--- a/headless-demo/src/jsMain/kotlin/dev/fritz2/headlessdemo/components/menu.kt
+++ b/headless-demo/src/jsMain/kotlin/dev/fritz2/headlessdemo/components/menu.kt
@@ -46,7 +46,7 @@ fun RenderContext.menuDemo() {
                 }
 
                 menuItems(
-                    """w-56 max-h-56 overflow-y-auto origin-top-left
+                    """w-56 max-h-56 overflow-y-auto origin-top-left z-30
                         | bg-white rounded shadow-md divide-y divide-gray-100
                         | border-white border-2  
                         | focus:outline-none""".trimMargin()

--- a/headless-demo/src/jsMain/kotlin/dev/fritz2/headlessdemo/components/popOver.kt
+++ b/headless-demo/src/jsMain/kotlin/dev/fritz2/headlessdemo/components/popOver.kt
@@ -44,7 +44,7 @@ fun RenderContext.popOverDemo() {
         }
 
         popOverPanel(
-            """z-10 max-w-sm lg:max-w-3xl px-0  
+            """z-30 max-w-sm lg:max-w-3xl px-0  
             | bg-white overflow-hidden rounded-lg shadow-lg ring-1 ring-black ring-opacity-5
             | focus:outline-none
             """.trimMargin()

--- a/headless-demo/src/jsMain/kotlin/dev/fritz2/headlessdemo/components/toast.kt
+++ b/headless-demo/src/jsMain/kotlin/dev/fritz2/headlessdemo/components/toast.kt
@@ -13,13 +13,13 @@ fun RenderContext.toastDemo() {
     div {
         toastContainer(
             toastContainerDefault,
-            "absolute top-5 right-5 z-10 flex flex-col gap-2 items-start",
+            "absolute z-50 top-5 right-5 z-10 flex flex-col gap-2 items-start",
             id = toastContainerDefault
         )
 
         toastContainer(
             containerImportant,
-            "absolute top-5 left-1/2 -translate-x-1/2 z-10 flex flex-col gap-2 items-center",
+            "absolute z-50 top-5 left-1/2 -translate-x-1/2 z-10 flex flex-col gap-2 items-center",
             id = containerImportant
         )
     }

--- a/headless-demo/src/jsMain/kotlin/dev/fritz2/headlessdemo/components/tooltip.kt
+++ b/headless-demo/src/jsMain/kotlin/dev/fritz2/headlessdemo/components/tooltip.kt
@@ -19,7 +19,7 @@ fun RenderContext.tooltipButton(idPrefix: String) {
         id = "$idPrefix-reference"
     ) {
         +"Some Button"
-    }.tooltip("px-2 py-1 bg-slate-400 rounded text-sm text-white", id = "$idPrefix-tooltip") {
+    }.tooltip("z-30 px-2 py-1 bg-slate-400 rounded text-sm text-white", id = "$idPrefix-tooltip") {
         placement = PlacementValues.right
         arrow()
         +"Some more Information"
@@ -38,7 +38,7 @@ fun RenderContext.tooltipInput(idPrefix: String) {
     ) {
         placeholder("some input")
         type("text")
-    }.tooltip("px-2 py-1 bg-slate-400 rounded text-sm text-white", id = "$idPrefix-tooltip") {
+    }.tooltip("z-30 px-2 py-1 bg-slate-400 rounded text-sm text-white", id = "$idPrefix-tooltip") {
         placement = PlacementValues.right
         arrow()
         +"Some more Information"

--- a/headless/src/jsMain/kotlin/dev/fritz2/headless/components/listbox.kt
+++ b/headless/src/jsMain/kotlin/dev/fritz2/headless/components/listbox.kt
@@ -341,6 +341,8 @@ class Listbox<T, C : HTMLElement>(tag: Tag<C>, id: String?) : Tag<C> by tag, Ope
     /**
      * Factory function to create a [listboxItems].
      *
+     * It is recommended to define some explicit z-index within the classes-parameter.
+     *
      * For more information refer to the
      * [official documentation](https://www.fritz2.dev/headless/listbox/#listboxitems)
      */
@@ -352,7 +354,7 @@ class Listbox<T, C : HTMLElement>(tag: Tag<C>, id: String?) : Tag<C> by tag, Ope
     ) {
         addComponentStructureInfo("listboxItems", this@listboxItems.scope, this)
         if (!openState.isSet) openState(storeOf(false))
-        portal(zIndex = PORTALLING_POPUP_ZINDEX) {
+        portal {
             ListboxItems(this, tag, classes, scope).run {
                 size = PopUpPanelSize.Min
                 initialize()
@@ -363,6 +365,8 @@ class Listbox<T, C : HTMLElement>(tag: Tag<C>, id: String?) : Tag<C> by tag, Ope
 
     /**
      * Factory function to create a [listboxItems] with a [HTMLDivElement] as default [Tag].
+     *
+     * It is recommended to define some explicit z-index within the classes-parameter.
      *
      * For more information refer to the
      * [official documentation](https://www.fritz2.dev/headless/listbox/#listboxitems)

--- a/headless/src/jsMain/kotlin/dev/fritz2/headless/components/menu.kt
+++ b/headless/src/jsMain/kotlin/dev/fritz2/headless/components/menu.kt
@@ -250,6 +250,8 @@ class Menu<C : HTMLElement>(tag: Tag<C>, id: String?) : Tag<C> by tag, OpenClose
     /**
      * Factory function to create a [menuItems].
      *
+     * It is recommended to define some explicit z-index within the classes-parameter.
+     *
      * For more information refer to the
      * [official documentation](https://www.fritz2.dev/headless/menu/#menuitems)
      */
@@ -261,7 +263,7 @@ class Menu<C : HTMLElement>(tag: Tag<C>, id: String?) : Tag<C> by tag, OpenClose
     ) {
         if (!openState.isSet) openState(storeOf(false))
         addComponentStructureInfo("menuItems", this@menuItems.scope, this)
-        portal(zIndex = PORTALLING_POPUP_ZINDEX) {
+        portal {
             MenuItems(this, tag, classes, scope).run {
                 initialize()
                 render()
@@ -271,6 +273,8 @@ class Menu<C : HTMLElement>(tag: Tag<C>, id: String?) : Tag<C> by tag, OpenClose
 
     /**
      * Factory function to create a [menuItems] with a [HTMLDivElement] as default [Tag].
+     *
+     * It is recommended to define some explicit z-index within the classes-parameter.
      *
      * For more information refer to the
      * [official documentation](https://www.fritz2.dev/headless/menu/#menuitems)

--- a/headless/src/jsMain/kotlin/dev/fritz2/headless/components/modal.kt
+++ b/headless/src/jsMain/kotlin/dev/fritz2/headless/components/modal.kt
@@ -16,9 +16,12 @@ import org.w3c.dom.*
  *
  * For more information refer to the [official documentation](https://www.fritz2.dev/headless/modal/)
  */
-class Modal : OpenClose(), WithJob {
+class Modal(id: String?) : OpenClose(), WithJob {
+
+    val componentId: String by lazy { id ?: Id.next() }
 
     override val job: Job = Job()
+
     var restoreFocus: Boolean = true
     var setInitialFocus: InitialFocus = InitialFocus.InsistToSet
 
@@ -27,7 +30,7 @@ class Modal : OpenClose(), WithJob {
     fun init() {
         opened.filter { it }.handledBy {
             PortalRenderContext.run {
-                portal(zIndex = PORTALLING_MODAL_ZINDEX, tag = RenderContext::dialog) { close ->
+                portal("display: contents", id = componentId, tag = RenderContext::dialog) { close ->
                     panel?.invoke(this)!!.apply {
                         trapFocusInMountpoint(restoreFocus, setInitialFocus)
                     }
@@ -151,6 +154,8 @@ class Modal : OpenClose(), WithJob {
     /**
      * Factory function to create a [modalPanel].
      *
+     * It is recommended to define some explicit z-index within the classes-parameter.
+     *
      * For more information refer to the
      * [official documentation](https://www.fritz2.dev/headless/modal/#modalpanel)
      */
@@ -174,6 +179,8 @@ class Modal : OpenClose(), WithJob {
 
     /**
      * Factory function to create a [modalPanel] with a [HTMLDivElement] as default [Tag].
+     *
+     * It is recommended to define some explicit z-index within the classes-parameter.
      *
      * For more information refer to the
      * [official documentation](https://www.fritz2.dev/headless/modal/#modalpanel)
@@ -214,9 +221,10 @@ class Modal : OpenClose(), WithJob {
  * For more information refer to the [official documentation](https://www.fritz2.dev/headless/modal/#modal)
  */
 fun modal(
+    id: String? = null,
     initialize: Modal.() -> Unit
 ) {
-    Modal().run {
+    Modal(id).run {
         initialize(this)
         init()
     }

--- a/headless/src/jsMain/kotlin/dev/fritz2/headless/components/modal.kt
+++ b/headless/src/jsMain/kotlin/dev/fritz2/headless/components/modal.kt
@@ -30,7 +30,8 @@ class Modal(id: String?) : OpenClose(), WithJob {
     fun init() {
         opened.filter { it }.handledBy {
             PortalRenderContext.run {
-                portal("display: contents", id = componentId, tag = RenderContext::dialog) { close ->
+                portal(id = componentId, tag = RenderContext::dialog) { close ->
+                    inlineStyle("display: contents")
                     panel?.invoke(this)!!.apply {
                         trapFocusInMountpoint(restoreFocus, setInitialFocus)
                     }

--- a/headless/src/jsMain/kotlin/dev/fritz2/headless/components/popOver.kt
+++ b/headless/src/jsMain/kotlin/dev/fritz2/headless/components/popOver.kt
@@ -80,6 +80,8 @@ class PopOver<C : HTMLElement>(tag: Tag<C>, id: String?) : Tag<C> by tag, OpenCl
     /**
      * Factory function to create a [popOverPanel].
      *
+     * It is recommended to define some explicit z-index within the classes-parameter.
+     *
      * For more information refer to the
      * [official documentation](https://www.fritz2.dev/headless/popover/#popoverpanel)
      */
@@ -90,7 +92,7 @@ class PopOver<C : HTMLElement>(tag: Tag<C>, id: String?) : Tag<C> by tag, OpenCl
         initialize: PopOverPanel<CP>.() -> Unit
     ) {
         addComponentStructureInfo("popOverPanel", this@popOverPanel.scope, this)
-        portal(zIndex = PORTALLING_POPUP_ZINDEX) {
+        portal {
             PopOverPanel(this, tag, classes, scope).run {
                 initialize()
                 render()
@@ -102,6 +104,8 @@ class PopOver<C : HTMLElement>(tag: Tag<C>, id: String?) : Tag<C> by tag, OpenCl
 
     /**
      * Factory function to create a [popOverPanel] with a [HTMLDivElement] as default [Tag].
+     *
+     * It is recommended to define some explicit z-index within the classes-parameter.
      *
      * For more information refer to the
      * [official documentation](https://www.fritz2.dev/headless/popover/#popoverpanel)

--- a/headless/src/jsMain/kotlin/dev/fritz2/headless/components/toast.kt
+++ b/headless/src/jsMain/kotlin/dev/fritz2/headless/components/toast.kt
@@ -36,6 +36,8 @@ private object ToastStore : RootStore<List<ToastSlice>>(emptyList()) {
 /**
  * Factory function to create a [toastContainer].
  *
+ * It is recommended to define some explicit z-index within the classes-parameter.
+ *
  * For more information refer to the
  * [official documentation](https://www.fritz2.dev/headless/toast/#toastContainer)
  *
@@ -48,7 +50,7 @@ fun <E : HTMLElement> toastContainer(
     scope: (ScopeContext.() -> Unit) = {},
     tag: TagFactory<Tag<E>>
 ) {
-    PortalRenderContext.portal(classes, id, scope, tag, PORTALLING_TOAST_ZINDEX) {
+    PortalRenderContext.portal(classes, id, scope, tag) {
         addComponentStructureInfo("toast-container ($name)", this.scope, this)
         attrIfNotSet(Aria.live, "polite")
         ToastStore.filteredByContainer(name).renderEach(into = this) { fragment ->
@@ -59,6 +61,8 @@ fun <E : HTMLElement> toastContainer(
 
 /**
  * Factory function to create a [toastContainer] with a [HTMLUListElement] as default [Tag].
+ *
+ * It is recommended to define some explicit z-index within the classes-parameter.
  *
  * For more information refer to the
  * [official documentation](https://www.fritz2.dev/headless/toast/#toastContainer)

--- a/headless/src/jsMain/kotlin/dev/fritz2/headless/components/tooltip.kt
+++ b/headless/src/jsMain/kotlin/dev/fritz2/headless/components/tooltip.kt
@@ -42,6 +42,8 @@ class Tooltip<C : HTMLElement>(
 /**
  * Factory function to create a [tooltip].
  *
+ * It is recommended to define some explicit z-index within the classes-parameter.
+ *
  * For more information refer to the
  * [official documentation](https://www.fritz2.dev/headless/tooltip/)
  */
@@ -52,7 +54,7 @@ fun <C : HTMLElement> Tag<HTMLElement>.tooltip(
     tag: TagFactory<Tag<C>>,
     initialize: Tooltip<C>.() -> Unit
 ) {
-    portal(zIndex = PORTALLING_POPUP_ZINDEX) {
+    portal {
         Tooltip(this, this@tooltip, tag, classes, id, scope).apply {
             addComponentStructureInfo("parent is tooltip", this@tooltip.scope, this)
         }.run {
@@ -65,6 +67,8 @@ fun <C : HTMLElement> Tag<HTMLElement>.tooltip(
 
 /**
  * Factory function to create a [tooltip] with a [HTMLDivElement] as default [Tag].
+ *
+ * It is recommended to define some explicit z-index within the classes-parameter.
  *
  * For more information refer to the
  * [official documentation](https://www.fritz2.dev/headless/tooltip)


### PR DESCRIPTION
The default `z-index`-Stylings are removed entirely from the portal-factory. As the portal-containers can be defined by the user, there is no more need to "hide" them with `display-contents` and implement some `z-index` behavior for their children.

This is a huge step to consequently remain headless and be agnostic of any styling!

fixes #799
fixes #802 