### PR TITLE
Fix ksp configuration in projects

### DIFF
--- a/examples/masterdetail/build.gradle.kts
+++ b/examples/masterdetail/build.gradle.kts
@@ -36,13 +36,6 @@ kotlin {
     }
 }
 
-/**
- * KSP support - start
- */
+// KSP support for Lens generation
 dependencies.kspCommonMainMetadata(project(":lenses-annotation-processor"))
 kotlin.sourceSets.commonMain { tasks.withType<KspTaskMetadata> { kotlin.srcDir(destinationDirectory) } }
-tasks.withType<KotlinCompilationTask<*>> { if (this !is KspTask) dependsOn(tasks.withType<KspTask>()) }
-tasks.withType<AbstractArchiveTask> { dependsOn(tasks.withType<KspTask>()) }
-/**
- * KSP support - end
- */

--- a/examples/masterdetail/build.gradle.kts
+++ b/examples/masterdetail/build.gradle.kts
@@ -1,3 +1,7 @@
+import com.google.devtools.ksp.gradle.KspTask
+import com.google.devtools.ksp.gradle.KspTaskMetadata
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompilationTask
+
 plugins {
     kotlin("multiplatform")
     kotlin("plugin.serialization")
@@ -35,15 +39,10 @@ kotlin {
 /**
  * KSP support - start
  */
-dependencies {
-    add("kspCommonMainMetadata", project(":lenses-annotation-processor"))
-}
-
-kotlin.sourceSets.commonMain { kotlin.srcDir("build/generated/ksp/metadata/commonMain/kotlin") }
-tasks.withType<org.jetbrains.kotlin.gradle.dsl.KotlinCompile<*>>().all {
-    if (name != "kspCommonMainKotlinMetadata") dependsOn("kspCommonMainKotlinMetadata")
-}
-// needed to work on Apple Silicon. Should be fixed by 1.6.20 (https://youtrack.jetbrains.com/issue/KT-49109#focus=Comments-27-5259190.0-0)
+dependencies.kspCommonMainMetadata(project(":lenses-annotation-processor"))
+kotlin.sourceSets.commonMain { tasks.withType<KspTaskMetadata> { kotlin.srcDir(destinationDirectory) } }
+tasks.withType<KotlinCompilationTask<*>> { if (this !is KspTask) dependsOn(tasks.withType<KspTask>()) }
+tasks.withType<AbstractArchiveTask> { dependsOn(tasks.withType<KspTask>()) }
 /**
  * KSP support - end
  */

--- a/examples/nestedmodel/build.gradle.kts
+++ b/examples/nestedmodel/build.gradle.kts
@@ -35,13 +35,6 @@ kotlin {
     }
 }
 
-/**
- * KSP support - start
- */
+// KSP support for Lens generation
 dependencies.kspCommonMainMetadata(project(":lenses-annotation-processor"))
 kotlin.sourceSets.commonMain { tasks.withType<KspTaskMetadata> { kotlin.srcDir(destinationDirectory) } }
-tasks.withType<KotlinCompilationTask<*>> { if (this !is KspTask) dependsOn(tasks.withType<KspTask>()) }
-tasks.withType<AbstractArchiveTask> { dependsOn(tasks.withType<KspTask>()) }
-/**
- * KSP support - end
- */

--- a/examples/nestedmodel/build.gradle.kts
+++ b/examples/nestedmodel/build.gradle.kts
@@ -1,3 +1,7 @@
+import com.google.devtools.ksp.gradle.KspTask
+import com.google.devtools.ksp.gradle.KspTaskMetadata
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompilationTask
+
 plugins {
     kotlin("multiplatform")
     kotlin("plugin.serialization")
@@ -34,15 +38,10 @@ kotlin {
 /**
  * KSP support - start
  */
-dependencies {
-    add("kspCommonMainMetadata", project(":lenses-annotation-processor"))
-}
-
-kotlin.sourceSets.commonMain { kotlin.srcDir("build/generated/ksp/metadata/commonMain/kotlin") }
-tasks.withType<org.jetbrains.kotlin.gradle.dsl.KotlinCompile<*>>().all {
-    if (name != "kspCommonMainKotlinMetadata") dependsOn("kspCommonMainKotlinMetadata")
-}
-// needed to work on Apple Silicon. Should be fixed by 1.6.20 (https://youtrack.jetbrains.com/issue/KT-49109#focus=Comments-27-5259190.0-0)
+dependencies.kspCommonMainMetadata(project(":lenses-annotation-processor"))
+kotlin.sourceSets.commonMain { tasks.withType<KspTaskMetadata> { kotlin.srcDir(destinationDirectory) } }
+tasks.withType<KotlinCompilationTask<*>> { if (this !is KspTask) dependsOn(tasks.withType<KspTask>()) }
+tasks.withType<AbstractArchiveTask> { dependsOn(tasks.withType<KspTask>()) }
 /**
  * KSP support - end
  */

--- a/examples/tictactoe/build.gradle.kts
+++ b/examples/tictactoe/build.gradle.kts
@@ -1,3 +1,7 @@
+import com.google.devtools.ksp.gradle.KspTask
+import com.google.devtools.ksp.gradle.KspTaskMetadata
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompilationTask
+
 plugins {
     kotlin("multiplatform")
     kotlin("plugin.serialization")
@@ -36,14 +40,10 @@ kotlin {
 /**
  * KSP support - start
  */
-dependencies {
-    add("kspCommonMainMetadata", project(":lenses-annotation-processor"))
-}
-
-kotlin.sourceSets.commonMain { kotlin.srcDir("build/generated/ksp/metadata/commonMain/kotlin") }
-tasks.withType<org.jetbrains.kotlin.gradle.dsl.KotlinCompile<*>>().all {
-    if (name != "kspCommonMainKotlinMetadata") dependsOn("kspCommonMainKotlinMetadata")
-}
+dependencies.kspCommonMainMetadata(project(":lenses-annotation-processor"))
+kotlin.sourceSets.commonMain { tasks.withType<KspTaskMetadata> { kotlin.srcDir(destinationDirectory) } }
+tasks.withType<KotlinCompilationTask<*>> { if (this !is KspTask) dependsOn(tasks.withType<KspTask>()) }
+tasks.withType<AbstractArchiveTask> { dependsOn(tasks.withType<KspTask>()) }
 /**
  * KSP support - end
  */

--- a/examples/tictactoe/build.gradle.kts
+++ b/examples/tictactoe/build.gradle.kts
@@ -37,13 +37,6 @@ kotlin {
     }
 }
 
-/**
- * KSP support - start
- */
+// KSP support for Lens generation
 dependencies.kspCommonMainMetadata(project(":lenses-annotation-processor"))
 kotlin.sourceSets.commonMain { tasks.withType<KspTaskMetadata> { kotlin.srcDir(destinationDirectory) } }
-tasks.withType<KotlinCompilationTask<*>> { if (this !is KspTask) dependsOn(tasks.withType<KspTask>()) }
-tasks.withType<AbstractArchiveTask> { dependsOn(tasks.withType<KspTask>()) }
-/**
- * KSP support - end
- */

--- a/examples/todomvc/build.gradle.kts
+++ b/examples/todomvc/build.gradle.kts
@@ -1,3 +1,7 @@
+import com.google.devtools.ksp.gradle.KspTask
+import com.google.devtools.ksp.gradle.KspTaskMetadata
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompilationTask
+
 plugins {
     kotlin("multiplatform")
     kotlin("plugin.serialization")
@@ -31,14 +35,10 @@ kotlin {
 /**
  * KSP support - start
  */
-dependencies {
-    add("kspCommonMainMetadata", project(":lenses-annotation-processor"))
-}
-
-kotlin.sourceSets.commonMain { kotlin.srcDir("build/generated/ksp/metadata/commonMain/kotlin") }
-tasks.withType<org.jetbrains.kotlin.gradle.dsl.KotlinCompile<*>>().all {
-    if (name != "kspCommonMainKotlinMetadata") dependsOn("kspCommonMainKotlinMetadata")
-}
+dependencies.kspCommonMainMetadata(project(":lenses-annotation-processor"))
+kotlin.sourceSets.commonMain { tasks.withType<KspTaskMetadata> { kotlin.srcDir(destinationDirectory) } }
+tasks.withType<KotlinCompilationTask<*>> { if (this !is KspTask) dependsOn(tasks.withType<KspTask>()) }
+tasks.withType<AbstractArchiveTask> { dependsOn(tasks.withType<KspTask>()) }
 /**
  * KSP support - end
  */

--- a/examples/todomvc/build.gradle.kts
+++ b/examples/todomvc/build.gradle.kts
@@ -32,13 +32,6 @@ kotlin {
     }
 }
 
-/**
- * KSP support - start
- */
+// KSP support for Lens generation
 dependencies.kspCommonMainMetadata(project(":lenses-annotation-processor"))
 kotlin.sourceSets.commonMain { tasks.withType<KspTaskMetadata> { kotlin.srcDir(destinationDirectory) } }
-tasks.withType<KotlinCompilationTask<*>> { if (this !is KspTask) dependsOn(tasks.withType<KspTask>()) }
-tasks.withType<AbstractArchiveTask> { dependsOn(tasks.withType<KspTask>()) }
-/**
- * KSP support - end
- */

--- a/examples/validation/build.gradle.kts
+++ b/examples/validation/build.gradle.kts
@@ -36,13 +36,6 @@ kotlin {
     }
 }
 
-/**
- * KSP support - start
- */
+// KSP support for Lens generation
 dependencies.kspCommonMainMetadata(project(":lenses-annotation-processor"))
 kotlin.sourceSets.commonMain { tasks.withType<KspTaskMetadata> { kotlin.srcDir(destinationDirectory) } }
-tasks.withType<KotlinCompilationTask<*>> { if (this !is KspTask) dependsOn(tasks.withType<KspTask>()) }
-tasks.withType<AbstractArchiveTask> { dependsOn(tasks.withType<KspTask>()) }
-/**
- * KSP support - end
- */

--- a/examples/validation/build.gradle.kts
+++ b/examples/validation/build.gradle.kts
@@ -1,3 +1,7 @@
+import com.google.devtools.ksp.gradle.KspTask
+import com.google.devtools.ksp.gradle.KspTaskMetadata
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompilationTask
+
 plugins {
     kotlin("multiplatform")
     kotlin("plugin.serialization")
@@ -35,15 +39,10 @@ kotlin {
 /**
  * KSP support - start
  */
-dependencies {
-    add("kspCommonMainMetadata", project(":lenses-annotation-processor"))
-}
-
-kotlin.sourceSets.commonMain { kotlin.srcDir("build/generated/ksp/metadata/commonMain/kotlin") }
-tasks.withType<org.jetbrains.kotlin.gradle.dsl.KotlinCompile<*>>().all {
-    if (name != "kspCommonMainKotlinMetadata") dependsOn("kspCommonMainKotlinMetadata")
-}
-// needed to work on Apple Silicon. Should be fixed by 1.6.20 (https://youtrack.jetbrains.com/issue/KT-49109#focus=Comments-27-5259190.0-0)
+dependencies.kspCommonMainMetadata(project(":lenses-annotation-processor"))
+kotlin.sourceSets.commonMain { tasks.withType<KspTaskMetadata> { kotlin.srcDir(destinationDirectory) } }
+tasks.withType<KotlinCompilationTask<*>> { if (this !is KspTask) dependsOn(tasks.withType<KspTask>()) }
+tasks.withType<AbstractArchiveTask> { dependsOn(tasks.withType<KspTask>()) }
 /**
  * KSP support - end
  */

--- a/headless-demo/build.gradle.kts
+++ b/headless-demo/build.gradle.kts
@@ -1,3 +1,7 @@
+import com.google.devtools.ksp.gradle.KspTask
+import com.google.devtools.ksp.gradle.KspTaskMetadata
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompilationTask
+
 plugins {
     kotlin("multiplatform")
     id("com.google.devtools.ksp")
@@ -41,14 +45,10 @@ kotlin {
 /**
  * KSP support - start
  */
-dependencies {
-    add("kspCommonMainMetadata",  project(":lenses-annotation-processor"))
-}
-kotlin.sourceSets.commonMain { kotlin.srcDir("build/generated/ksp/metadata/commonMain/kotlin") }
-
-tasks.withType<org.jetbrains.kotlin.gradle.dsl.KotlinCompile<*>>().all {
-    if (name != "kspCommonMainKotlinMetadata") dependsOn("kspCommonMainKotlinMetadata")
-}
+dependencies.kspCommonMainMetadata(project(":lenses-annotation-processor"))
+kotlin.sourceSets.commonMain { tasks.withType<KspTaskMetadata> { kotlin.srcDir(destinationDirectory) } }
+tasks.withType<KotlinCompilationTask<*>> { if (this !is KspTask) dependsOn(tasks.withType<KspTask>()) }
+tasks.withType<AbstractArchiveTask> { dependsOn(tasks.withType<KspTask>()) }
 /**
  * KSP support - end
  */

--- a/headless-demo/build.gradle.kts
+++ b/headless-demo/build.gradle.kts
@@ -42,13 +42,6 @@ kotlin {
     }
 }
 
-/**
- * KSP support - start
- */
+// KSP support for Lens generation
 dependencies.kspCommonMainMetadata(project(":lenses-annotation-processor"))
 kotlin.sourceSets.commonMain { tasks.withType<KspTaskMetadata> { kotlin.srcDir(destinationDirectory) } }
-tasks.withType<KotlinCompilationTask<*>> { if (this !is KspTask) dependsOn(tasks.withType<KspTask>()) }
-tasks.withType<AbstractArchiveTask> { dependsOn(tasks.withType<KspTask>()) }
-/**
- * KSP support - end
- */

--- a/www/src/pages/docs/10_Getting Started.md
+++ b/www/src/pages/docs/10_Getting Started.md
@@ -61,16 +61,9 @@ kotlin {
     }
 }
 
-/**
- * KSP support for Lens generation - start
- */
+// KSP support for Lens generation
 dependencies.kspCommonMainMetadata("dev.fritz2:lenses-annotation-processor:$fritz2Version")
 kotlin.sourceSets.commonMain { tasks.withType<KspTaskMetadata> { kotlin.srcDir(destinationDirectory) } }
-tasks.withType<KotlinCompilationTask<*>> { if (this !is KspTask) dependsOn(tasks.withType<KspTask>()) }
-tasks.withType<AbstractArchiveTask> { dependsOn(tasks.withType<KspTask>()) }
-/**
- * KSP support - end
- */
 ```
 
 ## Organize Your Code

--- a/www/src/pages/docs/10_Getting Started.md
+++ b/www/src/pages/docs/10_Getting Started.md
@@ -64,13 +64,10 @@ kotlin {
 /**
  * KSP support for Lens generation - start
  */
-dependencies {
-    add("kspCommonMainMetadata", "dev.fritz2:lenses-annotation-processor:$fritz2Version")
-}
-kotlin.sourceSets.commonMain { kotlin.srcDir("build/generated/ksp/metadata/commonMain/kotlin") }
-tasks.withType<org.jetbrains.kotlin.gradle.dsl.KotlinCompile<*>>().all {
-    if (name != "kspCommonMainKotlinMetadata") dependsOn("kspCommonMainKotlinMetadata")
-}
+dependencies.kspCommonMainMetadata("dev.fritz2:lenses-annotation-processor:$fritz2Version")
+kotlin.sourceSets.commonMain { tasks.withType<KspTaskMetadata> { kotlin.srcDir(destinationDirectory) } }
+tasks.withType<KotlinCompilationTask<*>> { if (this !is KspTask) dependsOn(tasks.withType<KspTask>()) }
+tasks.withType<AbstractArchiveTask> { dependsOn(tasks.withType<KspTask>()) }
 /**
  * KSP support - end
  */


### PR DESCRIPTION
Fixes implicit dependency errors in Gradle 8.5 by the ksp task.

line that causes the error
```
kotlin.sourceSets.commonMain { kotlin.srcDir("build/generated/ksp/metadata/commonMain/kotlin") }
```

the error message:
```
FAILURE: Build failed with an exception.

* What went wrong:
Some problems were found with the configuration of task ':my-project:kspCommonMainKotlinMetadata' (type 'KspTaskMetadata').
  - Gradle detected a problem with the following location: '/Users/jan/IdeaProjects/oe-auth-service/core/build/generated/ksp/metadata/commonMain/kotlin'.
    
    Reason: Task ':my-project:jvmSourcesJar' uses this output of task ':my-project:kspCommonMainKotlinMetadata' without declaring an explicit or implicit dependency. This can lead to incorrect results being produced, depending on what order the tasks are executed.
    
    Possible solutions:
      1. Declare task ':my-project:kspCommonMainKotlinMetadata' as an input of ':my-project:jvmSourcesJar'.
      2. Declare an explicit dependency on ':my-project:kspCommonMainKotlinMetadata' from ':my-project:jvmSourcesJar' using Task#dependsOn.
      3. Declare an explicit dependency on ':my-project:kspCommonMainKotlinMetadata' from ':my-project:jvmSourcesJar' using Task#mustRunAfter.
    
    For more information, please refer to https://docs.gradle.org/8.5/userguide/validation_problems.html#implicit_dependency in the Gradle documentation.
  - Gradle detected a problem with the following location: '/Users/jan/IdeaProjects/oe-auth-service/core/build/generated/ksp/metadata/commonMain/kotlin'.
```

line which fixes the error:
```
kotlin.sourceSets.commonMain { tasks.withType<KspTaskMetadata> { kotlin.srcDir(destinationDirectory) } }
```