### PR TITLE
Update the headless documentation of portalling

### DIFF
--- a/www/src/pages/headless/headlessComponents.md
+++ b/www/src/pages/headless/headlessComponents.md
@@ -548,28 +548,10 @@ and `tooltip`. If your are using one of these components, you have only to rende
 
 For custom components you have to wrap your render code with a `portal` like this:
 ```kotlin
-fun Tag<HTMLElement>.myCustomOverlay() = portal(zIndex = 100) {
+fun Tag<HTMLElement>.myCustomOverlay() = portal { close: suspend (Unit) -> Unit -> // a handler to close the portal 
     // ...
 }
 ```
 
-::: info
-Since such order of the floating panel are controlled using ``z-index``, we have set different z-indices for the 
-Headless-Components.
-
-These are defined as constants as:
-```
-/**
- * Z-Index used for Portalled-Modals
- */
-const val PORTALLING_MODAL_ZINDEX = 10
-/**
- * Z-Index used for Portalled-Popups
- */
-const val PORTALLING_POPUP_ZINDEX = 30
-/**
- * Z-Index used for Portalled-Toasts
- */
-const val PORTALLING_TOAST_ZINDEX = 50
-```
-:::
+Beware that there is no [z-index](https://developer.mozilla.org/en-US/docs/Web/CSS/z-index) handling managed by the 
+portal mechanism - following the zen of headless, the portalling is totally styling agnostic. 

--- a/www/src/pages/headless/listbox.md
+++ b/www/src/pages/headless/listbox.md
@@ -66,6 +66,11 @@ listbox<String> {
 }
 ```
 
+::: info
+**Beware:** to include a `portalRoot()`-call at the end of your initial `RenderContext` as explained 
+[here](/headless/#portalling).
+:::
+
 ## Styling the active or selected Item 
 
 A `listboxItem` has two special states:

--- a/www/src/pages/headless/menu.md
+++ b/www/src/pages/headless/menu.md
@@ -62,6 +62,11 @@ menu {
 }
 ```
 
+::: info
+**Beware:** to include a `portalRoot()`-call at the end of your initial `RenderContext` as explained
+[here](/headless/#portalling).
+:::
+
 ## Styling the active Item
 
 If a `menuItem` is navigated to by keyboard or mouse movement, it is `active`.

--- a/www/src/pages/headless/modal.md
+++ b/www/src/pages/headless/modal.md
@@ -53,6 +53,11 @@ modal {
 }
 ```
 
+::: info
+**Beware:** to include a `portalRoot()`-call at the end of your initial `RenderContext` as explained
+[here](/headless/#portalling).
+:::
+
 ## Focus Management
 
 In order to prevent interaction with the rest of the application via keyboard interaction, the modal dialog uses a

--- a/www/src/pages/headless/popOver.md
+++ b/www/src/pages/headless/popOver.md
@@ -52,6 +52,11 @@ popOver {
 }
 ```
 
+::: info
+**Beware:** to include a `portalRoot()`-call at the end of your initial `RenderContext` as explained
+[here](/headless/#portalling).
+:::
+
 ## Open State
 
 PopOver is an [`OpenClose` component](#closable-content---openclose). There are different `Flow`s and `Handler`

--- a/www/src/pages/headless/toast.md
+++ b/www/src/pages/headless/toast.md
@@ -39,6 +39,11 @@ toast("default") {
 ```
 
 ::: info
+**Beware:** to include a `portalRoot()`-call at the end of your initial `RenderContext` as explained
+[here](/headless/#portalling).
+:::
+
+::: info
 Please note that the functionality of the headless toast component is intentionally limited.
 Consider using another component (e.g. [data collection](/headless/datacollection)) for more complex uses cases like
 filtering or sorting the toast list, or displaying more complex data.

--- a/www/src/pages/headless/tooltip.md
+++ b/www/src/pages/headless/tooltip.md
@@ -36,6 +36,11 @@ parent in the DOM. Therefore, call it on the result of the factory function used
 describe - either directly or using a scope-method like `apply`.
 :::
 
+::: info
+**Beware:** to include a `portalRoot()`-call at the end of your initial `RenderContext` as explained
+[here](/headless/#portalling).
+:::
+
 ## Transitions
 
 Showing and hiding the tooltip can easily be animated with the help of `transition`:


### PR DESCRIPTION
Updates some documentation sections due to the portalling mechanism:

- add some info-boxes to all headless components, relying on the portal-initialization
- update the general portal doc to remove the outdated `z-index` descriptions


fixes #809