### PR TITLE
Fix Selection Behaviour of ListBox

### DIFF
--- a/headless-demo/tests/components/listbox.spec.ts
+++ b/headless-demo/tests/components/listbox.spec.ts
@@ -81,7 +81,7 @@ test.describe('To open and close a listBox', () => {
             await expect(page.locator("#" + itemId)).toHaveAttribute("data-listbox-selected", "false")
         }
 
-        const [btn,  listBoxItems] = await createLocators(page)
+        const [btn, listBoxItems] = await createLocators(page)
 
         await btn.focus()
         await assertListBoxIsClosed(btn, listBoxItems)
@@ -224,6 +224,46 @@ test.describe("To select an item from a listBox open the listBoxItems", () => {
         await expect(btn).toHaveText("Han")
         await expect(listBoxItems).toHaveAttribute("aria-activedescendant", "starwars-item-3")
     });
+
+    [
+        {
+            name: 'click on item', selectAction: async (item: Locator) => {
+                await item.click()
+            }
+        },
+        {
+            name: 'pressing Enter', selectAction: async (item: Locator) => {
+                await item.hover()
+                await item.press("Enter")
+            }
+        },
+        {
+            name: 'presssing Space', selectAction: async (item: Locator) => {
+                await item.hover()
+                await item.press("Space")
+            }
+        },
+    ].forEach(({name, selectAction}) => {
+        test(`and select the same item twice by ${name} will close the listBox`, async ({page}) => {
+            const listBoxItems = page.locator("#starwars-items")
+            const result = page.locator('#result')
+            const han = listBoxItems.getByText("Han")
+
+            // first selection
+            await page.getByRole("button", {name: "Luke"}).click()
+            await expect(listBoxItems).toBeVisible()
+            await selectAction(han)
+            await expect(listBoxItems).toBeHidden()
+            await expect(result).toContainText("Han")
+
+            // second selection
+            await page.getByRole("button", {name: "Han"}).click()
+            await expect(listBoxItems).toBeVisible()
+            await selectAction(han)
+            await expect(listBoxItems).toBeHidden()
+            await expect(result).toContainText("Han")
+        })
+    })
 
     for (const key of ["Enter", "Space"]) {
         test(`then press ${key}`, async ({page}) => {

--- a/headless/src/jsMain/kotlin/dev/fritz2/headless/components/listbox.kt
+++ b/headless/src/jsMain/kotlin/dev/fritz2/headless/components/listbox.kt
@@ -209,16 +209,16 @@ class Listbox<T, C : HTMLElement>(tag: Tag<C>, id: String?) : Tag<C> by tag, Ope
                 val currentIndex = activeIndex.current
                 val entries = entries.current
                 when (shortcutOf(event)) {
-                        Keys.ArrowUp -> nextItem(currentIndex, Direction.Previous, entries)
-                        Keys.ArrowDown -> nextItem(currentIndex, Direction.Next, entries)
-                        Keys.Home -> firstItem(entries)
-                        Keys.End -> lastItem(entries)
-                        else -> null
-                    }.also {
-                        if (it != null) {
-                            event.preventDefault()
-                            event.stopImmediatePropagation()
-                        }
+                    Keys.ArrowUp -> nextItem(currentIndex, Direction.Previous, entries)
+                    Keys.ArrowDown -> nextItem(currentIndex, Direction.Next, entries)
+                    Keys.Home -> firstItem(entries)
+                    Keys.End -> lastItem(entries)
+                    else -> null
+                }.also {
+                    if (it != null) {
+                        event.preventDefault()
+                        event.stopImmediatePropagation()
+                    }
                 }
             } handledBy activeIndex.update
 
@@ -247,7 +247,7 @@ class Listbox<T, C : HTMLElement>(tag: Tag<C>, id: String?) : Tag<C> by tag, Ope
                         it.stopImmediatePropagation()
                         entries[currentIndex].value
                     }
-                }
+                }.onEach { close() }
             )
 
             opened.filter { it }.flatMapLatest {
@@ -288,7 +288,7 @@ class Listbox<T, C : HTMLElement>(tag: Tag<C>, id: String?) : Tag<C> by tag, Ope
                             if (it.disabled) null
                             else it.value
                         }
-                    })
+                    }.onEach { close() })
 
                 value.data.map {} handledBy close
             }


### PR DESCRIPTION
Due to PR #833 the closing mechanism of headless listbox has changed, so that clicking / pressing enter or space on the previously selected item did not close the listbox anymore. This commit restores the previous and desired behaviour again.

In order to avoid future regressions, a dedicated playwright test is added.