### PR TITLE
avoid events in flatMapLatest

### DIFF
--- a/headless/src/jsMain/kotlin/dev/fritz2/headless/components/checkboxGroup.kt
+++ b/headless/src/jsMain/kotlin/dev/fritz2/headless/components/checkboxGroup.kt
@@ -167,9 +167,8 @@ class CheckboxGroup<C : HTMLElement, T>(tag: Tag<C>, private val explicitId: Str
                     value.handler?.invoke(
                         this,
                         keydowns.filter { shortcutOf(it) == Keys.Space }
+                            .stopImmediatePropagation().preventDefault()
                             .map {
-                                it.stopImmediatePropagation()
-                                it.preventDefault()
                                 val value = value.data.first()
                                 if (value.contains(option)) value - option else value + option
                         })

--- a/headless/src/jsMain/kotlin/dev/fritz2/headless/components/checkboxGroup.kt
+++ b/headless/src/jsMain/kotlin/dev/fritz2/headless/components/checkboxGroup.kt
@@ -3,7 +3,7 @@ package dev.fritz2.headless.components
 import dev.fritz2.core.*
 import dev.fritz2.headless.foundation.*
 import kotlinx.coroutines.flow.filter
-import kotlinx.coroutines.flow.flatMapLatest
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.map
 import org.w3c.dom.*
 
@@ -160,18 +160,18 @@ class CheckboxGroup<C : HTMLElement, T>(tag: Tag<C>, private val explicitId: Str
                     withKeyboardNavigation = false
                     toggleEvent = changes
                 }
-                value.handler?.invoke(this, value.data.flatMapLatest { value ->
-                    toggleEvent.map { if (value.contains(option)) value - option else value + option }
-                })
+                value.handler?.invoke(this, toggleEvent
+                    .map { value.data.first() }
+                    .map { value -> if (value.contains(option)) value - option else value + option })
                 if (withKeyboardNavigation) {
                     value.handler?.invoke(
                         this,
-                        value.data.flatMapLatest { value ->
-                            keydowns.filter { shortcutOf(it) == Keys.Space }.map {
+                        keydowns.filter { shortcutOf(it) == Keys.Space }
+                            .map {
                                 it.stopImmediatePropagation()
                                 it.preventDefault()
+                                val value = value.data.first()
                                 if (value.contains(option)) value - option else value + option
-                            }
                         })
                 }
             }.also { toggle = it }

--- a/headless/src/jsMain/kotlin/dev/fritz2/headless/components/dataCollection.kt
+++ b/headless/src/jsMain/kotlin/dev/fritz2/headless/components/dataCollection.kt
@@ -6,6 +6,7 @@ import dev.fritz2.headless.foundation.utils.scrollintoview.*
 import kotlinx.browser.document
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.MainScope
+import kotlinx.coroutines.NonCancellable.isActive
 import kotlinx.coroutines.flow.*
 import kotlinx.coroutines.plus
 import org.w3c.dom.HTMLButtonElement
@@ -422,11 +423,8 @@ class DataCollection<T, C : HTMLElement>(tag: Tag<C>) : Tag<C> by tag {
                     data.value?.let { selection.selectItem(clicks.map { item }, it) }
                 }
 
-                active.flatMapLatest { isActive ->
-                    mousemoves.mapNotNull {
-                        if (!isActive) (item to false)
-                        else null
-                    }
+                mousemoves.mapNotNull {
+                    if (!active.first()) (item to false) else null
                 } handledBy activeItem.update
 
                 if (scrollIntoView.isSet) {

--- a/headless/src/jsMain/kotlin/dev/fritz2/headless/components/menu.kt
+++ b/headless/src/jsMain/kotlin/dev/fritz2/headless/components/menu.kt
@@ -132,41 +132,39 @@ class Menu<C : HTMLElement>(tag: Tag<C>, id: String?) : Tag<C> by tag, OpenClose
             attrIfNotSet("tabindex", "0")
             attr("role", Aria.Role.menu)
 
-            state.flatMapLatest { (currentIndex, items) ->
-                keydowns.mapNotNull { event ->
-                    when (shortcutOf(event)) {
-                        Keys.ArrowUp -> nextItem(currentIndex, Direction.Previous, items)
-                        Keys.ArrowDown -> nextItem(currentIndex, Direction.Next, items)
-                        Keys.Home -> firstItem(items)
-                        Keys.End -> lastItem(items)
-                        else -> null
-                    }.also {
-                        if (it != null) {
-                            event.stopImmediatePropagation()
-                            event.preventDefault()
-                        }
+            keydowns.mapNotNull { event ->
+                val currentIndex = activeIndex.current
+                val items = items.current
+                when (shortcutOf(event)) {
+                    Keys.ArrowUp -> nextItem(currentIndex, Direction.Previous, items)
+                    Keys.ArrowDown -> nextItem(currentIndex, Direction.Next, items)
+                    Keys.Home -> firstItem(items)
+                    Keys.End -> lastItem(items)
+                    else -> null
+                }.also {
+                    if (it != null) {
+                        event.stopImmediatePropagation()
+                        event.preventDefault()
                     }
                 }
             } handledBy activeIndex.update
 
-            items.data.flatMapLatest { items ->
-                keydowns
-                    .mapNotNull { e -> if (e.key.length == 1) e.key.first().lowercaseChar() else null }
-                    .mapNotNull { c ->
-                        if (c.isLetterOrDigit()) itemByCharacter(items, c)
-                        else null
-                    }
-            } handledBy activeIndex.update
+            keydowns
+                .mapNotNull { e -> if (e.key.length == 1) e.key.first().lowercaseChar() else null }
+                .mapNotNull { c ->
+                    if (c.isLetterOrDigit()) itemByCharacter(items.current, c)
+                    else null
+                } handledBy activeIndex.update
 
-            state.flatMapLatest { (currentIndex, disabled) ->
-                keydowns.filter { setOf(Keys.Enter, Keys.Space).contains(shortcutOf(it)) }.mapNotNull {
-                    if (currentIndex == -1 || disabled[currentIndex].disabled) {
-                        null
-                    } else {
-                        it.preventDefault()
-                        it.stopImmediatePropagation()
-                        currentIndex
-                    }
+            keydowns.filter { setOf(Keys.Enter, Keys.Space).contains(shortcutOf(it)) }.mapNotNull {
+                val currentIndex = activeIndex.current
+                val disabled = items.current
+                if (currentIndex == -1 || disabled[currentIndex].disabled) {
+                    null
+                } else {
+                    it.preventDefault()
+                    it.stopImmediatePropagation()
+                    currentIndex
                 }
             } handledBy selections.update
 

--- a/headless/src/jsMain/kotlin/dev/fritz2/headless/components/radioGroup.kt
+++ b/headless/src/jsMain/kotlin/dev/fritz2/headless/components/radioGroup.kt
@@ -3,10 +3,7 @@ package dev.fritz2.headless.components
 import dev.fritz2.core.*
 import dev.fritz2.headless.foundation.*
 import kotlinx.browser.document
-import kotlinx.coroutines.flow.distinctUntilChanged
-import kotlinx.coroutines.flow.flatMapLatest
-import kotlinx.coroutines.flow.map
-import kotlinx.coroutines.flow.mapNotNull
+import kotlinx.coroutines.flow.*
 import org.w3c.dom.*
 
 /**
@@ -41,18 +38,17 @@ class RadioGroup<C : HTMLElement, T>(tag: Tag<C>, private val explicitId: String
         if (withKeyboardNavigation) {
             value.handler?.invoke(
                 this,
-                value.data.flatMapLatest { option ->
-                    keydowns.mapNotNull { event ->
-                        when (shortcutOf(event)) {
-                            Keys.ArrowDown -> options.rotateNext(option)
-                            Keys.ArrowUp -> options.rotatePrevious(option)
-                            else -> null
-                        }.also {
-                            if (it != null) {
-                                event.stopImmediatePropagation()
-                                event.preventDefault()
-                                isActive.update(it)
-                            }
+                keydowns.mapNotNull { event ->
+                    val option = value.data.first()
+                    when (shortcutOf(event)) {
+                        Keys.ArrowDown -> options.rotateNext(option)
+                        Keys.ArrowUp -> options.rotatePrevious(option)
+                        else -> null
+                    }.also {
+                        if (it != null) {
+                            event.stopImmediatePropagation()
+                            event.preventDefault()
+                            isActive.update(it)
                         }
                     }
                 })

--- a/headless/src/jsMain/kotlin/dev/fritz2/headless/components/switch.kt
+++ b/headless/src/jsMain/kotlin/dev/fritz2/headless/components/switch.kt
@@ -171,7 +171,7 @@ class SwitchWithLabel<C : HTMLElement>(tag: Tag<C>, id: String?) :
     ): Tag<CL> {
         addComponentStructureInfo("switchLabel", this@switchLabel.scope, this)
         return tag(this, classes, "$componentId-label", scope, content).apply {
-            value.handler?.invoke(this, clicks.map { !value.data.first() })
+            value.handler?.invoke(this, clicks.onEach { it.preventDefault() }.map { !value.data.first() })
         }.also { label = it }
     }
 

--- a/headless/src/jsMain/kotlin/dev/fritz2/headless/components/switch.kt
+++ b/headless/src/jsMain/kotlin/dev/fritz2/headless/components/switch.kt
@@ -38,11 +38,10 @@ abstract class AbstractSwitch<C : HTMLElement>(
         value.handler?.invoke(this, clicks.map { !value.data.first() })
         value.handler?.invoke(
             this,
-            keydowns.filter { shortcutOf(it) == Keys.Space }.map {
-                it.stopImmediatePropagation()
-                it.preventDefault()
-                !value.data.first()
-            }
+            keydowns.filter { shortcutOf(it) == Keys.Space }
+                .stopImmediatePropagation()
+                .preventDefault()
+                .map { !value.data.first() }
         )
     }
 
@@ -171,7 +170,7 @@ class SwitchWithLabel<C : HTMLElement>(tag: Tag<C>, id: String?) :
     ): Tag<CL> {
         addComponentStructureInfo("switchLabel", this@switchLabel.scope, this)
         return tag(this, classes, "$componentId-label", scope, content).apply {
-            value.handler?.invoke(this, clicks.onEach { it.preventDefault() }.map { !value.data.first() })
+            value.handler?.invoke(this, clicks.preventDefault().map { !value.data.first() })
         }.also { label = it }
     }
 

--- a/headless/src/jsMain/kotlin/dev/fritz2/headless/components/switch.kt
+++ b/headless/src/jsMain/kotlin/dev/fritz2/headless/components/switch.kt
@@ -2,10 +2,7 @@ package dev.fritz2.headless.components
 
 import dev.fritz2.core.*
 import dev.fritz2.headless.foundation.*
-import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.filter
-import kotlinx.coroutines.flow.flatMapLatest
-import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.*
 import org.w3c.dom.*
 
 /**
@@ -38,16 +35,15 @@ abstract class AbstractSwitch<C : HTMLElement>(
         attr(Aria.checked, enabled.asString())
         attr(Aria.invalid, "true".whenever(value.hasError))
         attr("tabindex", "0")
-        value.handler?.invoke(this, value.data.flatMapLatest { state -> clicks.map { !state } })
+        value.handler?.invoke(this, clicks.map { !value.data.first() })
         value.handler?.invoke(
             this,
-            value.data.flatMapLatest { state ->
-                keydowns.filter { shortcutOf(it) == Keys.Space }.map {
-                    it.stopImmediatePropagation()
-                    it.preventDefault()
-                    !state
-                }
-            })
+            keydowns.filter { shortcutOf(it) == Keys.Space }.map {
+                it.stopImmediatePropagation()
+                it.preventDefault()
+                !value.data.first()
+            }
+        )
     }
 
     /**
@@ -175,7 +171,7 @@ class SwitchWithLabel<C : HTMLElement>(tag: Tag<C>, id: String?) :
     ): Tag<CL> {
         addComponentStructureInfo("switchLabel", this@switchLabel.scope, this)
         return tag(this, classes, "$componentId-label", scope, content).apply {
-            value.handler?.invoke(this, value.data.flatMapLatest { state -> clicks.map { !state } })
+            value.handler?.invoke(this, clicks.map { !value.data.first() })
         }.also { label = it }
     }
 

--- a/headless/src/jsMain/kotlin/dev/fritz2/headless/components/tabGroup.kt
+++ b/headless/src/jsMain/kotlin/dev/fritz2/headless/components/tabGroup.kt
@@ -140,15 +140,17 @@ class TabGroup<C : HTMLElement>(tag: Tag<C>, id: String?) : Tag<C> by tag {
                 }
             }.handledBy(this, withActiveUpdates(::nextByKeys))
 
-            keydowns.filter { setOf(Keys.Home, Keys.PageUp).contains(shortcutOf(it)) }.map {
-                it.stopImmediatePropagation()
-                it.preventDefault()
-            }.handledBy(this, withActiveUpdates(::firstByKey))
+            keydowns.filter { setOf(Keys.Home, Keys.PageUp).contains(shortcutOf(it)) }
+                .stopImmediatePropagation()
+                .preventDefault()
+                .map { }
+                .handledBy(this, withActiveUpdates(::firstByKey))
 
-            keydowns.filter { setOf(Keys.End, Keys.PageDown).contains(shortcutOf(it)) }.map {
-                it.stopImmediatePropagation()
-                it.preventDefault()
-            }.handledBy(this, withActiveUpdates(::lastByKey))
+            keydowns.filter { setOf(Keys.End, Keys.PageDown).contains(shortcutOf(it)) }
+                .stopImmediatePropagation()
+                .preventDefault()
+                .map { }
+                .handledBy(this, withActiveUpdates(::lastByKey))
         }
 
         inner class Tab<CT : HTMLElement>(

--- a/headless/src/jsMain/kotlin/dev/fritz2/headless/foundation/OpenClose.kt
+++ b/headless/src/jsMain/kotlin/dev/fritz2/headless/foundation/OpenClose.kt
@@ -50,7 +50,7 @@ abstract class OpenClose: WithJob {
      */
     protected fun Tag<*>.toggleOnClicksEnterAndSpace() {
         merge(clicks, keydowns.filter { setOf(Keys.Space, Keys.Enter).contains(shortcutOf(it)) })
-            .onEach { it.preventDefault() }.onEach { it.stopPropagation() } handledBy toggle
+            .preventDefault().stopPropagation() handledBy toggle
     }
 
     /**

--- a/headless/src/jsMain/kotlin/dev/fritz2/headless/foundation/focus.kt
+++ b/headless/src/jsMain/kotlin/dev/fritz2/headless/foundation/focus.kt
@@ -251,9 +251,7 @@ fun Tag<HTMLElement>.trapFocusWhenever(
         }
     }
     trapFocusOn(
-        sharedCondition.flatMapLatest { isActive ->
-            keydowns.filter { isActive && setOf(Keys.Tab, Keys.Shift + Keys.Tab).contains(shortcutOf(it)) }
-        }
+        keydowns.filter { sharedCondition.first() && setOf(Keys.Tab, Keys.Shift + Keys.Tab).contains(shortcutOf(it)) }
     )
     restoreFocusOnDemandFromWhenever(
         sharedCondition.filter { it }.map { focusedElementBeforeTrap }


### PR DESCRIPTION
The current code contains lots of statements like


    state.flatMapLatest { value ->
        clicks.map { ... }
    } handledBy ...


The problem here is, that
1. the listener is attached after a minimal delay
2. event-calls might get lost, because the outer flow changes

For flows, which represent a state, it should be no problem to use flatMapLatest, but because events are one-shot operations, they should not be used within another flow transformation. While it seems to work for normal usage, it causes lots of problems for automated ui-tests e.g. using playwright. Actions might get lost or are not ready yet, what causes failing/flaky tests.

With this PR i replaced all event-Flows within Flow-Transformations i could found. The replacement always a followed similiar pattern. The above example code would be 

    clicks.map {
         val value = state.first()
         ...
    } handledBy ...

Or if state is the flow of a store, i used `Store.current` rather than `first()`