### PR TITLE
Improves and enhances the reactive styling

### DIFF
--- a/core/src/jsMain/kotlin/dev/fritz2/core/mount.kt
+++ b/core/src/jsMain/kotlin/dev/fritz2/core/mount.kt
@@ -126,8 +126,9 @@ internal class MountContext<T : HTMLElement>(
     override val domNode: HTMLElement = target.domNode
     override val id = target.id
     override val baseClass = target.baseClass
-    override fun addToClasses(classesToAdd: String) = target.addToClasses(classesToAdd)
-    override fun addToClasses(classesToAdd: Flow<String>) = target.addToClasses(classesToAdd)
+    override fun className(value: String) = target.className(value)
+    override fun className(value: Flow<String>, initial: String) = target.className(value, initial)
+
     override val annex: RenderContext = target.annex
 
     override val scope: Scope = Scope(mountScope).apply { set(MOUNT_POINT_KEY, this@MountContext) }
@@ -257,7 +258,12 @@ private fun insertOrAppend(target: Node, child: Node, index: Int) {
  * @param element from type [WithDomNode]
  * @param index place to insert or append
  */
-private suspend inline fun insert(target: Node, mountPoints: MutableMap<Node, MountPointImpl>, element: WithDomNode<*>, index: Int) {
+private suspend inline fun insert(
+    target: Node,
+    mountPoints: MutableMap<Node, MountPointImpl>,
+    element: WithDomNode<*>,
+    index: Int
+) {
     insertOrAppend(target, element.domNode, index)
     mountPoints[element.domNode]?.runAfterMounts()
 }
@@ -269,7 +275,12 @@ private suspend inline fun insert(target: Node, mountPoints: MutableMap<Node, Mo
  * @param elements [List] of [WithDomNode]s elements to insert
  * @param index place to insert or append
  */
-private suspend inline fun insertMany(target: Node, mountPoints: MutableMap<Node, MountPointImpl>, elements: List<WithDomNode<*>>, index: Int) {
+private suspend inline fun insertMany(
+    target: Node,
+    mountPoints: MutableMap<Node, MountPointImpl>,
+    elements: List<WithDomNode<*>>,
+    index: Int
+) {
     val f = document.createDocumentFragment()
     for (child in elements) {
         f.append(child.domNode)

--- a/core/src/jsMain/kotlin/dev/fritz2/core/tags.kt
+++ b/core/src/jsMain/kotlin/dev/fritz2/core/tags.kt
@@ -156,21 +156,21 @@ interface Tag<out E : Element> : RenderContext, WithDomNode<E>, WithEvents<E> {
     fun className(value: Flow<String>, initial: String = "")
 
     /**
-     * Uses a [Flow] of [T] to create some class names by a [generate] lambda expression and add them to the classes
+     * Uses a [Flow] of [T] to create some class names by a [transform] lambda expression and add them to the classes
      * attribute of the [Tag].
      *
      * In order to set some classes *immediately*, you must provide some initial [T], which is used to create the
-     * initial classes value with the [generate] lambda.
+     * initial classes value with the [transform] lambda.
      *
      * Use this function, to avoid flickering effects on reactively based styling!
      *
-     * @param value a [Flow] of [T] that provide the parameter for the [generate] lambda
+     * @param value a [Flow] of [T] that provide the parameter for the [transform] lambda
      * @param initial some [T] that should be used as initial state in order to generate and add class names
      * immediately without waiting for the first value of the [Flow]
-     * @param generate a lambda expression, which finally creates class names by passing one [T]
+     * @param transform a lambda expression, which finally creates class names by passing one [T]
      */
-    fun <T> className(value: Flow<T>, initial: T, generate: (T) -> String) {
-        className(value.map(generate), generate(initial))
+    fun <T> className(value: Flow<T>, initial: T, transform: (T) -> String) {
+        className(value.map(transform), transform(initial))
     }
 
     /**

--- a/core/src/jsMain/kotlin/dev/fritz2/core/tags.kt
+++ b/core/src/jsMain/kotlin/dev/fritz2/core/tags.kt
@@ -3,7 +3,9 @@ package dev.fritz2.core
 import kotlinx.browser.document
 import kotlinx.browser.window
 import kotlinx.coroutines.Job
+import kotlinx.coroutines.MainScope
 import kotlinx.coroutines.flow.*
+import kotlinx.coroutines.plus
 import kotlinx.dom.clear
 import org.w3c.dom.Element
 import org.w3c.dom.Node
@@ -393,9 +395,7 @@ open class HtmlTag<out E : Element>(
     }
 
     override fun className(value: Flow<String>, initial: String) {
-        val flow = MutableStateFlow(initial)
-        value handledBy { flow.value = it }
-        classesStateFlow.value += flow
+        classesStateFlow.value += value.stateIn(MainScope() + job, SharingStarted.Eagerly, initial)
         // this ensures that the set state gets applied *immediately* without `Flow`-"delay"!
         //  in this case, the `initial` value gets applied as "promised".
         attr("class", buildClasses())

--- a/core/src/jsTest/kotlin/dev/fritz2/test.kt
+++ b/core/src/jsTest/kotlin/dev/fritz2/test.kt
@@ -17,9 +17,9 @@ fun <T> runTest(block: suspend WithJob.() -> T): dynamic = MainScope().promise {
     job.cancelAndJoin()
 }
 
-fun WithJob.renderWithJob(content: RenderContext.() -> Unit) {
+fun WithJob.renderWithJob(content: RenderContext.() -> Unit) : HtmlTag<HTMLDivElement> =
     HtmlTag<HTMLDivElement>("div", job = job, scope = Scope()).apply(content)
-}
+
 
 fun <T> checkSingleFlow(
     done: CompletableDeferred<Boolean> = CompletableDeferred(),

--- a/examples/validation/src/commonMain/kotlin/dev/fritz2/examples/validation/validator.kt
+++ b/examples/validation/src/commonMain/kotlin/dev/fritz2/examples/validation/validator.kt
@@ -3,10 +3,7 @@ package dev.fritz2.examples.validation
 import dev.fritz2.core.Lens
 import dev.fritz2.validation.ValidationMessage
 import dev.fritz2.validation.validation
-import kotlinx.datetime.Clock
-import kotlinx.datetime.LocalDate
-import kotlinx.datetime.TimeZone
-import kotlinx.datetime.todayAt
+import kotlinx.datetime.*
 
 enum class Status(val inputClass: String, val messageClass: String) {
     Valid("is-valid", "valid-feedback"),
@@ -34,7 +31,7 @@ val personValidator = validation<Person, Message> { inspector ->
 
     // validate the birthday
     val birthday = inspector.map(Person.birthday())
-    val today = Clock.System.todayAt(TimeZone.currentSystemDefault())
+    val today = Clock.System.todayIn(TimeZone.currentSystemDefault())
     when {
         birthday.data == LocalDate(1900, 1, 1) -> {
             add(Message(Person.id + birthday.path, Status.Invalid, "Please provide a birthday"))

--- a/headless-demo/package-lock.json
+++ b/headless-demo/package-lock.json
@@ -5,16 +5,16 @@
   "packages": {
     "": {
       "devDependencies": {
-        "@playwright/test": "^1.38.1"
+        "@playwright/test": "^1.40.1"
       }
     },
     "node_modules/@playwright/test": {
-      "version": "1.38.1",
-      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.38.1.tgz",
-      "integrity": "sha512-NqRp8XMwj3AK+zKLbZShl0r/9wKgzqI/527bkptKXomtuo+dOjU9NdMASQ8DNC9z9zLOMbG53T4eihYr3XR+BQ==",
+      "version": "1.40.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.40.1.tgz",
+      "integrity": "sha512-EaaawMTOeEItCRvfmkI9v6rBkF1svM8wjl/YPRrg2N2Wmp+4qJYkWtJsbew1szfKKDm6fPLy4YAanBhIlf9dWw==",
       "dev": true,
       "dependencies": {
-        "playwright": "1.38.1"
+        "playwright": "1.40.1"
       },
       "bin": {
         "playwright": "cli.js"
@@ -38,12 +38,12 @@
       }
     },
     "node_modules/playwright": {
-      "version": "1.38.1",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.38.1.tgz",
-      "integrity": "sha512-oRMSJmZrOu1FP5iu3UrCx8JEFRIMxLDM0c/3o4bpzU5Tz97BypefWf7TuTNPWeCe279TPal5RtPPZ+9lW/Qkow==",
+      "version": "1.40.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.40.1.tgz",
+      "integrity": "sha512-2eHI7IioIpQ0bS1Ovg/HszsN/XKNwEG1kbzSDDmADpclKc7CyqkHw7Mg2JCz/bbCxg25QUPcjksoMW7JcIFQmw==",
       "dev": true,
       "dependencies": {
-        "playwright-core": "1.38.1"
+        "playwright-core": "1.40.1"
       },
       "bin": {
         "playwright": "cli.js"
@@ -56,9 +56,9 @@
       }
     },
     "node_modules/playwright-core": {
-      "version": "1.38.1",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.38.1.tgz",
-      "integrity": "sha512-tQqNFUKa3OfMf4b2jQ7aGLB8o9bS3bOY0yMEtldtC2+spf8QXG9zvXLTXUeRsoNuxEYMgLYR+NXfAa1rjKRcrg==",
+      "version": "1.40.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.40.1.tgz",
+      "integrity": "sha512-+hkOycxPiV534c4HhpfX6yrlawqVUzITRKwHAmYfmsVreltEl6fAZJ3DPfLMOODw0H3s1Itd6MDCWmP1fl/QvQ==",
       "dev": true,
       "bin": {
         "playwright-core": "cli.js"

--- a/headless-demo/package.json
+++ b/headless-demo/package.json
@@ -1,5 +1,5 @@
 {
   "devDependencies": {
-    "@playwright/test": "^1.38.1"
+    "@playwright/test": "^1.40.1"
   }
 }

--- a/headless/src/jsMain/kotlin/dev/fritz2/headless/components/listbox.kt
+++ b/headless/src/jsMain/kotlin/dev/fritz2/headless/components/listbox.kt
@@ -175,7 +175,7 @@ class Listbox<T, C : HTMLElement>(tag: Tag<C>, id: String?) : Tag<C> by tag, Ope
         "$componentId-items",
         scope,
         this@Listbox.opened,
-        reference = button,
+        reference = button ?: button { },
         ariaHasPopup = Aria.HasPopup.listbox
     ) {
 

--- a/headless/src/jsMain/kotlin/dev/fritz2/headless/components/menu.kt
+++ b/headless/src/jsMain/kotlin/dev/fritz2/headless/components/menu.kt
@@ -103,7 +103,7 @@ class Menu<C : HTMLElement>(tag: Tag<C>, id: String?) : Tag<C> by tag, OpenClose
         "$componentId-items",
         scope,
         this@Menu.opened,
-        reference = button,
+        reference = button ?: button {  },
         ariaHasPopup = Aria.HasPopup.menu
     ) {
 

--- a/headless/src/jsMain/kotlin/dev/fritz2/headless/components/popOver.kt
+++ b/headless/src/jsMain/kotlin/dev/fritz2/headless/components/popOver.kt
@@ -73,7 +73,7 @@ class PopOver<C : HTMLElement>(tag: Tag<C>, id: String?) : Tag<C> by tag, OpenCl
         "$componentId-items",
         scope,
         this@PopOver.opened,
-        reference = button,
+        reference = button ?: button {  },
         ariaHasPopup = Aria.HasPopup.dialog
     )
 

--- a/headless/src/jsMain/kotlin/dev/fritz2/headless/foundation/PopUpPanel.kt
+++ b/headless/src/jsMain/kotlin/dev/fritz2/headless/foundation/PopUpPanel.kt
@@ -50,7 +50,7 @@ abstract class PopUpPanel<C : HTMLElement>(
     private val fullWidth: Boolean = true,
     private val reference: Tag<HTMLElement>?,
     private val ariaHasPopup: String,
-    tag: Tag<C> = tagFactory(renderContext, classes(classes, POPUP_HIDDEN_CLASSES), id, scope) {},
+    tag: Tag<C> = tagFactory(renderContext, classes, id, scope) {},
     private val config: ComputePositionConfig = obj {}
 ) : Tag<C> by tag, ComputePositionConfig by config {
 
@@ -271,14 +271,15 @@ abstract class PopUpPanel<C : HTMLElement>(
                 opened.transform {
                     if (it) {
                         computePosition()
-                        emit(POPUP_VISIBLE_CLASSES)
+                        emit(true)
                         this@PopUpPanel.waitForAnimation()
                     } else {
                         this@PopUpPanel.waitForAnimation()
-                        emit(POPUP_HIDDEN_CLASSES)
+                        emit(false)
                     }
-                }
-            )
+                },
+                false
+            ) { isOpen -> if (isOpen) POPUP_VISIBLE_CLASSES else POPUP_HIDDEN_CLASSES }
         }
     }
 }

--- a/versions.properties
+++ b/versions.properties
@@ -8,6 +8,7 @@
 #### suppress inspection "UnusedProperty" for whole file
 
 plugin.com.google.devtools.ksp=1.9.20-1.0.14
+##                 # available=2.0.0-Beta1-1.0.14
 
 plugin.org.jetbrains.dokka=1.9.10
 
@@ -39,6 +40,7 @@ version.junit.jupiter=5.10.1
 
 # needs to match ksp version!
 version.kotlin=1.9.20
+## # available=2.0.0-Beta1
 
 version.kotlinpoet=1.14.2
 
@@ -47,6 +49,7 @@ version.kotlinx.coroutines=1.7.3
 version.kotlinx.datetime=0.4.1
 
 version.kotlinx.serialization=1.6.0
+##                # available=1.6.1
 
  version.ktor=2.3.6
 
@@ -68,6 +71,10 @@ version.npm.postcss-loader=7.3.3
 
 version.npm.scroll-into-view-if-needed=2.2.29
 
+version.npm.style-loader=3.3.3
+
+version.npm.tailwindcss=3.3.5
+
 version.org.jetbrains.dokka..dokka-base=plugin.org.jetbrains.dokka
 
 version.org.jetbrains.dokka..jekyll-template-processing-plugin=plugin.org.jetbrains.dokka
@@ -77,7 +84,3 @@ version.org.jetbrains.dokka..gfm-template-processing-plugin=plugin.org.jetbrains
 version.org.jetbrains.dokka..analysis-kotlin-descriptors=plugin.org.jetbrains.dokka
 
 version.org.jetbrains.dokka..all-modules-page-plugin=plugin.org.jetbrains.dokka
-
-version.npm.style-loader=3.3.3
-
-version.npm.tailwindcss=3.3.5

--- a/www/src/pages/docs/30_Render HTML.md
+++ b/www/src/pages/docs/30_Render HTML.md
@@ -555,6 +555,17 @@ render {
 Use this one-liner to add styling and meaning to your elements by using semantic CSS class-names. Also, it keeps your
 code clean when using CSS frameworks like Bootstrap, Tailwind, etc.
 
+There is also the `className`-function which can also be used for setting static classes:
+
+```kotlin
+render {
+    div {
+        className("some-static-css-class")
+        button(id = "someId")
+    }
+}
+```
+
 To reactively change the styling of a rendered element, you can add dynamic classes by assigning a `Flow` of strings to
 the `className`-attribute (like with any other attribute).
 
@@ -567,6 +578,93 @@ render {
             if (it) "enabled-css-class"
             else "disabled-css-class"
         })
+        +"Some important content"
+    }
+}
+```
+
+You can also combine all of these approaches with arbitrary usages of `className`-variants, to handle different aspects
+separately:
+
+```kotlin
+render {
+    val enabled = storeOf(true)
+    val readonly = storeOf(true)
+
+    div("common-css-class") {
+        className("some-other-static-class")
+        className(enabled.data.map {
+            if (it) "enabled-css-class" 
+            else "disabled-css-class"
+        })
+        className(readonly.data.map { if(it) "readonly-csss-class" else "" })
+        +"Some important content"
+    }
+}
+```
+
+Beware that the first value of a `Flow` might take some time to be consumed and therefore applied to the `class` 
+attribute of a tag. This could lead to *flicker effects*, for example with floating elements, that should only become
+visible if activated. The following sections explains, how to overcome such unwanted effets.
+
+### Avoid Flicker Effects with Reactive Styling
+
+In order to avoid flicker effects caused by the delay of the first value becoming available on the flow, you must 
+provide some initial value, that can be applied immediately within the rendering process.
+
+The already shown `className`-function offers such an optional parameter, when looking at its complete signature:
+```kotlin
+fun className(value: Flow<String>, initial: String): Unit
+```
+
+For single classes or short class name groups, you can simply pass the appropriate initial classnames as second 
+parameter:
+```kotlin
+render {
+    val enabled = storeOf(true)
+
+    div("common-css-class") {
+        className(enabled.data.map {
+                if (it) "enabled-css-class"
+                else "disabled-css-class"
+            },
+            initial = "enabled-css-class"
+        )
+        +"Some important content"
+    }
+}
+```
+
+For simple use cases this is fine, but imagine someone changes the classnames for the initial state.
+You would have to think about also changing the `initial = "..."`-parameter, which can easily be overseen.
+
+That is why there is another `className`-function variant, which might better fit for more complex or volatile
+initial class name values:
+```kotlin
+fun <T> className(value: Flow<T>, initial: T, generate: (T) -> String): Unit
+```
+
+This function takes three parameters in order to solve the above problem:
+- `value` is just some `Flow`, that provides arbitrary values `T`. This can be simply some `Flow<Boolean>` but also
+combinations or any other needed type can be provided.
+- `initial` some value of `T`, which represents the initial state, that should get applied immediately.
+- `generate` some lambda expression, that uses one value of `T` in order to generate the appropriate class names for
+this specific value.
+
+The above problem is now solved by this function, as the `generate`-expression is the *single source of truth* of all
+class names. At first the `initial`-parameter is passed to the `generate`-expression to create the initial class names,
+that are applied immediately. Further on, each value appearing on the `value`-`Flow` will also be used with `generate`
+to create the appropriate class names.
+
+```kotlin
+render {
+    val enabled = storeOf(true)
+
+    div("common-css-class") {
+        className(enabled.data, initial = true) {
+            if (it) "enabled-css-class"
+            else "disabled-css-class"
+        }
         +"Some important content"
     }
 }
@@ -656,6 +754,23 @@ render {
         }
     }
 }
+```
+
+### Avoid Unsound Values with Reactive Attributes
+
+As the first value of a `Flow` might appear some time after the DOM portion of some tag is already rendered, it is
+possible, that the initial value of an attribute is not set or set with the wrong value. This could already lead to
+further unwanted side effects, if other behaviour or redering is derived by those attributes. Think of a falsy
+enabled `disabled` attribute of some `input` element for example.
+
+To immediately set any attribute like, the respective attribute-method must simply be called twice: First with the
+static value that should be set immediately, then with the `Flow` that provides the dynamic values:
+
+```kotlin
+val disabled: Flow<Boolean> = ...
+
+attr("disabled", "false")
+attr("disabled", disabled) // the first value of the `Flow` will override the static value set before.
 ```
 
 ### Minimize DOM Structure Changes within Reactive Updates: Precise Rendering
@@ -943,19 +1058,6 @@ render {
         +"Important content"
     }
 }
-```
-
-### Avoid Flicker Effects with Reactive Styling
-
-To immediately set any attribute like initial CSS classes (for example to avoid flicker effects caused by the delay
-of the first value becoming available on the flow), the respective attribute-method must be called twice.
-First with the static value that should be set immediately, then with the `Flow` that provides the dynamic values:
-
-```kotlin
-val visibility: Flow<String> = ...
-
-className("invisible")
-className(visibility)
 ```
 
 ## Advanced Topics

--- a/www/src/pages/docs/30_Render HTML.md
+++ b/www/src/pages/docs/30_Render HTML.md
@@ -641,19 +641,19 @@ You would have to think about also changing the `initial = "..."`-parameter, whi
 That is why there is another `className`-function variant, which might better fit for more complex or volatile
 initial class name values:
 ```kotlin
-fun <T> className(value: Flow<T>, initial: T, generate: (T) -> String): Unit
+fun <T> className(value: Flow<T>, initial: T, transform: (T) -> String): Unit
 ```
 
 This function takes three parameters in order to solve the above problem:
 - `value` is just some `Flow`, that provides arbitrary values `T`. This can be simply some `Flow<Boolean>` but also
 combinations or any other needed type can be provided.
 - `initial` some value of `T`, which represents the initial state, that should get applied immediately.
-- `generate` some lambda expression, that uses one value of `T` in order to generate the appropriate class names for
+- `transform` some lambda expression, that uses one value of `T` in order to generate the appropriate class names for
 this specific value.
 
-The above problem is now solved by this function, as the `generate`-expression is the *single source of truth* of all
-class names. At first the `initial`-parameter is passed to the `generate`-expression to create the initial class names,
-that are applied immediately. Further on, each value appearing on the `value`-`Flow` will also be used with `generate`
+The above problem is now solved by this function, as the `transform`-expression is the *single source of truth* of all
+class names. At first the `initial`-parameter is passed to the `transform`-expression to create the initial class names,
+that are applied immediately. Further on, each value appearing on the `value`-`Flow` will also be used with `transform`
 to create the appropriate class names.
 
 ```kotlin


### PR DESCRIPTION
needs #822 to be merged first!

- removes `addToClasses` functions. Migration: Just rename all occurrences to `className`.
- substitutes the internal class name management with a `MutableStateFlow` based approach, where the former manages all different portions of the overall class names, so those can get merged appropriately and mounted only once into the tag's `class` attribute.
- add a new `className`-function variant: This generic function accepts some `Flow[T]`, which is then be used by some lamba expression to generate the class names. Additionally the calles must also provide some initial `T`, which is used to create the
  initial class names that gets set immediately to the DOM, without needing to wait for the flow's first value.
- add unit tests for new `className`-function
- add and adapt documentation
- updates Playwright to version 1.40.1

Proposal for the release note:
- extract simple examples
- add link to the doc sections