### PR TITLE
make RootStore.runWithJob public

### DIFF
--- a/core/src/jsMain/kotlin/dev/fritz2/core/store.kt
+++ b/core/src/jsMain/kotlin/dev/fritz2/core/store.kt
@@ -201,9 +201,9 @@ open class RootStore<D>(
     }
 
     /**
-     * Allows to use the [WithJob]-Context of this Store. Allows to run [handledBy] on the Store-Job
+     * Allows to use the [WithJob]-Context of this Store and to run [handledBy] on the Store-Job
      */
-    protected fun runWithJob(init: WithJob.() -> Unit) = withJob.init()
+    fun runWithJob(init: WithJob.() -> Unit) = withJob.init()
 
     /**
      * Connects a [Flow] to a [Handler].


### PR DESCRIPTION
In #806 we created a protected runWithJob-Function within the RootStore to allow using the WithJob-Scope within a RootStore without allowing all handledBy functions be statically imported. To avoid excessive usage of the WithJob-Scope, we made this function protected.

After using the new RC in different projects we noticed, that not having a public runWithJob forces the developers to create workarounds for legitimate reasons. Therefore it seems to be a better idea to make runWithJob public.