### PR TITLE
scope handling for portal containers

### DIFF
--- a/core/src/jsMain/kotlin/dev/fritz2/core/foundation.kt
+++ b/core/src/jsMain/kotlin/dev/fritz2/core/foundation.kt
@@ -48,6 +48,7 @@ fun render(
  * @param targetElement [HTMLElement] to mount to, default is *document.body*
  * @param override if true all child elements are removed before rendering
  * @param content [RenderContext] for rendering the data to the DOM
+ * @param scope scope for tag
  * @throws MountTargetNotFoundException if [targetElement] not found
  */
 fun render(

--- a/core/src/jsMain/kotlin/dev/fritz2/core/foundation.kt
+++ b/core/src/jsMain/kotlin/dev/fritz2/core/foundation.kt
@@ -25,17 +25,19 @@ class MountTargetNotFoundException(message: String) : Exception(message)
  * @param selector [query selector](https://developer.mozilla.org/en-US/docs/Web/API/Document/querySelector)
  * of the element to mount to
  * @param override if true all child elements are removed before rendering
+ * @param scope scope for tag
  * @param content [RenderContext] for rendering the data to the DOM
  * @throws MountTargetNotFoundException if target element with [selector] not found
  */
 fun render(
     selector: String,
     override: Boolean = true,
+    scope: (ScopeContext.() -> Unit) = {},
     content: RenderContext.() -> Unit
 ) {
     document.querySelector(selector)?.let { parentElement ->
         if (parentElement is HTMLElement) {
-            render(parentElement, override, content)
+            render(parentElement, override, scope, content)
         } else MountTargetNotFoundException("element with id=$selector is not an HTMLElement")
     } ?: throw MountTargetNotFoundException("html document contains no element with id=$selector")
 }
@@ -51,6 +53,7 @@ fun render(
 fun render(
     targetElement: HTMLElement? = document.body,
     override: Boolean = true,
+    scope: (ScopeContext.() -> Unit) = {},
     content: RenderContext.() -> Unit
 ) {
     //add style sheet containing mount-point-class
@@ -61,7 +64,10 @@ fun render(
 
         val mountPoint = object : RenderContext, MountPointImpl() {
             override val job = Job()
-            override val scope: Scope = Scope().also { scope -> scope[MOUNT_POINT_KEY] = this }
+            override val scope: Scope = ScopeContext(Scope()).also {
+                scope(it)
+                it.set(MOUNT_POINT_KEY, this)
+            }.scope
 
             override fun <N : Node, W : WithDomNode<N>> register(element: W, content: (W) -> Unit): W {
                 content(element)

--- a/core/src/jsMain/kotlin/dev/fritz2/core/scope.kt
+++ b/core/src/jsMain/kotlin/dev/fritz2/core/scope.kt
@@ -206,3 +206,9 @@ operator fun (ScopeContext.() -> Unit).plus(scope: Scope): ScopeContext.() -> Un
     scope.keys.map { it.unsafeCast<Key<Any>>() }
         .forEach { key -> scope[key]?.let { set(key, it) } }
 }
+
+operator fun Scope.plus(scope: ScopeContext.() -> Unit): ScopeContext.() -> Unit = {
+    keys.map { it.unsafeCast<Key<Any>>() }
+        .forEach { key -> get(key)?.let { set(key, it) } }
+    scope.invoke(this)
+}

--- a/core/src/jsMain/kotlin/dev/fritz2/core/scope.kt
+++ b/core/src/jsMain/kotlin/dev/fritz2/core/scope.kt
@@ -195,3 +195,14 @@ class ScopeContext(private var current: Scope) {
         current[key] = value
     }
 }
+
+operator fun (ScopeContext.() -> Unit).plus(plus: ScopeContext.() -> Unit): ScopeContext.() -> Unit = {
+    this@plus.invoke(this)
+    plus.invoke(this)
+}
+
+operator fun (ScopeContext.() -> Unit).plus(scope: Scope): ScopeContext.() -> Unit = {
+    this@plus.invoke(this)
+    scope.keys.map { it.unsafeCast<Key<Any>>() }
+        .forEach { key -> scope[key]?.let { set(key, it) } }
+}

--- a/headless/src/jsMain/kotlin/dev/fritz2/headless/components/listbox.kt
+++ b/headless/src/jsMain/kotlin/dev/fritz2/headless/components/listbox.kt
@@ -164,7 +164,7 @@ class Listbox<T, C : HTMLElement>(tag: Tag<C>, id: String?) : Tag<C> by tag, Ope
     ) = listboxValidationMessages(classes, scope, RenderContext::div, initialize)
 
     inner class ListboxItems<CI : HTMLElement>(
-        val renderContext: RenderContext,
+        renderContext: RenderContext,
         tagFactory: TagFactory<Tag<CI>>,
         classes: String?,
         scope: ScopeContext.() -> Unit

--- a/headless/src/jsMain/kotlin/dev/fritz2/headless/components/modal.kt
+++ b/headless/src/jsMain/kotlin/dev/fritz2/headless/components/modal.kt
@@ -30,7 +30,7 @@ class Modal(id: String?) : OpenClose() {
     fun init() {
         opened.filter { it }.handledBy {
             PortalRenderContext.run {
-                portal(id = componentId, tag = RenderContext::dialog) { close ->
+                portal(id = componentId, tag = RenderContext::dialog, scope = scopeContext) { close ->
                     inlineStyle("display: contents")
                     panel?.invoke(this)!!.apply {
                         trapFocusInMountpoint(restoreFocus, setInitialFocus)

--- a/headless/src/jsMain/kotlin/dev/fritz2/headless/components/toast.kt
+++ b/headless/src/jsMain/kotlin/dev/fritz2/headless/components/toast.kt
@@ -50,7 +50,7 @@ fun <E : HTMLElement> toastContainer(
     scope: (ScopeContext.() -> Unit) = {},
     tag: TagFactory<Tag<E>>
 ) {
-    PortalRenderContext.portal(classes, id, scope + PortalRenderContext.scopeContext, tag) {
+    PortalRenderContext.portal(classes, id, PortalRenderContext.scopeContext + scope, tag) {
         addComponentStructureInfo("toast-container ($name)", this.scope, this)
         attrIfNotSet(Aria.live, "polite")
         ToastStore.filteredByContainer(name).renderEach(into = this) { fragment ->

--- a/headless/src/jsMain/kotlin/dev/fritz2/headless/components/toast.kt
+++ b/headless/src/jsMain/kotlin/dev/fritz2/headless/components/toast.kt
@@ -50,7 +50,7 @@ fun <E : HTMLElement> toastContainer(
     scope: (ScopeContext.() -> Unit) = {},
     tag: TagFactory<Tag<E>>
 ) {
-    PortalRenderContext.portal(classes, id, scope, tag) {
+    PortalRenderContext.portal(classes, id, scope + PortalRenderContext.scopeContext, tag) {
         addComponentStructureInfo("toast-container ($name)", this.scope, this)
         attrIfNotSet(Aria.live, "polite")
         ToastStore.filteredByContainer(name).renderEach(into = this) { fragment ->

--- a/headless/src/jsMain/kotlin/dev/fritz2/headless/foundation/portalling.kt
+++ b/headless/src/jsMain/kotlin/dev/fritz2/headless/foundation/portalling.kt
@@ -42,15 +42,19 @@ private data class PortalContainer<C : HTMLElement>(
  *
  * @see portal
  */
-fun RenderContext.portalRoot(): RenderContext {
+fun RenderContext.portalRoot(scopeContext: (ScopeContext.() -> Unit) = {}): RenderContext {
     addComponentStructureInfo(portalRootId, this.scope, this)
-    register(PortalRenderContext) {}
+    register(PortalRenderContext.withScope(scopeContext + scope)) {}
     return PortalRenderContext
 }
 
 internal object PortalRenderContext : HtmlTag<HTMLDivElement>("div", portalRootId, null, Job(), Scope()) {
 
+    var scopeContext: ScopeContext.() -> Unit = {}
 
+    fun withScope(scopeContext: ScopeContext.() -> Unit): PortalRenderContext = apply {
+        this.scopeContext = scopeContext + scope
+    }
 
     init {
         attr(Aria.live, "polite")
@@ -92,7 +96,7 @@ fun <C : HTMLElement> RenderContext.portal(
         PortalContainer(
             classes = classes,
             id = portalId,
-            scope = scope,
+            scope = scope + this.scope,
             tag = tag,
             reference = reference?.mountPoint(),
             content = content

--- a/headless/src/jsMain/kotlin/dev/fritz2/headless/foundation/portalling.kt
+++ b/headless/src/jsMain/kotlin/dev/fritz2/headless/foundation/portalling.kt
@@ -96,7 +96,7 @@ fun <C : HTMLElement> RenderContext.portal(
         PortalContainer(
             classes = classes,
             id = portalId,
-            scope = scope + this.scope,
+            scope = this.scope + scope,
             tag = tag,
             reference = reference?.mountPoint(),
             content = content


### PR DESCRIPTION
In #781 we added portalling, but portals currently do not inherit any scope.

In this PR portal-containers get a scope of some defined parent tags.

We have two types of portals:

Bound to the ViewPort:

- Modal
- Toast

These Portals will inherit the Scope of the PortalRoot, which inherits the Scope of its parent (usually the main render Function). 
Both the portalRoot() function and the global render() function got a scope parameter, so the user can set scopes as for every tag.

The second type of portals is bound to a reference element:

- listbox
- menu
- popOver
- tooltip

These portals inherit the scope of their reference element, to which they get aligned.