### PR TITLE
Make lenses genration more resilient with KSP >= 1.9.x

### DIFF
--- a/lenses-annotation-processor/src/jvmTest/kotlin/dev/fritz2/lens/LensesProcessorTests.kt
+++ b/lenses-annotation-processor/src/jvmTest/kotlin/dev/fritz2/lens/LensesProcessorTests.kt
@@ -308,19 +308,27 @@ class LensesProcessorTests {
 
     @ExperimentalPathApi
     @Test
-    fun `lenses ignore none ctor or private ctor properties`() {
+    fun `lenses ignore none ctor or private ctor properties, other annotations, delegated none ctor properties and functions in companion`() {
         val kotlinSource = SourceFile.kotlin(
             "dataClassesForLensesTests.kt", """
                 package dev.fritz2.lenstest
 
                 import dev.fritz2.core.Lenses
+                // should not disturb
+                import kotlinx.serialization.Serializable
+                import kotlinx.serialization.json.Json
 
                 @Lenses
+                @Serializable // should not disturb
                 data class Foo(val bar: Int, private val ignoredProp: Int) {
                 //                           ^^^^^^^
                 //                           private field -> no lens possible!
-                    companion object
+                    companion object {
+                        // should not disturb
+                        fun toJson(foo: Foo) = Json.decodeFromString(serializer(), foo)
+                    }
                     val ignored = bar + 1 // must not appear in lens!
+                    val ignoredDelegated by lazy { bar + 1 } // must not appear in lens!
                 }
             """
         )


### PR DESCRIPTION
Obviously the ksp based LensesAnnotationProcessor was more resilient in the past before we upgraded to Kotlin 1.9.x and appropriate ksp with RC15.

We encountered some issues with generating lenses that only came with this bad warning:
```
w: [ksp] Unable to process:dev.fritz2.lens.LensesProcessor:   SomeClass
```

This was due to some not resolvable types inside the annotated data class, like calls to functions from other libs or delegated properties. With former ksp-versions those problems did not arise - so obviously ksp has evolved since then and got stronger constraints for the `evaluate`-function.

This PR fixes such issues, as we ignore everything from the annotated class but the primary constructor. The latter is the only interesting piece for our lens generation.