### PR TITLE
Improve disclosure component for state creating content, add options to control a transition's initial and after-end classes

### DIFF
--- a/core/src/jsMain/kotlin/dev/fritz2/core/foundation.kt
+++ b/core/src/jsMain/kotlin/dev/fritz2/core/foundation.kt
@@ -119,14 +119,14 @@ fun addGlobalStyles(css: List<String>) {
  * Joins all given [classes] strings to one html-class-attribute [String]
  * by filtering all out which are null or blank.
  */
-@Deprecated("Use joinClassNames instead.", ReplaceWith("joinClasses(*classes)"))
+@Deprecated("Use joinClasses instead.", ReplaceWith("joinClasses(*classes)"))
 fun classes(vararg classes: String?): String = joinClasses(*classes)
 
 /**
  * Joins all given [classes] strings to one html-class-attribute [String].
  * Individual Strings that are null or blank are filtered out.
  *
- * __Examples__
+ * #### Examples
  *
  * ```
  * val classes = joinClasses(

--- a/headless-demo/src/jsMain/kotlin/dev/fritz2/headlessdemo/components/disclosure.kt
+++ b/headless-demo/src/jsMain/kotlin/dev/fritz2/headlessdemo/components/disclosure.kt
@@ -1,9 +1,8 @@
 package dev.fritz2.headlessdemo.components
 
-import dev.fritz2.core.RenderContext
-import dev.fritz2.core.href
-import dev.fritz2.core.transition
+import dev.fritz2.core.*
 import dev.fritz2.headless.components.disclosure
+import kotlinx.coroutines.flow.map
 
 fun RenderContext.disclosureDemo() {
     val faqs = listOf<Pair<String, RenderContext.() -> Unit>>(
@@ -53,10 +52,12 @@ fun RenderContext.disclosureDemo() {
                         dt("text-base") {
                             /* <!-- Expand/collapse question button --> */
                             disclosureButton(
-                                """relative z-10 flex justify-between items-start w-full my-2 p-4
-                                | bg-primary-800 rounded-lg hover:bg-primary-900 
-                                | text-left text-white 
-                                | focus:outline-none focus:ring-4 focus:ring-primary-600""".trimMargin()
+                                joinClasses(
+                                    "relative z-10 flex justify-between items-start w-full my-2 p-4",
+                                    "bg-primary-800 rounded-lg hover:bg-primary-900",
+                                    "text-left text-white",
+                                    "focus:outline-none focus:ring-4 focus:ring-primary-600",
+                                )
                             ) {
                                 span("font-medium") { +question }
                                 span("ml-6 h-7 flex items-center") {
@@ -74,12 +75,15 @@ fun RenderContext.disclosureDemo() {
                             tag = RenderContext::dd
                         ) {
                             transition(
-                                "transition duration-100 ease-out",
-                                "opacity-0 scale-y-95",
-                                "opacity-100 scale-y-100",
-                                "transition duration-100 ease-in",
-                                "opacity-100 scale-y-100",
-                                "opacity-0 scale-y-95"
+                                opened,
+                                enter = "transition duration-100 ease-out",
+                                enterStart = "opacity-0 scale-y-95",
+                                enterEnd = "opacity-100 scale-y-100",
+                                leave = "transition duration-100 ease-in",
+                                leaveStart = "opacity-100 scale-y-100",
+                                leaveEnd = "opacity-0 scale-y-95",
+                                hasLeftClasses = "hidden",
+                                initialClasses = "hidden"
                             )
                             div("text-base text-gray-700") { answer(this) }
                         }

--- a/headless-demo/src/jsMain/kotlin/dev/fritz2/headlessdemo/components/disclosure.kt
+++ b/headless-demo/src/jsMain/kotlin/dev/fritz2/headlessdemo/components/disclosure.kt
@@ -76,10 +76,10 @@ fun RenderContext.disclosureDemo() {
                         ) {
                             transition(
                                 opened,
-                                enter = "transition duration-100 ease-out",
+                                enter = "transition duration-300 ease-out",
                                 enterStart = "opacity-0 scale-y-95",
                                 enterEnd = "opacity-100 scale-y-100",
-                                leave = "transition duration-100 ease-in",
+                                leave = "transition duration-300 ease-in",
                                 leaveStart = "opacity-100 scale-y-100",
                                 leaveEnd = "opacity-0 scale-y-95",
                                 hasLeftClasses = "hidden",

--- a/headless/src/jsMain/kotlin/dev/fritz2/headless/components/disclosure.kt
+++ b/headless/src/jsMain/kotlin/dev/fritz2/headless/components/disclosure.kt
@@ -5,6 +5,8 @@ import dev.fritz2.headless.foundation.Aria
 import dev.fritz2.headless.foundation.OpenClose
 import dev.fritz2.headless.foundation.TagFactory
 import dev.fritz2.headless.foundation.addComponentStructureInfo
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
 import org.w3c.dom.HTMLButtonElement
 import org.w3c.dom.HTMLDivElement
 import org.w3c.dom.HTMLElement
@@ -22,13 +24,9 @@ class Disclosure<C : HTMLElement>(tag: Tag<C>, id: String?) : Tag<C> by tag, Ope
     val componentId: String by lazy { id ?: Id.next() }
 
     private var button: Tag<HTMLElement>? = null
-    private var panel: (RenderContext.() -> Unit)? = null
 
     fun render() {
         attr("id", componentId)
-        opened.render {
-            if (it) panel?.invoke(this)
-        }
     }
 
     /**
@@ -68,6 +66,7 @@ class Disclosure<C : HTMLElement>(tag: Tag<C>, id: String?) : Tag<C> by tag, Ope
     }
 
     inner class DisclosurePanel<CP : HTMLElement>(tag: Tag<CP>) : Tag<CP> by tag {
+
         fun render() {
             button?.attr(Aria.controls, id.whenever(opened))
         }
@@ -119,12 +118,10 @@ class Disclosure<C : HTMLElement>(tag: Tag<C>, id: String?) : Tag<C> by tag, Ope
         initialize: DisclosurePanel<CP>.() -> Unit
     ) {
         addComponentStructureInfo("disclosurePanel", this@disclosurePanel.scope, this)
-        panel = {
-            tag(this, classes, "$componentId-panel", scope) {
-                DisclosurePanel(this).run {
-                    initialize()
-                    render()
-                }
+        tag(this, classes, "$componentId-panel", scope) {
+            DisclosurePanel(this).run {
+                initialize()
+                render()
             }
         }
     }

--- a/www/src/pages/headless/disclosure.md
+++ b/www/src/pages/headless/disclosure.md
@@ -21,12 +21,26 @@ by `disclosureButton` and a panel via `disclosurePanel`.
 The button serves as a control element for opening and closing the panel area. This is done by one
 Mouse click or the [[Space]] key if the button tag has focus.
 
+::: warning  
+__Important__  
+
+The headless disclosure only provides the logic to determine the state of the panel. The actual visibility
+of the panel must be implemented by the developer using CSS!
+
+The simplest way is to hide and show the panel via the `display` property.  
+
+For more in-depth information, see the section on [State depending Styling](#state-depending-styling).  
+:::
+
 ```kotlin
 disclosure {
     disclosureButton {
         +"When is being headless a good thing?"
     }
     disclosurePanel {
+        inlineStyle(opened.map {
+            if (it) "display: block;" else "display: none;"
+        })
         +"As foundation for web components!"
     }
 }
@@ -37,27 +51,57 @@ disclosure {
 In order to design the styling or entire structures depending on the state of the disclosure, you can refer to the
 Boolean data stream `opened`.
 
-Typical patterns are use within `className` to set different CSS classes depending on state,
-or simply some conditional rendering.
+::: warning  
+As mentioned earlier, the disclosure not only _allows_ you to tp provide styling depending on the state, it also
+_requires_ you to do so.  
+:::
+
+This is due to the fact of the panel not rendering and removing itself from the DOM, but only hiding and showing it.
+Since fritz2 is framework-agnostic, it does not provide any styling or classes for that purpose.
+
+There are multiple reasons for this design decision:
+- Creating a mount-point is not related to styling, thus it can easily be done in headless. Hiding/showing an element 
+is - that's why it cannot be done in headless.
+- Leaving the entire styling (including the styles used for hiding/showing the element) to the implementor allows for 
+greater flexibility on how a concrete disclosure component might work.
+- By leaving the styling to the user, all styling can be applied in a single place whithout some internal mechanics
+working against you.
+
+Styling of the `opened` and `closed` states is not limited to just hiding or showing the panel. You are free to design
+the panel in any way you like. For example, the disclosure may be designed to behave more like a spoiler element
+that blurs its content when closed.
+
+In order to work with transitions, you can use the `transition` function. Because of the specific nature of the 
+disclosure component, you have to use a special overloaded version of the `transition` function, which essentially
+combines the `transition` function with the `inlineStyle` function. This enables you to define both the styling and the
+transition effect in one place, based on the `opened` state.
 
 ```kotlin
 disclosure {
-    disclosureButton {
-        +"When is being headless a good thing?"
-        
-        span("ml-6 h-7 flex items-center") {
-            // add some Icon that reflects the state visually
-            opened.render(into = this) {
-                svg("h-6 w-6 transform") {
-                    // change Icon depending on `opened` state
-                    if (it) content(HeroIcons.chevron_up)
-                    else content(HeroIcons.chevron_down)
-                }
+    disclosureButton("flex items-center gap-2") {
+        opened.render {
+            svg("h-6 w-6 transform") {
+                // change Icon depending on `opened` state
+                if (it) content(HeroIcons.chevron_up)
+                else content(HeroIcons.chevron_down)
             }
         }
+        +"When is being headless a good thing?"
     }
     disclosurePanel {
-        +"As foundation for web components!"
+        transition(
+            opened,
+            enter = "transition duration-250 ease-out",
+            enterStart = "opacity-0 scale-y-95",
+            enterEnd = "opacity-100 scale-y-100",
+            leave = "transition duration-250 ease-in",
+            leaveStart = "opacity-100 scale-y-100",
+            leaveEnd = "opacity-0 scale-y-95",
+            hasLeftClasses = "hidden",
+            initialClasses = "hidden"
+        )
+
+        +"As a foundation for web components!"
     }
 }
 ```
@@ -82,7 +126,12 @@ disclosure {
         +"When is being headless a good thing?"
     }
     disclosurePanel {
-        +"As foundation for web components!"
+        inlineStyle(opened.map {
+            if (it) "display: block;" else "display: none;"
+        })
+        
+        +"As a foundation for web components!"
+        
         button {
             +"Close"
             // use `close` Handler to explicitly close the panel from within
@@ -103,6 +152,9 @@ disclosure {
         +"When is being headless a good thing?"
     }
     disclosurePanel {
+        inlineStyle(opened.map {
+            if (it) "display: block;" else "display: none;"
+        })
         disclosureCloseButton {
             +"As foundation for web components!"
             +"Simply click or press Space to close."

--- a/www/src/pages/headless/disclosure.md
+++ b/www/src/pages/headless/disclosure.md
@@ -29,7 +29,7 @@ of the panel must be implemented by the developer using CSS!
 
 The simplest way is to hide and show the panel via the `display` property.  
 
-For more in-depth information, see the section on [State depending Styling](#state-depending-styling).  
+For more in-depth information, see the section on [State-Dependent Styling](#state-dependent-styling).  
 :::
 
 ```kotlin
@@ -46,7 +46,7 @@ disclosure {
 }
 ```
 
-## State depending Styling
+## State-Dependent Styling
 
 In order to design the styling or entire structures depending on the state of the disclosure, you can refer to the
 Boolean data stream `opened`.


### PR DESCRIPTION
## Overview

This PR changes the headless disclosure to only render its panel's content once and then show/hide it based on styling. Currently, the panel's content is rendered every time the disclosure is opened/closed. 

> [!WARNING] 
> In order to achieve this, the headless component no longer controls the panel's visibility. All styling is now solely done by the implementor of a headless discloure and needs to be adjusted accordingly. Thus, the changes introduced in this PR are _api breaking_!

Additionally, the `transition` function for `Flow`-based transitions has been extended to allow optional control over initial classes and classes that should be present after the leave-transition has ended. This is useful to allow transitions on an element's visibility which are normally not possible using pure CSS.

## Disclosure

As mentioned earlier, the headless disclosure no longer creates a mount-point for its panel to re-render based on the open-state. Instead, it now only provides the _state_ and leaves the styling to the implementor.

This is necessary due to multiple reasons:
1) Creating a mount-point is _not related to styling_, thus it can easily be done in headless. Hiding/showing an element _is_ - that's why it cannot be done in headless.
2) Leaving the entire styling (including the styles used for hiding/showing the element) to the implementor allows for greater flexibility on _how_ a concrete disclosure component might work. For example, it might behave similar to a spoiler element on social media sites and provide a blurred preview of some content that is revealed when clicked.
3) By leaving the styling to the user, all styling can be applied in a single place whithout some internal styling working against you.

### Migration

In order to migrate an existing disclosure component, styling information for the opened/closed states must be provided.
Find different migration scenarios below.

> [!NOTE]
> Most of the examples below use Tailwind CSS. However, you are free to use any CSS framework, or even plain CSS, as well.

Example using plain CSS:
```kotlin
disclosurePanel {
    inlineStyle(opened.map {
        if (it) "display: block;" else "display: none;"
    })
}
```

#### 1) The disclosure to migrate does _not_ use transitions

In this case, the appropriate styling for the opened/closed states needs to be added. No existing styles have to be adjusted.
This can be as easy as simply providing basic CSS styling:

Before:
```kotlin
disclosurePanel {
    // some content
}
```

After:
```kotlin
disclosurePanel {
    className(
        opened.map { if (it) "" else "hidden" },
        initial = "hidden"
    )
    // some content
}
```

#### 2) The existing disclosure makes use of transitions

In this case, the existing `transition` call needs to be adjusted in order to provide visible/hidden classes. As mentioned in the beginning, this function has been adjusted accordingly.

Before:
```kotlin
disclosurePanel {
    transition(
        "transition transition-all duration-500 ease-in",
        "opacity-0 scale-y-95 max-h-0",
        "opacity-100 scale-y-100 max-h-[100vh]",
        "transition transition-all duration-500 ease-out",
        "opacity-100 scale-y-100 max-h-[100vh]",
        "opacity-0 scale-y-95 max-h-[0]"
    )
    // some content
}
```

After:
```kotlin
disclosurePanel {
    transition(
        opened,
//      ^^^^^^
//      change the transition to be flow based by specifing a triggering flow via the `on` parameter
        "transition transition-all duration-500 ease-in",
        "opacity-0 scale-y-95 max-h-0",
        "opacity-100 scale-y-100 max-h-[100vh]",
        "transition transition-all duration-500 ease-out",
        "opacity-100 scale-y-100 max-h-[100vh]",
        "opacity-0 scale-y-95 max-h-[0]",
         afterLeaveClasses = "hidden",
//      ^^^^^^
//      provide classes that should be present when the leave transition is over (panel hidden)
         initialClasses = "hidden"
//      ^^^^^^
//      provide an initial styling. In this case: `hidden`, since `opened` is false by default
    )
    // some content
}
``````

---

Closes #754 