### PR TITLE
Fix javadoc jar publication for publishing to MavenCentral

### DIFF
--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -1,16 +1,17 @@
 plugins {
     kotlin("multiplatform")
     kotlin("plugin.serialization")
+    id("org.jetbrains.dokka")
 }
 
 kotlin {
     jvm()
     js(IR).browser {
-        testTask(Action {
+        testTask {
             //running test-server in background
             dependsOn(":test-server:start")
             // see "karma.config.d" folder for customizing karma
-        })
+        }
         // just to have a place to copy it from...
         /*
         runTask {
@@ -60,6 +61,15 @@ kotlin {
             }
         }
     }
+}
+
+// Generates a javadoc jar from dokka html sources
+val dokkaJavadocJar by tasks.creating(Jar::class) {
+    group = JavaBasePlugin.DOCUMENTATION_GROUP
+    description = "Assembles java doc to jar"
+    archiveClassifier.set("javadoc")
+    dependsOn(tasks.dokkaHtml)
+    from(tasks.dokkaHtml.flatMap { it.outputDirectory })
 }
 
 apply(from = "$rootDir/publishing.gradle.kts")

--- a/headless/build.gradle.kts
+++ b/headless/build.gradle.kts
@@ -1,5 +1,6 @@
 plugins {
     kotlin("multiplatform")
+    id("org.jetbrains.dokka")
 }
 
 kotlin {
@@ -54,6 +55,15 @@ kotlin {
             }
         }
     }
+}
+
+// Generates a javadoc jar from dokka html sources
+val dokkaJavadocJar by tasks.creating(Jar::class) {
+    group = JavaBasePlugin.DOCUMENTATION_GROUP
+    description = "Assembles java doc to jar"
+    archiveClassifier.set("javadoc")
+    dependsOn(tasks.dokkaHtml)
+    from(tasks.dokkaHtml.flatMap { it.outputDirectory })
 }
 
 apply(from = "$rootDir/publishing.gradle.kts")

--- a/lenses-annotation-processor/build.gradle.kts
+++ b/lenses-annotation-processor/build.gradle.kts
@@ -1,6 +1,7 @@
 plugins {
     kotlin("multiplatform")
     id("com.google.devtools.ksp")
+    id("org.jetbrains.dokka")
 }
 
 ksp {
@@ -41,6 +42,15 @@ kotlin {
             }
         }
     }
+}
+
+// Generates a javadoc jar from dokka html sources
+val dokkaJavadocJar by tasks.creating(Jar::class) {
+    group = JavaBasePlugin.DOCUMENTATION_GROUP
+    description = "Assembles java doc to jar"
+    archiveClassifier.set("javadoc")
+    dependsOn(tasks.dokkaHtml)
+    from(tasks.dokkaHtml.flatMap { it.outputDirectory })
 }
 
 apply(from = "$rootDir/publishing.gradle.kts")

--- a/publishing.gradle.kts
+++ b/publishing.gradle.kts
@@ -4,7 +4,6 @@ apply(plugin = "maven-publish")
 apply(plugin = "signing")
 apply(plugin = "org.jetbrains.dokka")
 
-
 the<SigningExtension>().apply {
     val signingKey: String = System.getenv("GPG_SIGNING_KEY").orEmpty()
     val signingPassphrase: String = System.getenv("GPG_SIGNING_PASSPHRASE").orEmpty()
@@ -36,6 +35,7 @@ the<PublishingExtension>().apply {
     }
 
     publications.withType<MavenPublication>().configureEach {
+        artifact(tasks.getByName("dokkaJavadocJar"))
         pom {
             name.set("fritz2")
             description.set("Easily build reactive web-apps in Kotlin based on flows and coroutines")

--- a/serialization/build.gradle.kts
+++ b/serialization/build.gradle.kts
@@ -1,6 +1,7 @@
 plugins {
     kotlin("multiplatform")
     kotlin("plugin.serialization")
+    id("org.jetbrains.dokka")
 }
 
 kotlin {
@@ -14,6 +15,15 @@ kotlin {
             }
         }
     }
+}
+
+// Generates a javadoc jar from dokka html sources
+val dokkaJavadocJar by tasks.creating(Jar::class) {
+    group = JavaBasePlugin.DOCUMENTATION_GROUP
+    description = "Assembles java doc to jar"
+    archiveClassifier.set("javadoc")
+    dependsOn(tasks.dokkaHtml)
+    from(tasks.dokkaHtml.flatMap { it.outputDirectory })
 }
 
 apply(from = "$rootDir/publishing.gradle.kts")

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -13,7 +13,6 @@ plugins {
 refreshVersions {
 }
 
-
 include(
     "core",
     "lenses-annotation-processor",


### PR DESCRIPTION
It is mandatory to provide a javadoc jar for publishing to MavenCentral. That is why we added and correct the needed tasks again.