### PR TITLE
Fix nested listbox selection behavior

### DIFF
--- a/headless/src/jsMain/kotlin/dev/fritz2/headless/components/listbox.kt
+++ b/headless/src/jsMain/kotlin/dev/fritz2/headless/components/listbox.kt
@@ -281,7 +281,7 @@ class Listbox<T, C : HTMLElement>(tag: Tag<C>, id: String?) : Tag<C> by tag, Ope
 
                 value.handler?.invoke(
                     this,
-                    mousedowns.mapNotNull { e ->
+                    clicks.mapNotNull { e ->
                         e.preventDefault()
                         e.stopImmediatePropagation()
                         entries.current[index].let {

--- a/headless/src/jsMain/kotlin/dev/fritz2/headless/foundation/OpenClose.kt
+++ b/headless/src/jsMain/kotlin/dev/fritz2/headless/foundation/OpenClose.kt
@@ -48,7 +48,7 @@ abstract class OpenClose: WithJob {
         return if (domNode is HTMLButtonElement) {
             clicks
         } else {
-            keydowns.filter { shortcutOf(it) in listOf(Keys.Space, Keys.Enter) }
+            merge(clicks, keydowns.filter { shortcutOf(it) in listOf(Keys.Space, Keys.Enter) })
         }
     }
 }

--- a/headless/src/jsMain/kotlin/dev/fritz2/headless/foundation/OpenClose.kt
+++ b/headless/src/jsMain/kotlin/dev/fritz2/headless/foundation/OpenClose.kt
@@ -48,7 +48,7 @@ abstract class OpenClose: WithJob {
         return if (domNode is HTMLButtonElement) {
             clicks
         } else {
-            merge(clicks, keydowns.filter { shortcutOf(it) in listOf(Keys.Space, Keys.Enter) })
+            merge(clicks, keydowns.filter { shortcutOf(it) in setOf(Keys.Space, Keys.Enter) })
         }
     }
 }


### PR DESCRIPTION
This PR fixes a problem where a popover would close when selecting  a listbox item from a nested listbox.

When selecting an item from a nested listbox, the click event's `target` property differs depending on the OS the browser is running on. While the browser on MacOS sets the `target` to the actual element I clicked on, on Windows it sets the `target` to another element (in my case this was the portal root element).
This behavior seems to be browser-independent, but I only tested this for Edge and Safari on MacOS and Edge and Chrome on Windows.
This PR avoids this problem altogether by changing the event the listbox item listens to from `mousedown` to `click`. This way, the event listener registered by the `closeOnDismiss()` method does not run, because the event gets correctly cancelled by the listbox item. Before, the listbox item only cancelled the `mousedown` event triggered by the click, but not the `click` event.

The tests are passing on both MacOS and Windows.

This PR also adds an event listener to elements using `OpenClose` functionality, so that non-`HTMLButtonElement`s behave identical to actual `HTMLButtonElement`s.