### PR TITLE
Improves the validation message filtering and resets the default behaviour

### DIFF
--- a/core/src/jsMain/kotlin/dev/fritz2/validation/validation.kt
+++ b/core/src/jsMain/kotlin/dev/fritz2/validation/validation.kt
@@ -233,6 +233,6 @@ fun <M : ValidationMessage> Store<*>.messages(): Flow<List<M>>? = messages { mes
  * Be aware that the  filtering is based upon the correct usage of [Store.path]'s field. This can be reliably achieved
  * by using [dev.fritz2.core.Inspector]s and their mappings for creating the correct path values.
  */
-fun <M : ValidationMessage> Store<*>.messagesOfSubTree(): Flow<List<M>>? = messages { message ->
+fun <M : ValidationMessage> Store<*>.messagesOfSubModel(): Flow<List<M>>? = messages { message ->
     message.path == path || message.path.startsWith("$path.")
 }

--- a/core/src/jsMain/kotlin/dev/fritz2/validation/validation.kt
+++ b/core/src/jsMain/kotlin/dev/fritz2/validation/validation.kt
@@ -147,7 +147,7 @@ fun <D, T, M> WithJob.storeOf(
     job: Job = this.job,
     id: String = Id.next(),
 ): ValidatingStore<D, T, M> =
-    ValidatingStore(initialData, validation, metadataDefault,  job, validateAfterUpdate = true, id)
+    ValidatingStore(initialData, validation, metadataDefault, job, validateAfterUpdate = true, id)
 
 /**
  * Convenience function to create a simple [ValidatingStore] without any metadata and handlers.
@@ -168,12 +168,14 @@ fun <D, M> WithJob.storeOf(
     ValidatingStore(initialData, validation, Unit, job, validateAfterUpdate = true, id)
 
 /**
- * Finds all corresponding [ValidationMessage]s to this [Store].
+ * Finds all corresponding [ValidationMessage]s to this [Store] which satisfy the [filterPredicate]-expression.
  *
  * Be aware that the  filtering is based upon the correct usage of [Store.path]'s field. This can be reliably achieved
  * by using [dev.fritz2.core.Inspector]s and their mappings for creating the correct path values.
+ *
+ * @param filterPredicate expression to filter messages.
  */
-fun <M : ValidationMessage> Store<*>.messages(): Flow<List<M>>? =
+fun <M : ValidationMessage> Store<*>.messages(filterPredicate: (M) -> Boolean): Flow<List<M>>? =
     when (this) {
         is ValidatingStore<*, *, *> -> {
             try {
@@ -190,10 +192,7 @@ fun <M : ValidationMessage> Store<*>.messages(): Flow<List<M>>? =
             }
             if (store is ValidatingStore<*, *, *>) {
                 try {
-                    store.messages.map {
-                        it.unsafeCast<List<M>>()
-                            .filter { m -> m.path == this.path || m.path.startsWith("${this.path}.") }
-                    }
+                    store.messages.map { it.unsafeCast<List<M>>().filter(filterPredicate) }
                 } catch (e: Exception) {
                     null
                 }
@@ -202,3 +201,38 @@ fun <M : ValidationMessage> Store<*>.messages(): Flow<List<M>>? =
 
         else -> null
     }
+
+/**
+ * Finds all exactly corresponding [ValidationMessage]s to this [Store], which means all messages, which have exactly
+ * the same path as the [Store].
+ *
+ * Be aware that the  filtering is based upon the correct usage of [Store.path]'s field. This can be reliably achieved
+ * by using [dev.fritz2.core.Inspector]s and their mappings for creating the correct path values.
+ */
+fun <M : ValidationMessage> Store<*>.messages(): Flow<List<M>>? = messages { message -> message.path == path }
+
+/**
+ * Finds all corresponding [ValidationMessage]s to this [Store], which means all messages, that fit exactly with their
+ * path or which are sub-elements of this [Store]s data model.
+ *
+ * Consider the following example:
+ * ```
+ * Store path = ".person.address"
+ *
+ * // included
+ * ".person.address"
+ * ".person.address.street"
+ * ".person.address.city"
+ * ".person.address.coordinates.altitude"
+ *
+ * // not included
+ * - ".person.addresses"
+ * - ".person.other"
+ * ```
+ *
+ * Be aware that the  filtering is based upon the correct usage of [Store.path]'s field. This can be reliably achieved
+ * by using [dev.fritz2.core.Inspector]s and their mappings for creating the correct path values.
+ */
+fun <M : ValidationMessage> Store<*>.messagesOfSubTree(): Flow<List<M>>? = messages { message ->
+    message.path == path || message.path.startsWith("$path.")
+}

--- a/core/src/jsTest/kotlin/dev/fritz2/validation/validation.kt
+++ b/core/src/jsTest/kotlin/dev/fritz2/validation/validation.kt
@@ -104,33 +104,33 @@ class ValidationJSTests {
                     colorStore.data.map { "${it.r}, ${it.g}, ${it.b}" }.renderText()
                 }
                 div(id = idMessagesIntermediateLevel) {
-                    colorStore.messagesOfSubTree<Message>()?.renderEach(Message::path, into = this) {
+                    colorStore.messagesOfSubModel<Message>()?.renderEach(Message::path, into = this) {
                         p {
                             +it.text
                         }
                     }
                 }
                 div(id = idPathIntermediateLevel) {
-                    colorStore.messagesOfSubTree<Message>()
+                    colorStore.messagesOfSubModel<Message>()
                         ?.map { messages -> messages.all { it.path.startsWith(".color") } }
                         ?.renderText(into = this)
                 }
                 div(id = idMessagesR) {
-                    rColorStore.messagesOfSubTree<Message>()?.renderEach(Message::path, into = this) {
+                    rColorStore.messagesOfSubModel<Message>()?.renderEach(Message::path, into = this) {
                         p {
                             +it.path
                         }
                     }
                 }
                 div(id = idMessagesG) {
-                    gColorStore.messagesOfSubTree<Message>()?.renderEach(Message::path, into = this) {
+                    gColorStore.messagesOfSubModel<Message>()?.renderEach(Message::path, into = this) {
                         p {
                             +it.path
                         }
                     }
                 }
                 div(id = idMessagesB) {
-                    bColorStore.messagesOfSubTree<Message>()?.renderEach(Message::path, into = this) {
+                    bColorStore.messagesOfSubModel<Message>()?.renderEach(Message::path, into = this) {
                         p {
                             +it.path
                         }
@@ -232,7 +232,7 @@ class MessageFilterTests {
         val id = Id.next()
         render {
             span(id = id) {
-                store.map(Foo.barLens).messagesOfSubTree<Message>()?.mapNotNull { it.size.toString() }?.renderText()
+                store.map(Foo.barLens).messagesOfSubModel<Message>()?.mapNotNull { it.size.toString() }?.renderText()
             }
         }
 
@@ -286,15 +286,15 @@ class MessageFilterTests {
         render {
             span(id = id) {
                 // 1
-                store.map(Foo.fooLens).messagesOfSubTree<Message>()?.map { it.size.toString() }?.renderText()
+                store.map(Foo.fooLens).messagesOfSubModel<Message>()?.map { it.size.toString() }?.renderText()
                 // 1
-                store.map(Foo.foobarLens).messagesOfSubTree<Message>()?.map { it.size.toString() }?.renderText()
+                store.map(Foo.foobarLens).messagesOfSubModel<Message>()?.map { it.size.toString() }?.renderText()
                 // 2
-                store.map(Foo.barLens).messagesOfSubTree<Message>()?.map { it.size.toString() }?.renderText()
+                store.map(Foo.barLens).messagesOfSubModel<Message>()?.map { it.size.toString() }?.renderText()
                 // 1
-                store.map(Foo.fooLens).messagesOfSubTree<Message>()?.map { it.size.toString() }?.renderText()
+                store.map(Foo.fooLens).messagesOfSubModel<Message>()?.map { it.size.toString() }?.renderText()
                 // 1
-                store.map(Foo.fooLens).messagesOfSubTree<Message>()?.map { it.size.toString() }?.renderText()
+                store.map(Foo.fooLens).messagesOfSubModel<Message>()?.map { it.size.toString() }?.renderText()
             }
         }
 


### PR DESCRIPTION
### Motivation

Up to the `RC5 / RC6` version of fritz2, the `messages()`-function on `Store`s just matched the *exact* path. This behavior was changed by those release candidates: Right now all messages that matches the exact path, but also all messages machining the sub-path will be collected.

Our experience has shown, that this behavior change was a mistake, as the 80% use case is to collect all messages for an exact path. Most of the time one has dedicated form elements, that fit exactly one property of a model and thus should only show messages for itself. It is very rarely happening, that all messages of a sub-model should be shown all together.

This is why this PR changes again the default behavior, but also introduces a dedicated variant for collecting all sub-model messages with the new `messagesOfSubModel()`-function.

Also, we expose the `messages(filterPredicate: (M) -> Boolean)`-function, which both other functions uses internally. You can use this function apply custom filtering to the messages.

#### Overview

- use `messages()` if you want only exact path-matches
- use `messagesOfSubModel()` if you want all paths that match exactly or that share the same prefix as the receiving `Store`
- use `messages(filterPredicate: (M) -> Boolean)` if you want to apply your own, custom filter

#### Migration Guide

If you want to stick with the behavior from RC5 up to now, just rename all your `messages()` calls into `messagesOfSubModel()` and you are done.

If you have created custom filtering to get the exact match, in order to bypass the behavior, you can simply drop those now.

Reverts introduced behavior from #767 and #761