### PR TITLE
make ComponentValidationMessage a data class

### DIFF
--- a/headless/api/headless.api
+++ b/headless/api/headless.api
@@ -1,10 +1,18 @@
-public class dev/fritz2/headless/validation/ComponentValidationMessage : dev/fritz2/validation/ValidationMessage {
+public final class dev/fritz2/headless/validation/ComponentValidationMessage : dev/fritz2/validation/ValidationMessage {
 	public fun <init> (Ljava/lang/String;Ldev/fritz2/headless/validation/Severity;Ljava/lang/String;Ljava/lang/String;)V
 	public synthetic fun <init> (Ljava/lang/String;Ldev/fritz2/headless/validation/Severity;Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ldev/fritz2/headless/validation/Severity;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Ldev/fritz2/headless/validation/Severity;Ljava/lang/String;Ljava/lang/String;)Ldev/fritz2/headless/validation/ComponentValidationMessage;
+	public static synthetic fun copy$default (Ldev/fritz2/headless/validation/ComponentValidationMessage;Ljava/lang/String;Ldev/fritz2/headless/validation/Severity;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Ldev/fritz2/headless/validation/ComponentValidationMessage;
+	public fun equals (Ljava/lang/Object;)Z
 	public final fun getDetails ()Ljava/lang/String;
 	public final fun getMessage ()Ljava/lang/String;
 	public fun getPath ()Ljava/lang/String;
 	public final fun getSeverity ()Ldev/fritz2/headless/validation/Severity;
+	public fun hashCode ()I
 	public fun isError ()Z
 	public fun toString ()Ljava/lang/String;
 }

--- a/headless/src/commonMain/kotlin/dev/fritz2/headless/validation/validation.kt
+++ b/headless/src/commonMain/kotlin/dev/fritz2/headless/validation/validation.kt
@@ -25,7 +25,7 @@ enum class Severity {
  * @param message contains the message
  * @param details optional details for extending the message
  */
-open class ComponentValidationMessage(
+data class ComponentValidationMessage(
     override val path: String,
     val severity: Severity,
     val message: String,


### PR DESCRIPTION
The `ComponentValidationMessage` implements the `Message` interface, which is the building block for all validation related aspects in fritz2 and is also the default type for all `headless` components. It is definitely a `value` type from the domain perspective and thuis should be a `data class`. This makes it so much easier to filter duplicates for example.

That is why we change the type from an `open class` to a `data class`.

fixes #801