### PR TITLE
fix mountpoint in portals

### DIFF
--- a/core/src/jsMain/kotlin/dev/fritz2/core/mount.kt
+++ b/core/src/jsMain/kotlin/dev/fritz2/core/mount.kt
@@ -88,7 +88,7 @@ internal abstract class MountPointImpl : MountPoint, WithJob {
     }
 }
 
-internal val MOUNT_POINT_KEY = Scope.Key<MountPoint>("MOUNT_POINT")
+val MOUNT_POINT_KEY = Scope.Key<MountPoint>("MOUNT_POINT")
 
 /**
  * Allows to access the nearest [MountPoint] from any [WithScope]

--- a/headless/src/jsMain/kotlin/dev/fritz2/headless/foundation/portalling.kt
+++ b/headless/src/jsMain/kotlin/dev/fritz2/headless/foundation/portalling.kt
@@ -29,7 +29,7 @@ private data class PortalContainer<C : HTMLElement>(
     val remove = PortalStack.handle { list -> list.filterNot { it.portalId == portalId } }
 
     fun render(ctx: RenderContext) =
-        tag(ctx, classes, id, scope) {
+        tag(ctx, classes, id, scope + { ctx.scope[MOUNT_POINT_KEY]?.let { set(MOUNT_POINT_KEY, it) } }) {
             content.invoke(this) { remove.invoke() }
             reference?.beforeUnmount(this, null) { _, _ -> remove.invoke() }
         }
@@ -60,7 +60,9 @@ internal object PortalRenderContext : HtmlTag<HTMLDivElement>("div", portalRootI
         attr(Aria.live, "polite")
 
         PortalStack.data.distinctUntilChangedBy { it.map { it.portalId } }
-            .renderEach(PortalContainer<*>::portalId, into = this) { it.render(this) }
+            .renderEach(PortalContainer<*>::portalId, into = this) {
+                it.render(this)
+            }
 
         MainScope().launch {
             delay(500)


### PR DESCRIPTION
In #829 we implemented a special scope inheritance for portal containers. 
Because of that the MountPoint (which is stored as Scope) was also overwritten. 

The MountPoint is also used for afterMounts/afterUnmounts, which are currently broken in portals. Therefore FocusTrap does also not always work in Modals.

With this PR the MountPoint in Portals got fixed, so that afterMounts/afterUnmounts continue to work as expected