### PR TITLE
Add `renderTrue` and `renderFalse` convenience functions

### DIFF
--- a/core/src/jsMain/kotlin/dev/fritz2/core/rendercontext.kt
+++ b/core/src/jsMain/kotlin/dev/fritz2/core/rendercontext.kt
@@ -59,7 +59,7 @@ interface RenderContext : WithJob, WithScope {
     }
 
     /**
-     * Renders the data of a boolean [Flow] only if it's value is `true`.
+     * Renders the data of a boolean [Flow] only if its value is `true`.
      *
      * @receiver [Flow] containing the data
      * @param into target to mount content to. If not set a child div is added to the [Tag] this method is called on
@@ -78,7 +78,7 @@ interface RenderContext : WithJob, WithScope {
     }
 
     /**
-     * Renders the data of a boolean [Flow] only if it's value is `false`.
+     * Renders the data of a boolean [Flow] only if its value is `false`.
      *
      * @receiver [Flow] containing the data
      * @param into target to mount content to. If not set a child div is added to the [Tag] this method is called on

--- a/core/src/jsMain/kotlin/dev/fritz2/core/rendercontext.kt
+++ b/core/src/jsMain/kotlin/dev/fritz2/core/rendercontext.kt
@@ -59,6 +59,44 @@ interface RenderContext : WithJob, WithScope {
     }
 
     /**
+     * Renders the data of a boolean [Flow] only if it's value is `true`.
+     *
+     * @receiver [Flow] containing the data
+     * @param into target to mount content to. If not set a child div is added to the [Tag] this method is called on
+     * @param content [RenderContext] for rendering the data to the DOM
+     *
+     * @see renderIf
+     * @see renderFalse
+     */
+    fun Flow<Boolean>.renderTrue(
+        into: Tag<HTMLElement>? = null,
+        content: Tag<*>.() -> Unit
+    ) {
+        renderIf(predicate = { it }, into) { _ ->
+            content()
+        }
+    }
+
+    /**
+     * Renders the data of a boolean [Flow] only if it's value is `false`.
+     *
+     * @receiver [Flow] containing the data
+     * @param into target to mount content to. If not set a child div is added to the [Tag] this method is called on
+     * @param content [RenderContext] for rendering the data to the DOM
+     *
+     * @see renderIf
+     * @see renderTrue
+     */
+    fun Flow<Boolean>.renderFalse(
+        into: Tag<HTMLElement>? = null,
+        content: Tag<*>.() -> Unit
+    ) {
+        renderIf(predicate = { !it }, into) { _ ->
+            content()
+        }
+    }
+
+    /**
      * Renders the non-null data of a [Flow].
      *
      * @receiver [Flow] containing the data

--- a/core/src/jsTest/kotlin/dev/fritz2/core/rendercontext.kt
+++ b/core/src/jsTest/kotlin/dev/fritz2/core/rendercontext.kt
@@ -97,6 +97,84 @@ class RenderContextTests {
     }
 
     @Test
+    fun testRenderIfTrueFunction() = runTest {
+        val store = storeOf(true)
+
+        val id = Id.next()
+        val expectedContentIfTrue = "rendered"
+        val expectedContentIfFalse = ""
+
+
+        render {
+            div(id = id) {
+                store.data.renderTrue(into = this) {
+                    +expectedContentIfTrue
+                }
+            }
+        }
+
+
+        delay(100)
+
+        val divContent = document.getElementById(id)?.textContent
+        assertEquals(
+            expected = expectedContentIfTrue,
+            actual = divContent,
+            message = "Content must be present"
+        )
+
+
+        store.update(false)
+        delay(100)
+
+        val divContentAfterUpdate = document.getElementById(id)?.textContent
+        assertEquals(
+            expected = expectedContentIfFalse,
+            actual = divContentAfterUpdate,
+            message = "Content must be absent"
+        )
+    }
+
+    @Test
+    fun testRenderIfFalseFunction() = runTest {
+        val store = storeOf(false)
+
+        val id = Id.next()
+        val expectedContentIfFalse = "rendered"
+        val expectedContentIfTrue = ""
+
+
+        render {
+            div(id = id) {
+                store.data.renderFalse(into = this) {
+                    +expectedContentIfFalse
+                }
+            }
+        }
+
+
+        delay(100)
+
+        val divContent = document.getElementById(id)?.textContent
+        assertEquals(
+            expected = expectedContentIfFalse,
+            actual = divContent,
+            message = "Content must be present"
+        )
+
+
+        store.update(true)
+        delay(100)
+
+        val divContentAfterUpdate = document.getElementById(id)?.textContent
+        assertEquals(
+            expected = expectedContentIfTrue,
+            actual = divContentAfterUpdate,
+            message = "Content must be absent"
+        )
+    }
+
+    @Test
     fun testRenderNotNullFunction() = runTest {
         val store = storeOf<String?>(null)
         val div1 = Id.next()

--- a/core/src/jsTest/kotlin/dev/fritz2/core/rendercontext.kt
+++ b/core/src/jsTest/kotlin/dev/fritz2/core/rendercontext.kt
@@ -97,7 +97,7 @@ class RenderContextTests {
     }
 
     @Test
-    fun testRenderIfTrueFunction() = runTest {
+    fun testRenderTrueFunction() = runTest {
         val store = storeOf(true)
 
         val id = Id.next()
@@ -136,7 +136,7 @@ class RenderContextTests {
     }
 
     @Test
-    fun testRenderIfFalseFunction() = runTest {
+    fun testRenderFalseFunction() = runTest {
         val store = storeOf(false)
 
         val id = Id.next()

--- a/www/src/pages/docs/30_Render HTML.md
+++ b/www/src/pages/docs/30_Render HTML.md
@@ -257,15 +257,17 @@ As you already know, all [state handling](/docs/fundamentals/#state-handling) is
 Based upon the `data`-property, which provides a `Flow` of the store's generic data type, there are a variety of
 `render*`-functions which can be used to create *reactive* UIs:
 
-| Render-Function            | Additional parameters | Description                                                                                                                   | Default Tag |    
-|----------------------------|-----------------------|-------------------------------------------------------------------------------------------------------------------------------|-------------|
-| `Flow<T>.render`           | -                     | Creates a mount-point providing the whole store's data value `T` inside `content` expression                                  | `div`       |
-| `Flow<T>.renderIf`         | predicate             | Creates a mount-point providing the whole store's data value `T` inside `content` expression when `predicate` is `true`       | `div`       |
-| `Flow<T>.renderNotNull`    | -                     | Creates a mount-point providing the whole store's data value `T` inside `content` expression when `T` is not `null`           | `div`       |
-| `Flow<T>.renderIs`         | klass                 | Creates a mount-point providing the whole store's data value `T` inside `content` expression when `T` is of type `klass`      | `div`       |
-| `Flow<String>.renderText`  | -                     | Creates a mount-point creating a text-node                                                                                    | `span`      |
-| `Flow<List<T>>.renderEach` | -                     | Creates a mount-point optimizing changes by `T.equals`. Provides a `T` inside the `content` expression. Use for value objects | `div`       |
-| `Flow<List<T>>.renderEach` | idProvider            | Creates a mount-point optimizing changes by `idProvider`. Provides a `T` inside the `content` expression. Use for entities    | `div`       |
+| Render-Function             | Additional parameters | Description                                                                                                                   | Default Tag |    
+|-----------------------------|-----------------------|-------------------------------------------------------------------------------------------------------------------------------|-------------|
+| `Flow<T>.render`            | -                     | Creates a mount-point providing the whole store's data value `T` inside `content` expression                                  | `div`       |
+| `Flow<T>.renderIf`          | predicate             | Creates a mount-point providing the whole store's data value `T` inside `content` expression when `predicate` is `true`       | `div`       |
+| `Flow<Boolean>.renderTrue`  | -                     | Creates a mount-point rendering the `content` expression with no store data provided when the flow's value is `true`          | `div`       |
+| `Flow<Boolean>.renderFalse` | -                     | Creates a mount-point rendering the `content` expression with no store data provided when the flow's value is `false`         | `div`       |
+| `Flow<T>.renderNotNull`     | -                     | Creates a mount-point providing the whole store's data value `T` inside `content` expression when `T` is not `null`           | `div`       |
+| `Flow<T>.renderIs`          | klass                 | Creates a mount-point providing the whole store's data value `T` inside `content` expression when `T` is of type `klass`      | `div`       |
+| `Flow<String>.renderText`   | -                     | Creates a mount-point creating a text-node                                                                                    | `span`      |
+| `Flow<List<T>>.renderEach`  | -                     | Creates a mount-point optimizing changes by `T.equals`. Provides a `T` inside the `content` expression. Use for value objects | `div`       |
+| `Flow<List<T>>.renderEach`  | idProvider            | Creates a mount-point optimizing changes by `idProvider`. Provides a `T` inside the `content` expression. Use for entities    | `div`       |
 
 There is one more `renderEach` variant which is defined as an extension to a `Store` instead of a `Flow`.
 This special variant and its application are described in the 


### PR DESCRIPTION
#### Motivation

With [fritz1.0-RC8](https://github.com/jwstegemann/fritz2/releases/tag/v1.0-RC8) we added a bunch of convenience-render-functions to reduce boilerplate-code within the ui-sections, such as `renderIf({/*some boolean expression */}) { ... }`. In many cases however, we have to work with boolean Flows which lead to code like this:
```kotlin
someBooleanFlow.renderIf({ it }) { 
    /* render UI */ 
}
```
This looks not as clean as it could.

#### Solution

This PR adds two convenience functions `Flow<Boolean>.renderIfTrue(...)` and `Flow<Boolean>.renderIfFalse(...)` that render a given content if a boolean Flow's value is `true` or `false` respectively.

Examples:

```kotlin
val store = storeOf(true)

store.data.renderIfTrue {
    // content is rendered if the Store's value is true.
    // If the Store's value is false, nothing is rendered.
}
```

```kotlin
val store = storeOf(false)

store.data.renderIfFalse {
    // content is rendered if the Store's value is false.
    // If the Store's value is true, nothing is rendered.
}
```