### PR TITLE
Adds a headless `combobox` component

### DIFF
--- a/headless-demo/src/jsMain/kotlin/dev/fritz2/headlessdemo/app.kt
+++ b/headless-demo/src/jsMain/kotlin/dev/fritz2/headlessdemo/app.kt
@@ -44,6 +44,12 @@ val pages: Map<String, Page> = mapOf(
             |complete with robust support for keyboard navigation.""".trimMargin(),
         RenderContext::listboxDemo
     ),
+    "combobox" to DemoPage(
+        "Headless ComboBox",
+        """Comboboxes are an easy way to build queryable dropdown lists with live-updated suggestions, complete with
+            | robust support for keyboard naigation.""".trimMargin(),
+        RenderContext::comboboxDemo
+    ),
     "menu" to DemoPage(
         "Headless Menu",
         """Menus offer an easy way to build custom, accessible dropdown components with robust support for keyboard

--- a/headless-demo/src/jsMain/kotlin/dev/fritz2/headlessdemo/components/combobox.kt
+++ b/headless-demo/src/jsMain/kotlin/dev/fritz2/headlessdemo/components/combobox.kt
@@ -8,6 +8,7 @@ import kotlinx.coroutines.flow.map
 
 fun RenderContext.comboboxDemo() {
     val selectionStore = storeOf<Country?>(null)
+    val readOnlyStore = storeOf(false)
     val enableAutoselectStore = storeOf(false)
 
     div("max-w-96 flex flex-col gap-4") {
@@ -41,7 +42,9 @@ fun RenderContext.comboboxDemo() {
                         "vui-label-4 p-0 focus:ring-transparent focus:shadow-none disabled:text-gray-400",
                         "text-ellipsis",
                     ),
-                ) { }
+                ) {
+                    readOnly(readOnlyStore.data)
+                }
 
                 icon("pl-2w-5 h-5", content = HeroIcons.selector).clicks handledBy open
             }
@@ -132,17 +135,8 @@ fun RenderContext.comboboxDemo() {
             }
         }
 
-        div("flex items-center gap-2") {
-            input("", id = "checkbox-enable-autoselect") {
-                type("checkbox")
-                checked(enableAutoselectStore.data)
-            }.clicks.map { !enableAutoselectStore.current } handledBy enableAutoselectStore.update
-
-            label {
-                `for`("checkbox-enable-autoselect")
-                +"Auto-select exact matches"
-            }
-        }
+        checkbox("Read-only", readOnlyStore, "checkbox-enable-readonly")
+        checkbox("Auto-select exact matches", enableAutoselectStore, "checkbox-enable-autoselect")
 
         result {
             p {
@@ -169,6 +163,21 @@ private fun RenderContext.quickSelectButton(country: Country, store: Store<Count
     button("p-2 bg-primary-500 hover:bg-primary-600 shadow rounded text-sm text-primary-900") {
         +country.name
     }.clicks.map { country } handledBy store.update
+}
+
+private fun RenderContext.checkbox(text: String, value: Store<Boolean>, testId: String) {
+    val id = Id.next()
+    div("flex items-center gap-2") {
+        input("", id = testId) {
+            type("checkbox")
+            checked(value.data)
+        }.clicks.map { !value.current } handledBy value.update
+
+        label {
+            `for`(testId)
+            +text
+        }
+    }
 }
 
 private data class Country(

--- a/headless-demo/src/jsMain/kotlin/dev/fritz2/headlessdemo/components/combobox.kt
+++ b/headless-demo/src/jsMain/kotlin/dev/fritz2/headlessdemo/components/combobox.kt
@@ -8,14 +8,21 @@ import kotlinx.coroutines.flow.map
 
 fun RenderContext.comboboxDemo() {
     val selectionStore = storeOf<Country?>(null)
+    val enableAutoselectStore = storeOf(false)
 
     div("max-w-96 flex flex-col gap-4") {
-        combobox<Country> {
+        combobox<Country>(id = "countries") {
             items(COUNTRY_LIST)
             itemFormat = Country::name
             value(selectionStore)
             filterBy(Country::name)
-            selectionStrategy.autoSelectMatch()
+
+            enableAutoselectStore.data handledBy {
+                if (it) selectionStrategy.autoSelectMatch()
+                else selectionStrategy.manual()
+            }
+
+            maximumDisplayedItems = 20
 
             comboboxLabel("sr-only") {
                 +"Select a Country"
@@ -102,7 +109,7 @@ fun RenderContext.comboboxDemo() {
                             }
                         }
                         if (truncated) {
-                            p("py-2 pl-10 pr-4 text-sm text-gray-400") {
+                            span("py-2 pl-10 pr-4 text-sm text-gray-400") {
                                 +"Refine your query for more results"
                             }
                         }
@@ -125,10 +132,24 @@ fun RenderContext.comboboxDemo() {
             }
         }
 
+        div("flex items-center gap-2") {
+            input("", id = "checkbox-enable-autoselect") {
+                type("checkbox")
+                checked(enableAutoselectStore.data)
+            }.clicks.map { !enableAutoselectStore.current } handledBy enableAutoselectStore.update
+
+            label {
+                `for`("checkbox-enable-autoselect")
+                +"Auto-select exact matches"
+            }
+        }
+
         result {
             p {
                 span("font-semibold") { +"Selected: " }
-                selectionStore.data.renderText()
+                span(id = "countries-selection") {
+                    selectionStore.data.renderText(into = this)
+                }
             }
         }
     }

--- a/headless-demo/src/jsMain/kotlin/dev/fritz2/headlessdemo/components/combobox.kt
+++ b/headless-demo/src/jsMain/kotlin/dev/fritz2/headlessdemo/components/combobox.kt
@@ -136,7 +136,7 @@ fun RenderContext.comboboxDemo() {
         }
 
         checkbox("Read-only", readOnlyStore, "checkbox-enable-readonly")
-        checkbox("Auto-select exact matches", enableAutoselectStore, "checkbox-enable-autoselect")
+        checkbox("Auto-select exact matches (try 'oman')", enableAutoselectStore, "checkbox-enable-autoselect")
 
         result {
             p {

--- a/headless-demo/src/jsMain/kotlin/dev/fritz2/headlessdemo/components/combobox.kt
+++ b/headless-demo/src/jsMain/kotlin/dev/fritz2/headlessdemo/components/combobox.kt
@@ -112,7 +112,7 @@ fun RenderContext.comboboxDemo() {
                             }
                         }
                         if (truncated) {
-                            span("py-2 pl-10 pr-4 text-sm text-gray-400") {
+                            div("py-2 pl-10 pr-4 text-sm text-gray-400") {
                                 +"Refine your query for more results"
                             }
                         }

--- a/headless-demo/src/jsMain/kotlin/dev/fritz2/headlessdemo/components/combobox.kt
+++ b/headless-demo/src/jsMain/kotlin/dev/fritz2/headlessdemo/components/combobox.kt
@@ -1,0 +1,408 @@
+package dev.fritz2.headlessdemo.components
+
+import dev.fritz2.core.*
+import dev.fritz2.headless.components.combobox
+import dev.fritz2.headless.foundation.utils.floatingui.core.middleware.offset
+import dev.fritz2.headlessdemo.result
+import kotlinx.coroutines.flow.map
+
+fun RenderContext.comboboxDemo() {
+    val selectionStore = storeOf<Country?>(null)
+
+    div("max-w-96 flex flex-col gap-4") {
+        combobox<Country> {
+            items(COUNTRY_LIST)
+            itemFormat = Country::name
+            value(selectionStore)
+            filterBy(Country::name)
+            selectionStrategy.autoSelectMatch()
+
+            comboboxLabel("sr-only") {
+                +"Select a Country"
+            }
+
+            comboboxPanelReference(
+                joinClasses(
+                    "w-full py-2.5 px-4 flex items-center bg-white rounded border border-primary-600",
+                    "cursor-default font-sans text-sm text-left text-primary-800 hover:border-primary-800",
+                    "focus-within:outline-none focus-within:ring-4 focus-within:ring-primary-600 focus-within:border-primary-800"
+                ),
+            ) {
+                comboboxInput(
+                    joinClasses(
+                        "w-full block flex-grow bg-transparent border-0 outline-0 placeholder-gray-700",
+                        "vui-label-4 p-0 focus:ring-transparent focus:shadow-none disabled:text-gray-400",
+                        "text-ellipsis",
+                    ),
+                ) { }
+
+                icon("pl-2w-5 h-5", content = HeroIcons.selector).clicks handledBy open
+            }
+
+            comboboxValidationMessages {
+                ul("list-disc list-inside") {
+                    msgs.render(into = this) { messages ->
+                        messages.forEach { message ->
+                            li {
+                                +"(${message.severity}) ${message.message}"
+                            }
+                        }
+                    }
+                }
+            }
+
+            comboboxItems(
+                joinClasses(
+                    "max-h-60 py-1 overflow-auto origin-top z-30 bg-white rounded shadow-md divide-y divide-gray-100",
+                    "ring-1 ring-primary-600 ring-opacity-5 focus:outline-none"
+                )
+            ) {
+                addMiddleware(offset(5))
+
+                transition(
+                    opened,
+                    enter = "transition duration-100 ease-out",
+                    enterStart = "opacity-0 scale-95",
+                    enterEnd = "opacity-100 scale-100",
+                    leave = "transition duration-100 ease-in",
+                    leaveStart = "opacity-100 scale-100",
+                    leaveEnd = "opacity-0 scale-95"
+                )
+
+                results.render(into = this) { (query, results, truncated) ->
+                    if (results.isEmpty()) {
+                        p("px-4 py-2 text-gray-400") {
+                            +"No results found"
+                        }
+                    } else {
+                        results.forEach { item ->
+                            comboboxItem(
+                                item,
+                                "w-full relative py-2 pl-10 pr-4 cursor-default select-none disabled:opacity-50 text-sm"
+                            ) {
+                                className(active.map { active->
+                                    if (active) "bg-primary-600 text-white"
+                                    else "text-primary-800"
+                                })
+
+                                highlightedText(item.value.name, query).run {
+                                    className(selected.map {
+                                        if (it) "font-semibold"
+                                        else "font-normal"
+                                    })
+                                }
+
+                                selected.render {
+                                    if (it) {
+                                        span("absolute left-0 inset-y-0 flex items-center pl-3") {
+                                            icon("w-5 h-5", content = HeroIcons.check)
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                        if (truncated) {
+                            p("py-2 pl-10 pr-4 text-sm text-gray-400") {
+                                +"Refine your query for more results"
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        div("space-y-2") {
+            p("text-sm text-primary-800") {
+                +"Select via data-binding:"
+            }
+            div("flex flex-wrap gap-2") {
+                buildList {
+                    addAll(COUNTRY_LIST.take(2))
+                    addAll(COUNTRY_LIST.takeLast(2))
+                }.forEach { country ->
+                    quickSelectButton(country, selectionStore)
+                }
+            }
+        }
+
+        result {
+            p {
+                span("font-semibold") { +"Selected: " }
+                selectionStore.data.renderText()
+            }
+        }
+    }
+}
+
+private fun RenderContext.highlightedText(text: String, highlight: String) =
+    span {
+        val split = text.split(Regex("(?<=($highlight))|(?=($highlight))", RegexOption.IGNORE_CASE))
+        for (segment in split) {
+            span("font-semibold".takeIf { segment.contentEquals(highlight, ignoreCase = true) }) {
+                +segment
+            }
+        }
+    }
+
+private fun RenderContext.quickSelectButton(country: Country, store: Store<Country?>) {
+    button("p-2 bg-primary-500 hover:bg-primary-600 shadow rounded text-sm text-primary-900") {
+        +country.name
+    }.clicks.map { country } handledBy store.update
+}
+
+private data class Country(
+    val code: String,
+    val name: String,
+)
+
+private val COUNTRY_LIST = listOf(
+    Country("AF", "Afghanistan"),
+    Country("AX", "Åland Islands"),
+    Country("AL", "Albania"),
+    Country("DZ", "Algeria"),
+    Country("AS", "American Samoa"),
+    Country("AD", "Andorra"),
+    Country("AO", "Angola"),
+    Country("AI", "Anguilla"),
+    Country("AQ", "Antarctica"),
+    Country("AG", "Antigua and Barbuda"),
+    Country("AR", "Argentina"),
+    Country("AM", "Armenia"),
+    Country("AW", "Aruba"),
+    Country("AU", "Australia"),
+    Country("AT", "Austria"),
+    Country("AZ", "Azerbaijan"),
+    Country("BS", "Bahamas"),
+    Country("BH", "Bahrain"),
+    Country("BD", "Bangladesh"),
+    Country("BB", "Barbados"),
+    Country("BY", "Belarus"),
+    Country("BE", "Belgium"),
+    Country("BZ", "Belize"),
+    Country("BJ", "Benin"),
+    Country("BM", "Bermuda"),
+    Country("BT", "Bhutan"),
+    Country("BOL", "Plurinational State of Bolivia"),
+    Country("BES", "Sint Eustatius and Saba Bonaire"),
+    Country("BA", "Bosnia and Herzegovina"),
+    Country("BW", "Botswana"),
+    Country("BV", "Bouvet Island"),
+    Country("BR", "Brazil"),
+    Country("IO", "British Indian Ocean Territory"),
+    Country("BN", "Brunei Darussalam"),
+    Country("BG", "Bulgaria"),
+    Country("BF", "Burkina Faso"),
+    Country("BI", "Burundi"),
+    Country("CV", "Cabo Verde"),
+    Country("KH", "Cambodia"),
+    Country("CM", "Cameroon"),
+    Country("CA", "Canada"),
+    Country("KY", "Cayman Islands"),
+    Country("CF", "Central African Republic"),
+    Country("TD", "Chad"),
+    Country("CL", "Chile"),
+    Country("CN", "China"),
+    Country("CX", "Christmas Island"),
+    Country("CC", "Cocos (Keeling) Islands"),
+    Country("CO", "Colombia"),
+    Country("KM", "Comoros"),
+    Country("CG", "Congo"),
+    Country("COD", "Democratic Republic of the Congo"),
+    Country("CK", "Cook Islands"),
+    Country("CR", "Costa Rica"),
+    Country("CI", "Côte d'Ivoire"),
+    Country("HR", "Croatia"),
+    Country("CU", "Cuba"),
+    Country("CW", "Curaçao"),
+    Country("CY", "Cyprus"),
+    Country("CZ", "Czechia"),
+    Country("DK", "Denmark"),
+    Country("DJ", "Djibouti"),
+    Country("DM", "Dominica"),
+    Country("DO", "Dominican Republic"),
+    Country("EC", "Ecuador"),
+    Country("EG", "Egypt"),
+    Country("SV", "El Salvador"),
+    Country("GQ", "Equatorial Guinea"),
+    Country("ER", "Eritrea"),
+    Country("EE", "Estonia"),
+    Country("SZ", "Eswatini"),
+    Country("ET", "Ethiopia"),
+    Country("FK", "Falkland Islands (Malvinas)"),
+    Country("FO", "Faroe Islands"),
+    Country("FJ", "Fiji"),
+    Country("FI", "Finland"),
+    Country("FR", "France"),
+    Country("GF", "French Guiana"),
+    Country("PF", "French Polynesia"),
+    Country("TF", "French Southern Territories"),
+    Country("GA", "Gabon"),
+    Country("GM", "Gambia"),
+    Country("GE", "Georgia"),
+    Country("DE", "Germany"),
+    Country("GH", "Ghana"),
+    Country("GI", "Gibraltar"),
+    Country("GR", "Greece"),
+    Country("GL", "Greenland"),
+    Country("GD", "Grenada"),
+    Country("GP", "Guadeloupe"),
+    Country("GU", "Guam"),
+    Country("GT", "Guatemala"),
+    Country("GG", "Guernsey"),
+    Country("GN", "Guinea"),
+    Country("GW", "Guinea-Bissau"),
+    Country("GY", "Guyana"),
+    Country("HT", "Haiti"),
+    Country("HM", "Heard Island and McDonald Islands"),
+    Country("VA", "Holy See"),
+    Country("HN", "Honduras"),
+    Country("HK", "Hong Kong"),
+    Country("HU", "Hungary"),
+    Country("IS", "Iceland"),
+    Country("IN", "India"),
+    Country("ID", "Indonesia"),
+    Country("IRN", "Islamic Republic of IranIR"),
+    Country("IQ", "Iraq"),
+    Country("IE", "Ireland"),
+    Country("IM", "Isle of Man"),
+    Country("IL", "Israel"),
+    Country("IT", "Italy"),
+    Country("JM", "Jamaica"),
+    Country("JP", "Japan"),
+    Country("JE", "Jersey"),
+    Country("JO", "Jordan"),
+    Country("KZ", "Kazakhstan"),
+    Country("KE", "Kenya"),
+    Country("KI", "Kiribati"),
+    Country("PRK", "Democratic People's Republic of Korea"),
+    Country("KOR", "Republic of Korea"),
+    Country("KW", "Kuwait"),
+    Country("KG", "Kyrgyzstan"),
+    Country("LA", "Lao People's Democratic Republic"),
+    Country("LV", "Latvia"),
+    Country("LB", "Lebanon"),
+    Country("LS", "Lesotho"),
+    Country("LR", "Liberia"),
+    Country("LY", "Libya"),
+    Country("LI", "Liechtenstein"),
+    Country("LT", "Lithuania"),
+    Country("LU", "Luxembourg"),
+    Country("MO", "Macao"),
+    Country("MG", "Madagascar"),
+    Country("MW", "Malawi"),
+    Country("MY", "Malaysia"),
+    Country("MV", "Maldives"),
+    Country("ML", "Mali"),
+    Country("MT", "Malta"),
+    Country("MH", "Marshall Islands"),
+    Country("MQ", "Martinique"),
+    Country("MR", "Mauritania"),
+    Country("MU", "Mauritius"),
+    Country("YT", "Mayotte"),
+    Country("MX", "Mexico"),
+    Country("FSM", "Federated States of Micronesia"),
+    Country("MDA", "Republic of Moldova"),
+    Country("MC", "Monaco"),
+    Country("MN", "Mongolia"),
+    Country("ME", "Montenegro"),
+    Country("MS", "Montserrat"),
+    Country("MA", "Morocco"),
+    Country("MZ", "Mozambique"),
+    Country("MM", "Myanmar"),
+    Country("NA", "Namibia"),
+    Country("NR", "Nauru"),
+    Country("NP", "Nepal"),
+    Country("NLD", "Kingdom of the Netherlands"),
+    Country("NC", "New Caledonia"),
+    Country("NZ", "New Zealand"),
+    Country("NI", "Nicaragua"),
+    Country("NE", "Niger"),
+    Country("NG", "Nigeria"),
+    Country("NU", "Niue"),
+    Country("NF", "Norfolk Island"),
+    Country("MK", "North Macedonia"),
+    Country("MP", "Northern Mariana Islands"),
+    Country("NO", "Norway"),
+    Country("OM", "Oman"),
+    Country("PK", "Pakistan"),
+    Country("PW", "Palau"),
+    Country("PSE", "State of Palestine"),
+    Country("PA", "Panama"),
+    Country("PG", "Papua New Guinea"),
+    Country("PY", "Paraguay"),
+    Country("PE", "Peru"),
+    Country("PH", "Philippines"),
+    Country("PN", "Pitcairn"),
+    Country("PL", "Poland"),
+    Country("PT", "Portugal"),
+    Country("PR", "Puerto Rico"),
+    Country("QA", "Qatar"),
+    Country("RE", "Réunion"),
+    Country("RO", "Romania"),
+    Country("RU", "Russian Federation"),
+    Country("RW", "Rwanda"),
+    Country("BL", "Saint Barthélemy"),
+    Country("SHN", "Ascension and Tristan da Cunha Saint Helena"),
+    Country("KN", "Saint Kitts and Nevis"),
+    Country("LC", "Saint Lucia"),
+    Country("MF", "Saint Martin (French part)"),
+    Country("PM", "Saint Pierre and Miquelon"),
+    Country("VC", "Saint Vincent and the Grenadines"),
+    Country("WS", "Samoa"),
+    Country("SM", "San Marino"),
+    Country("ST", "Sao Tome and Principe"),
+    Country("SA", "Saudi Arabia"),
+    Country("SN", "Senegal"),
+    Country("RS", "Serbia"),
+    Country("SC", "Seychelles"),
+    Country("SL", "Sierra Leone"),
+    Country("SG", "Singapore"),
+    Country("SX", "Sint Maarten (Dutch part)"),
+    Country("SK", "Slovakia"),
+    Country("SI", "Slovenia"),
+    Country("SB", "Solomon Islands"),
+    Country("SO", "Somalia"),
+    Country("ZA", "South Africa"),
+    Country("GS", "South Georgia and the South Sandwich Islands"),
+    Country("SS", "South Sudan"),
+    Country("ES", "Spain"),
+    Country("LK", "Sri Lanka"),
+    Country("SD", "Sudan"),
+    Country("SR", "Suriname"),
+    Country("SJ", "Svalbard and Jan Mayen"),
+    Country("SE", "Sweden"),
+    Country("CH", "Switzerland"),
+    Country("SY", "Syrian Arab Republic"),
+    Country("TWN", "Taiwan"),
+    Country("TJ", "Tajikistan"),
+    Country("TZA", "United Republic of Tanzania"),
+    Country("TH", "Thailand"),
+    Country("TL", "Timor-Leste"),
+    Country("TG", "Togo"),
+    Country("TK", "Tokelau"),
+    Country("TO", "Tonga"),
+    Country("TT", "Trinidad and Tobago"),
+    Country("TN", "Tunisia"),
+    Country("TR", "Türkiye"),
+    Country("TM", "Turkmenistan"),
+    Country("TC", "Turks and Caicos Islands"),
+    Country("TV", "Tuvalu"),
+    Country("UG", "Uganda"),
+    Country("UA", "Ukraine"),
+    Country("AE", "United Arab Emirates"),
+    Country("GB", "United Kingdom of Great Britain and Northern Ireland"),
+    Country("US", "United States of America"),
+    Country("UM", "United States Minor Outlying Islands"),
+    Country("UY", "Uruguay"),
+    Country("UZ", "Uzbekistan"),
+    Country("VU", "Vanuatu"),
+    Country("VEN", "Bolivarian Republic of Venezuela"),
+    Country("VN", "Viet Nam"),
+    Country("VG", "Virgin Islands (British)"),
+    Country("VI", "Virgin Islands (U.S.)"),
+    Country("WF", "Wallis and Futuna"),
+    Country("EH", "Western Sahara"),
+    Country("YE", "Yemen"),
+    Country("ZM", "Zambia"),
+    Country("ZW", "Zimbabwe"),
+)

--- a/headless-demo/tests/components/combobox.spec.ts
+++ b/headless-demo/tests/components/combobox.spec.ts
@@ -25,6 +25,15 @@ async function assertIsClosed(input: Locator, popupRoot: Locator) {
 }
 
 
+const clickInput = (page: Page) => page.locator("#countries-input").click();
+
+const clickOutside = (page: Page) => page.mouse.click(0, 0);
+
+const pressTab = (page: Page) => page.keyboard.down("Tab");
+
+const pressEscape = (page: Page) => page.keyboard.down("Escape");
+
+
 test("Dropdown is initially closed", async ({ page }) => {
     const [input, items] = await createLocators(page);
     await assertIsClosed(input, items);
@@ -32,15 +41,6 @@ test("Dropdown is initially closed", async ({ page }) => {
 
 
 test.describe("To open and close a combobox", () => {
-
-    const clickInput = (page: Page) => page.locator("#countries-input").click();
-
-    const clickOutside = (page: Page) => page.mouse.click(0, 0);
-
-    const pressTab = (page: Page) => page.keyboard.down("Tab");
-
-    const pressEscape = (page: Page) => page.keyboard.down("Escape");
-
 
     const testArgs = [
         {
@@ -87,6 +87,31 @@ test.describe("To open and close a combobox", () => {
         });
     }
 
+});
+
+test.describe("When the input is read-only", () => {
+
+    const selectInputText = async (page: Page) => page.locator("#countries-input").selectText();
+
+    for (const { desc, action } of [
+        {
+            desc: "focusing the input does not open the dropdown",
+            action: clickInput
+        },
+        {
+            desc: "selecting text does not open the dropdown",
+            action: selectInputText
+        },
+    ]) {
+        test(desc, async ({ page }) => {
+            const [input, items] = await createLocators(page);
+
+            await page.locator('#checkbox-enable-readonly').check();
+
+            await action(page);
+            await expect(items).not.toBeVisible();
+        })
+    }
 });
 
 test.describe("Activating an item", () => {

--- a/headless-demo/tests/components/combobox.spec.ts
+++ b/headless-demo/tests/components/combobox.spec.ts
@@ -1,0 +1,271 @@
+import { expect, Locator, Page, test } from "@playwright/test";
+
+
+test.beforeEach(async ({ page }) => {
+    await page.goto("#combobox");
+    await expect(page.locator("#portal-root")).toBeAttached();
+    await page.waitForTimeout(200);
+});
+
+
+async function createLocators(page: Page): Promise<[Locator, Locator]> {
+    const btn = page.locator("#countries-input")
+    const listBoxItems = page.locator("#countries-items")
+    return [btn, listBoxItems]
+}
+
+async function assertIsOpen(input: Locator, popupRoot: Locator) {
+    await expect(popupRoot).toBeVisible();
+    await expect(input).toHaveAttribute("aria-expanded", "true")
+}
+
+async function assertIsClosed(input: Locator, popupRoot: Locator) {
+    await expect(popupRoot).toBeHidden();
+    await expect(input).toHaveAttribute("aria-expanded", "false")
+}
+
+
+test("Dropdown is initially closed", async ({ page }) => {
+    const [input, items] = await createLocators(page);
+    await assertIsClosed(input, items);
+});
+
+
+test.describe("To open and close a combobox", () => {
+
+    const clickInput = (page: Page) => page.locator("#countries-input").click();
+
+    const clickOutside = (page: Page) => page.mouse.click(0, 0);
+
+    const pressTab = (page: Page) => page.keyboard.down("Tab");
+
+    const pressEscape = (page: Page) => page.keyboard.down("Escape");
+
+
+    const testArgs = [
+        {
+            desc: "click into the input field, then click outside",
+            open: clickInput,
+            close: clickOutside,
+        },
+        {
+            desc: "tab into the input field, then press tab again",
+            open: pressTab,
+            close: pressTab,
+        },
+        {
+            desc: "click into the input field, then press tab",
+            open: clickInput,
+            close: pressTab,
+        },
+        {
+            desc: "tab into the input field, then click outside",
+            open: pressTab,
+            close: clickOutside,
+        },
+        {
+            desc: "click into the input field, then press escape",
+            open: clickInput,
+            close: pressEscape,
+        },
+        {
+            desc: "tab into the input field, then press escape",
+            open: pressTab,
+            close: pressEscape,
+        },
+    ];
+
+    for (const { desc, open, close } of testArgs) {
+        test(desc, async ({ page }) => {
+            const [input, items] = await createLocators(page);
+
+            await open(page);
+            await assertIsOpen(input, items);
+
+            await close(page);
+            await assertIsClosed(input, items);
+        });
+    }
+
+});
+
+test.describe("Activating an item", () => {
+
+    for (const { desc, activate } of [
+        {
+            desc: "via mouse hover",
+            activate: (page: Page) => page.locator("#countries-item-0").hover()
+        },
+        {
+            desc: "via keyboard",
+            activate: (page: Page) => page.keyboard.down("ArrowDown")
+        },
+    ]) {
+        test(`${desc} sets 'aria-activedescendant'`, async ({ page }) => {
+            const [input, items] = await createLocators(page);
+            await input.click();
+
+            await expect(items).not.toHaveAttribute("aria-activedescendant");
+
+            const firstItem = page.locator("#countries-item-0");
+            await expect(firstItem).toBeVisible();
+
+            await activate(page);
+            await expect(items).toHaveAttribute("aria-activedescendant", "countries-item-0");
+        })
+    }
+});
+
+test("Changing the active item updates 'aria-activedescendant'", async ({ page }) => {
+    const [input, items] = await createLocators(page);
+    await input.click();
+
+    await expect(items).not.toHaveAttribute("aria-activedescendant");
+
+    const firstItem = page.locator("#countries-item-0");
+    await expect(firstItem).toBeVisible();
+
+    const secondItem = page.locator("#countries-item-1");
+    await expect(secondItem).toBeVisible();
+
+    await firstItem.hover();
+    await expect(items).toHaveAttribute("aria-activedescendant", "countries-item-0");
+
+    await secondItem.hover();
+    await expect(items).toHaveAttribute("aria-activedescendant", "countries-item-1");
+});
+
+test.describe("When activating an item via keyboard", () => {
+
+    for (const { key, index } of [
+        { key: "Home", index: 0 },
+        { key: "End", index: 19 }
+    ]) {
+        test(`'pressing ${{ key }}' jumps to the ${index}th item`, async ({ page }) => {
+            const [input, items] = await createLocators(page);
+            await input.click();
+
+            const item = page.locator("#countries-item-0");
+            await expect(item).toBeVisible();
+
+            await page.keyboard.down(key);
+            await expect(items).toHaveAttribute("aria-activedescendant", `countries-item-${index}`);
+        });
+    }
+
+    for (const { setupKey, testKey, index, indexName } of [
+        { setupKey: "Home", testKey: "ArrowUp", index: 0, indexName: "first" },
+        { setupKey: "End", testKey: "ArrowDown", index: 19, indexName: "last" }
+    ]) {
+        test(`'pressing ${testKey}' on the ${indexName} item does nothing`, async ({ page }) => {
+            const [input, items] = await createLocators(page);
+            await input.click();
+
+            await expect(page.locator("#countries-item-0")).toBeVisible();
+
+            await page.keyboard.down(setupKey);
+            await expect(items).toHaveAttribute("aria-activedescendant", `countries-item-${index}`);
+
+            await page.keyboard.down(testKey);
+            await expect(items).toHaveAttribute("aria-activedescendant", `countries-item-${index}`);
+        });
+    }
+});
+
+test.describe("Select an item", () => {
+
+    test("by clicking on it", async ({ page }) => {
+        const [input, items] = await createLocators(page);
+        const selection = page.locator("#countries-selection");
+
+        await expect(selection).toContainText("null");
+
+        await input.click();
+
+        const firstItem = page.locator("#countries-item-0");
+        await expect(firstItem).toBeVisible();
+
+        await firstItem.click();
+        await expect(selection).toContainText((await firstItem.textContent())!);
+    });
+
+    test("by activating it via the keyboard and pressing Enter", async ({ page }) => {
+        const [input, items] = await createLocators(page);
+        const selection = page.locator("#countries-selection");
+
+        await expect(selection).toContainText("null");
+
+        await page.keyboard.down("Tab");
+
+        const firstItem = page.locator("#countries-item-0");
+        await expect(firstItem).toBeVisible();
+
+        await page.keyboard.down("ArrowDown");
+        await expect(items).toHaveAttribute("aria-activedescendant", "countries-item-0");
+
+        await page.keyboard.down("Enter");
+        await expect(selection).toContainText((await firstItem.textContent())!);
+    });
+});
+
+test.describe("When typing a query", () => {
+
+    test("the result dropdown is updated", async ({ page }) => {
+        const [input, items] = await createLocators(page);
+
+        await input.click();
+        await expect(page.locator("#countries-item-0")).toBeVisible();
+
+        await expect(page.locator("#countries-items > [data-combobox-item]")).toHaveCount(20);
+
+        await input.fill("oma");
+
+        await expect(page.locator("#countries-items > [data-combobox-item]")).toHaveCount(3);
+        await expect(page.locator("#countries-item-0")).toContainText("Oman");
+        await expect(page.locator("#countries-item-1")).toContainText("Romania");
+        await expect(page.locator("#countries-item-2")).toContainText("Somalia");
+    });
+
+    test("closing the dropdown resets the input field", async ({ page }) => {
+        const [input, items] = await createLocators(page);
+
+        await input.click();
+        await expect(page.locator("#countries-item-0")).toBeVisible();
+
+        await input.fill("oma");
+
+        await page.mouse.click(0, 0);
+
+        const selection = page.locator("#countries-selection");
+        await expect(selection).toContainText("null");
+    });
+
+    test("by default, exact matches are not auto-selected", async ({ page }) => {
+        const [input, items] = await createLocators(page);
+
+        await input.click();
+        await expect(page.locator("#countries-item-0")).toBeVisible();
+
+        await input.fill("Oman");
+
+        await expect(page.locator("#countries-items > [data-combobox-item]")).toHaveCount(2);
+        await expect(items).toBeVisible();
+        const selection = page.locator("#countries-selection");
+        await expect(selection).toContainText("null");
+    });
+
+    test("exact matches are auto-selected if configured", async ({ page }) => {
+        const [input, items] = await createLocators(page);
+
+        await page.locator("#checkbox-enable-autoselect").check();
+
+        await input.click();
+        await expect(page.locator("#countries-item-0")).toBeVisible();
+
+        await input.fill("Oman");
+
+        const selection = page.locator("#countries-selection");
+        await expect(items).not.toBeVisible();
+        await expect(selection).toContainText("Oman");
+    });
+});

--- a/headless/src/jsMain/kotlin/dev/fritz2/headless/components/combobox.kt
+++ b/headless/src/jsMain/kotlin/dev/fritz2/headless/components/combobox.kt
@@ -676,6 +676,9 @@ class Combobox<E : HTMLElement, T>(tag: Tag<E>, id: String?) : Tag<E> by tag, Op
 
                     initialize()
                 }
+
+                // for testing purposes only
+                domNode.setAttribute("data-combobox-item", "")
             }
         }
 

--- a/headless/src/jsMain/kotlin/dev/fritz2/headless/components/combobox.kt
+++ b/headless/src/jsMain/kotlin/dev/fritz2/headless/components/combobox.kt
@@ -1,0 +1,929 @@
+package dev.fritz2.headless.components
+
+import dev.fritz2.core.*
+import dev.fritz2.core.Window
+import dev.fritz2.headless.foundation.*
+import dev.fritz2.headless.foundation.utils.floatingui.utils.PlacementValues
+import dev.fritz2.headless.foundation.utils.scrollintoview.HeadlessScrollOptions
+import kotlinx.coroutines.FlowPreview
+import kotlinx.coroutines.flow.*
+import org.w3c.dom.*
+import kotlin.math.max
+import kotlin.math.min
+
+/**
+ * This class provides the building blocks to implement a combobox.
+ *
+ * Use the [combobox] functions to create an instance, set up the needed [Hook]s or [Property]s and refine the
+ * component by using the further factory methods offered by this class.
+ *
+ * For more information refer to the [official documentation](https://www.fritz2.dev/headless/combobox/).
+ */
+class Combobox<E : HTMLElement, T>(tag: Tag<E>, id: String?) : Tag<E> by tag, OpenClose() {
+
+    private val componentId: String by lazy { id ?: Id.next() }
+
+
+    inner class ItemsHook : Hook<Combobox<E, T>, Unit, Unit>() {
+
+        operator fun invoke(items: List<T>) {
+            value = { _, _ ->
+                internalState.updateItems(items)
+            }
+        }
+
+        operator fun invoke(items: Flow<List<T>>) {
+            value = { _, _ ->
+                items handledBy internalState.updateItems
+            }
+        }
+    }
+
+    /**
+     * This hook holds the available items [T] which are queried based on the user's input.
+     *
+     * Invoke this hook in order to configure the desired items.
+     * Both static values and [Flow]s are applicable.
+     *
+     * Example:
+     * ```kotlin
+     * items(listOf("A", "B", "C"))
+     *
+     * items(
+     *     flow {
+     *         emit(listOf("A", "B", "C")
+     *         delay(1000L)
+     *         emit(listOf("D", "E", "F")
+     *     }
+     * )
+     * ```
+     */
+    val items: ItemsHook = ItemsHook()
+
+    /**
+     * Specifies how the String representation of an Item is generated.
+     *
+     * This not only needed in order to format the input's text, but also to determine whether an item returned by the
+     * [filterBy] function is an exact match.
+     */
+    var itemFormat: (T) -> String = { it.toString() }
+
+
+    /**
+     * [DatabindingProperty] holding the currently selected item [T].
+     *
+     * When an item is selected via mouse or keyboard, it will be passed upstream via this binding.
+     *
+     * The other way around, all items pushed tp this binding will be reflected as the selected item.
+     */
+    val value: DatabindingProperty<T?> = DatabindingProperty()
+
+
+    inner class FilterFunctionProperty : Property<(Sequence<T>, String) -> Sequence<T>>() {
+
+        private val default: (Sequence<T>, String) -> Sequence<T> = { items, query ->
+            items.filter { item ->
+                item.toString().contains(query, ignoreCase = true)
+            }
+        }
+
+        init {
+            var warningShown = false
+            value = { items, query ->
+                // The following expression checks whether the List of available items is likely to be a List<String>
+                // or not. Since we cannot type-check the generic type of a List, we have to check an actual element and
+                // assume all elements have the same type. In some edge cases this might not be true but this check is
+                // good enough for now :-)
+                if (!warningShown && items.firstOrNull()?.let { it !is String } == true) {
+                    warnAboutDefaultFilter(this@Combobox.domNode)
+                    warningShown = true
+                }
+                default(items, query)
+            }
+        }
+
+
+        /**
+         * Enforces the use of the default filter implementation.
+         *
+         * > __Warning:__ Using this implementation with _non-String_ item types is not recommended unless you can
+         * > ensure their `toString()` method equals exactly what the user would type in the input field of the
+         * > combobox.
+         *
+         * In most cases, explicitly specifying a filter via [FilterFunctionProperty.invoke] is the recommended way!
+         */
+        fun default() {
+            value = default
+        }
+
+        operator fun invoke(filter: (Sequence<T>, String) -> Sequence<T>) {
+            value = filter
+        }
+
+        operator fun invoke(fieldSelector: T.() -> String) {
+            value = { list, query ->
+                list.filter { item ->
+                    fieldSelector(item).contains(query, ignoreCase = true)
+                }
+            }
+        }
+
+
+        internal fun filter(items: Sequence<T>, query: String): Sequence<T> =
+            value!!.invoke(items, query)
+
+
+        private fun warnAboutDefaultFilter(domNode: HTMLElement) {
+            console.warn(
+                buildString {
+                    append("Warning: combobox#$componentId: ")
+                    append("You are implicitly using the default filter function in a component whose items are not ")
+                    append("of type String! ")
+                    appendLine()
+                    appendLine()
+                    append("This may cause problems since in the default implementation `toString()` is ")
+                    append("used to find matching items for each query. Please set a custom filter via the ")
+                    append("`filterBy` property.")
+                    appendLine()
+                    appendLine()
+                    append("If the default implementation is explicitly needed, specify it's use via ")
+                    append("`filterBy.default()`.")
+                    appendLine()
+                    appendLine()
+                },
+                domNode
+            )
+        }
+    }
+
+    /**
+     * Filter function used to query the available [items] based on the user's input.
+     *
+     * By default, the [toString] representation of each item is used to find items matching the current query.
+     * In most cases, however, a specific field (e.g. a country's name) is needed in order to get meaningful results!
+     *
+     * The `filterBy` property takes any function with the following signature:
+     * `(Sequence<Country>, String) -> Sequence<Country>`.
+     *
+     * Since in practice many filterings rely on a single `String` property, a getter function returning a `String`
+     * (`T.() -> String`) can be passed as well.
+     *
+     * > __Important:__ Using non-String items and not providing a specialized filter function may result in undefined
+     * > behavior regarding the filter results! This is due to default implementation using `toString()` to find
+     * > matching items for each query.
+     * > If you still need to use the default filter function it can explicitly be set via
+     * > [filterBy.default][FilterFunctionProperty.default].
+     *
+     * Example:
+     * ```kotlin
+     * data class Country(val code: String, val name: String)
+     *
+     * // ...
+     *
+     * filterBy(Country::name)
+     *
+     * // OR
+     *
+     * filterBy { countries, query ->
+     *     countries.filter { country ->
+     *         country.name.contains(query, ignoreCase = true)
+     *     }
+     * }
+     * ```
+     */
+    val filterBy: FilterFunctionProperty = FilterFunctionProperty()
+
+
+    inner class SelectionStrategyProperty : Property<(Sequence<T>, String) -> QueryResult<T>>() {
+
+        private fun isExactMatch(item: T, query: String) =
+            itemFormat(item).contentEquals(query, ignoreCase = true)
+
+        private fun buildItemListResult(itemSequence: Sequence<T>, query: String): QueryResult.ItemList<T> {
+            val (itemList, count) = itemSequence
+                .mapIndexed(::Item)
+                .fold(emptyList<Item<T>>() to 0) { (list, count), item ->
+                    (list + item) to (count + 1)
+                }
+
+            return QueryResult.ItemList(
+                query,
+                itemList.take(maximumDisplayedItems),
+                truncated = count > maximumDisplayedItems
+            )
+        }
+
+        private val autoSelectMatch: (Sequence<T>, String) -> QueryResult<T> = { itemSequence, query ->
+            when (val exactMatch = itemSequence.find { isExactMatch(it, query) }) {
+                null -> buildItemListResult(itemSequence, query)
+                else -> QueryResult.ExactMatch(exactMatch)
+            }
+        }
+
+
+        init {
+            value = ::buildItemListResult
+        }
+
+        fun autoSelectMatch() {
+            value = autoSelectMatch
+        }
+
+        fun manual() {
+            value = ::buildItemListResult
+        }
+
+
+        internal fun buildResult(filteredItems: Sequence<T>, query: String): QueryResult<T> =
+            value!!.invoke(filteredItems, query)
+    }
+
+    /**
+     * This property allows the configuration of the selection strategy of the combobox.
+     *
+     * The selection strategy controls whether an item should automatically be selected if the user types in an exact
+     * match in the combobox's input or not.
+     *
+     * The following strategies can be configured:
+     * - [autoSelectMatch()][SelectionStrategyProperty.autoSelectMatch] (__default__): Automatically select elements if
+     *   they are an exact match
+     * - [manual()][SelectionStrategyProperty.manual]: Render exact matches as part of the regular dropdown for the user
+     *   to manually select. If no selection is made, the input is reset to the last selected value.
+     *
+     * Example:
+     * ```kotlin
+     * combobox {
+     *     selectionStrategy.autoSelectMatches()
+     *     // OR
+     *     selectionStrategy.manual()
+     * }
+     * ```
+     */
+    val selectionStrategy: SelectionStrategyProperty = SelectionStrategyProperty()
+
+
+    /**
+     * Number of maximum suggested items displayed in the dropdown.
+     *
+     * If more items match the query than specified in this threshold, only the first n items are displayed.
+     */
+    var maximumDisplayedItems: Int = 20
+
+    /**
+     * Number of milliseconds to wait and debounce before the items are queried based on the user's input.
+     *
+     * This debouncing is in place to prevent unnecessary executions of the [filterBy] functions when the user quickly
+     * inputs new text in a short amount of time (i.e. fast typing).
+     *
+     * The value can be adjusted in order to fine-tune the performance:
+     * - A lower value may lead to a better perceived responsiveness but may slow to component down if a large amount
+     *   of items is present and/or the user has a weak system
+     * - A higher value may lower the perceived responsiveness but can in turn result in a better performance with large
+     *   amounts of data
+     *
+     * > Important:__ In most cases, the default value should be the optimal value. It is a well-balanced compromise
+     * > between responsiveness and general performance.
+     */
+    var inputDebounceMillis: Long = 50L
+
+    /**
+     * Number of milliseconds to wait and debounce before the query results are actually rendered in the dropdown.
+     *
+     * This debouncing ensures that the dropdown items are only rendered once if new query-results arrive
+     * within the given time period (rendering is expensive).
+     *
+     * The value can be adjusted in order to fine-tune the performance:
+     * - A lower value may lead to a better perceived responsiveness but may quickly lead to a dramatically worse
+     *   render performance
+     * - A higher value may lower the perceived responsiveness but generally results in a more efficient rendering
+     *
+     * > Important:__ In most cases, the default value should be the optimal value. It is a well-balanced compromise
+     *      * > between responsiveness and general performance.
+     */
+    var renderDebounceMillis: Long = 50L
+
+
+    private val activeIndexStore = storeOf<Int?>(null)
+
+
+    private var panelReference: Tag<HTMLElement>? = null
+
+    private var input: Tag<HTMLInputElement>? = null
+
+    private var label: Tag<HTMLElement>? = null
+
+
+    private data class InternalState<T>(
+        val items: List<T> = emptyList(),
+        val query: String = "",
+        val opened: Boolean = false
+    )
+
+
+    /**
+     * Represents an item consisting of its associated current [index] as well as its [value].
+     *
+     * Instances of this class are part of the [ItemList][QueryResult.ItemList] [QueryResult] and are passed to the
+     * [comboboxItem][ComboboxItems.comboboxItem] brick in order for it to know which item it represents.
+     */
+    data class Item<T> internal constructor(
+        val index: Int,
+        val value: T
+    )
+
+    /**
+     * Represents the result produced by a query.
+     *
+     * There are two concrete types of results:
+     * - [ExactMatch]: The query matches exactly one item and should automatically be taken as the selection.
+     *   If automatic selections are disabled, this type is never emitted.
+     * - [ItemList]: The query returned one or more possible matches which should be rendered in the selection dropdown.
+     *   In order to do so, results of this type are exposed to the user via the [ComboboxItems.results] flow.
+     *
+     * For more information refer to the [official documentation](https://www.fritz2.dev/headless/combobox/).
+     *
+     * @see ComboboxItems.comboboxItem
+     */
+    sealed interface QueryResult<T> {
+
+        /**
+         * Represents an exact match of an [item] produced by a query.
+         *
+         * See [QueryResult] for more information.
+         */
+        value class ExactMatch<T> internal constructor(val item: T) : QueryResult<T>
+
+        /**
+         * Represents a list of [items] produced by a [query] that should be displayed in the selection dropdown.
+         *
+         * The [truncated] property is set to `true if the filter function specified via [filterBy] returned more than
+         * [maximumDisplayedItems] items.
+         *
+         * See [QueryResult] for more information.
+         */
+        data class ItemList<T> internal constructor(
+            val query: String,
+            val items: List<Item<T>>,
+            val truncated: Boolean
+        ) : QueryResult<T>
+    }
+
+
+    private val internalState = object : RootStore<InternalState<T>>(InternalState(), job) {
+
+        val updateItems: Handler<List<T>> = handle { current, items ->
+            current.copy(items = items)
+        }
+
+        val updateQuery: EmittingHandler<String, String> = handleAndEmit { current, query ->
+            current.copy(query = query, opened = true).also {
+                emit(query)
+            }
+        }
+
+        val resetQuery: EmittingHandler<Unit, Unit> = handleAndEmit { current, _ ->
+            current.copy(query = "").also {
+                emit(Unit)
+            }
+        }
+
+        val setOpened: Handler<Boolean> = handle { current, opened ->
+            current.copy(opened = opened)
+        }
+
+        val select: EmittingHandler<T, T> = handleAndEmit { current, selection ->
+            current.copy(query = "", opened = false).also {
+                emit(selection)
+            }
+        }
+
+
+        private fun computeQueryResult(items: List<T>, query: String): QueryResult<T> =
+            filterBy
+                .filter(items.asSequence(), query)
+                .let { itemSequence ->
+                    selectionStrategy.buildResult(itemSequence, query)
+                }
+
+        @OptIn(FlowPreview::class)
+        val queryResults: Flow<QueryResult<T>> =
+            merge(
+                // Emit initial data straight-away to avoid flickering upon first opening of the dropdown:
+                flowOnceOf(
+                    computeQueryResult(current.items, current.query)
+                ),
+                // All subsequent states are computed based on the changing internal state:
+                data
+                    .drop(1)
+                    .filter { it.opened }
+                    .debounce(inputDebounceMillis)
+                    .mapLatest { state -> computeQueryResult(state.items, state.query) }
+                    .debounce(renderDebounceMillis)
+            )
+
+        init {
+            queryResults.mapNotNull { (it as? QueryResult.ExactMatch<T>)?.item } handledBy select
+        }
+    }
+
+
+    init {
+        openState(storeOf(false))
+    }
+
+
+    /**
+     * Factory function to create a [comboboxPanelReference].
+     *
+     * This brick may be used to specify an alternative anchor for the combobox's dropdown. This may be useful when
+     * there are other decorative elements positioned around the input element.
+     *
+     * For more information refer to the
+     * [official documentation](https://www.fritz2.dev/headless/combobox/#comboboxItems)
+     */
+    fun <ER : HTMLElement> RenderContext.comboboxPanelReference(
+        classes: String? = null,
+        scope: (ScopeContext.() -> Unit) = {},
+        tag: TagFactory<Tag<ER>>,
+        content: Tag<ER>.() -> Unit
+    ): Tag<ER> =
+        tag(this, classes, "", scope) {
+            content()
+        }.also {
+            panelReference = it
+        }
+
+    /**
+     * Factory function to create a [comboboxPanelReference] with an [HTMLDivElement] as default root [Tag].
+     *
+     * This brick may be used to specify an alternative anchor for the combobox's dropdown. This is useful when
+     * there are other decorative elements positioned around the input element.
+     *
+     * For more information refer to the
+     * [official documentation](https://www.fritz2.dev/headless/combobox/#comboboxItems)
+     */
+    fun RenderContext.comboboxPanelReference(
+        classes: String? = null,
+        scope: (ScopeContext.() -> Unit) = {},
+        content: Tag<HTMLDivElement>.() -> Unit
+    ): Tag<HTMLDivElement> =
+        comboboxPanelReference(classes, scope, tag = RenderContext::div, content)
+
+
+    inner class ComboboxInput(tag: Tag<HTMLInputElement>) : Tag<HTMLInputElement> by tag {
+
+        private fun handleKeyboardSelections() {
+            val selectionKeydowns = keydowns {
+                if (shortcutOf(key) in setOf(Keys.ArrowUp, Keys.ArrowDown, Keys.Enter, Keys.Home, Keys.End))
+                    preventDefault()
+            }
+
+            internalState.queryResults.flatMapLatest { result ->
+                when (result) {
+                    is QueryResult.ExactMatch<T> -> flowOnceOf(null)
+                    is QueryResult.ItemList<T> -> selectionKeydowns
+                        .mapNotNull { event ->
+                            shortcutOf(event).takeIf {
+                                it in setOf(Keys.ArrowUp, Keys.ArrowDown, Keys.Enter, Keys.Home, Keys.End)
+                            }
+                        }
+                        .mapNotNull { shortcut ->
+                            val index = activeIndexStore.current ?: -1
+                            val lastIndex = result.items.size - 1
+                            when (shortcut) {
+                                Keys.Home -> 0
+                                Keys.ArrowUp -> max(index - 1, 0)
+                                Keys.ArrowDown -> min(index + 1, lastIndex)
+                                Keys.End -> lastIndex
+                                else -> null
+                            }
+                        }
+                }
+            } handledBy activeIndexStore.update
+
+            internalState.queryResults.flatMapLatest { result ->
+                selectionKeydowns.mapNotNull {
+                    val active = activeIndexStore.current
+                    if (result is QueryResult.ItemList<T> && active != null && shortcutOf(it) == Keys.Enter) {
+                        result.items.getOrNull(active)?.value
+                    } else null
+                }
+            } handledBy internalState.select
+        }
+
+        fun render() {
+            value(
+                merge(
+                    internalState.select.map { itemFormat(it) },
+                    value.data.flatMapLatest { value ->
+                        internalState.resetQuery.map { value?.let { itemFormat(it) } ?: "" }
+                    },
+                    // Update the input every time the user types in a new value. This is needed because `mountSimple`
+                    // (used internally by `value()`) does not work with repeating identical values. This is needed,
+                    // however, when the previous selection should be re-applied to the input.
+                    inputs.values()
+                ).distinctUntilChanged()
+            )
+
+            inputs.values() handledBy internalState.updateQuery
+
+
+            focusins handledBy {
+                open()
+                domNode.select()
+            }
+
+            Window.keydowns.mapNotNull { event ->
+                if (internalState.current.opened && shortcutOf(event) == Keys.Tab) false
+                else null
+            } handledBy internalState.setOpened
+
+            selects.map { true } handledBy internalState.setOpened
+
+            handleKeyboardSelections()
+
+
+            // aria-controls is set automatically by the PopUpPanel
+            attr("role", Aria.Role.combobox)
+            attr(Aria.expanded, opened.asString())
+            attr(Aria.autocomplete, "list")
+        }
+    }
+
+    /**
+     * Factory function to create a [comboboxInput].
+     *
+     * For more information refer to the
+     * [official documentation](https://www.fritz2.dev/headless/combobox/#comboboxInput)
+     */
+    fun RenderContext.comboboxInput(
+        classes: String? = null,
+        scope: ScopeContext.() -> Unit = {},
+        initialize: ComboboxInput.() -> Unit
+    ): Tag<HTMLInputElement> {
+        addComponentStructureInfo("combobox-input", this.scope, this)
+        return input(classes, "$componentId-input", scope) {
+            with(ComboboxInput(this)) {
+                initialize()
+                render()
+            }
+        }.also {
+            input = it
+        }
+    }
+
+
+    /**
+     * Factory function to create a [comboboxLabel].
+     *
+     * For more information refer to the
+     * [official documentation](https://www.fritz2.dev/headless/combobox/#comboboxLabel)
+     */
+    fun <CL : HTMLElement> RenderContext.comboboxLabel(
+        classes: String? = null,
+        scope: (ScopeContext.() -> Unit) = {},
+        tag: TagFactory<Tag<CL>>,
+        content: Tag<CL>.() -> Unit
+    ): Tag<CL> {
+        addComponentStructureInfo("combobox-label", this.scope, this)
+        return tag(this, classes, "$componentId-label", scope, content).also { label = it }
+    }
+
+    /**
+     * Factory function to create a [comboboxLabel] with an [HTMLLabelElement] as default root [Tag].
+     *
+     * For more information refer to the
+     * [official documentation](https://www.fritz2.dev/headless/combobox/#comboboxLabel)
+     */
+    fun RenderContext.comboboxLabel(
+        classes: String? = null,
+        scope: (ScopeContext.() -> Unit) = {},
+        content: Tag<HTMLLabelElement>.() -> Unit
+    ): Tag<HTMLLabelElement> =
+        comboboxLabel(classes, scope, tag = RenderContext::label, content)
+
+
+    inner class ComboboxItems<EI : HTMLElement>(
+        renderContext: RenderContext,
+        tagFactory: TagFactory<Tag<EI>>,
+        classes: String?,
+        scope: ScopeContext.() -> Unit,
+    ) : PopUpPanel<EI>(
+        renderContext,
+        tagFactory,
+        classes,
+        id = "${componentId}-items",
+        scope,
+        this@Combobox.opened,
+        reference = panelReference ?: input ?: input { },
+        ariaHasPopup = Aria.HasPopup.listbox,
+    ) {
+
+        /**
+         * Emits the current query result each time the user updates the query and the result is meant to be rendered
+         * in the selection dropdown.
+         *
+         * The emitted [QueryResult.ItemList] holds both the current [query][QueryResult.ItemList.query] and the
+         * associated list of [items][QueryResult.ItemList.items].
+         *
+         * The dropdown can be populated by iterating over the [items][QueryResult.ItemList.items], while the
+         * [query][QueryResult.ItemList.query] may optionally be used to highlight the matching passage of the item's
+         * String representation.
+         *
+         * For more information refer to the [official documentation](https://www.fritz2.dev/headless/combobox/).
+         *
+         * @see comboboxItem
+         */
+        val results: Flow<QueryResult.ItemList<T>> =
+            internalState.queryResults.mapNotNull { it as? QueryResult.ItemList<T> }
+
+
+        private fun itemId(index: Int) = "$componentId-item-$index"
+
+
+        inner class ComboboxItem<EJ : HTMLElement>(
+            tag: Tag<EJ>,
+            val active: Flow<Boolean>,
+            val selected: Flow<Boolean>
+        ) : Tag<EJ> by tag
+
+        /**
+         * Factory function to create a [comboboxItem].
+         *
+         * For more information refer to the
+         * [official documentation](https://www.fritz2.dev/headless/combobox/#comboboxItem)
+         */
+        fun <EJ : HTMLElement> RenderContext.comboboxItem(
+            item: Item<T>,
+            classes: String? = null,
+            scope: ScopeContext.() -> Unit = {},
+            tag: TagFactory<Tag<EJ>>,
+            initialize: ComboboxItem<EJ>.() -> Unit
+        ): Tag<EJ> {
+            addComponentStructureInfo("combobox-item", this.scope, this)
+            return tag(this, classes, itemId(item.index), scope) {
+                with(ComboboxItem(
+                    this,
+                    active = activeIndexStore.data.map { activeIndex -> item.index == activeIndex },
+                    selected = value.data.map { selected -> item.value == selected }
+                )) {
+                    clicks.map { item.value } handledBy internalState.select
+                    mouseenters.mapNotNull { item.index } handledBy activeIndexStore.update
+
+                    active.filter { it } handledBy {
+                        domNode.scrollIntoView(HeadlessScrollOptions)
+                    }
+
+                    initialize()
+                }
+            }
+        }
+
+        /**
+         * Factory function to create a [comboboxItem] with an [HTMLDivElement] as default root [Tag].
+         *
+         * For more information refer to the
+         * [official documentation](https://www.fritz2.dev/headless/combobox/#comboboxItem)
+         */
+        fun RenderContext.comboboxItem(
+            item: Item<T>,
+            classes: String? = null,
+            scope: ScopeContext.() -> Unit = {},
+            initialize: ComboboxItem<HTMLDivElement>.() -> Unit
+        ): Tag<HTMLDivElement> =
+            comboboxItem(item, classes, scope, tag = RenderContext::div, initialize)
+
+
+        override fun render() {
+            super.render()
+
+            attr(Aria.activedescendant, activeIndexStore.data.map { it?.let(::itemId) })
+
+            onDismiss {
+                internalState.resetQuery()
+                close()
+            }
+        }
+    }
+
+    /**
+     * Factory function to create a [comboboxItems].
+     *
+     * For more information refer to the
+     * [official documentation](https://www.fritz2.dev/headless/combobox/#comboboxItems)
+     */
+    fun <EI : HTMLElement> comboboxItems(
+        classes: String? = null,
+        scope: ScopeContext.() -> Unit = {},
+        tag: TagFactory<Tag<EI>>,
+        initialize: ComboboxItems<EI>.() -> Unit
+    ) {
+        portal {
+            addComponentStructureInfo("combobox-items", this.scope, this)
+            ComboboxItems(this, tag, classes, scope).run {
+                size = PopUpPanelSize.Exact
+                placement = PlacementValues.bottomStart
+                initialize()
+                render()
+            }
+        }
+    }
+
+    /**
+     * Factory function to create a [comboboxItems] with an [HTMLDivElement] as default root [Tag].
+     *
+     * For more information refer to the
+     * [official documentation](https://www.fritz2.dev/headless/combobox/#comboboxItems)
+     */
+    fun comboboxItems(
+        classes: String? = null,
+        scope: ScopeContext.() -> Unit = {},
+        initialize: ComboboxItems<HTMLDivElement>.() -> Unit
+    ) {
+        comboboxItems(classes, scope, tag = RenderContext::div, initialize)
+    }
+
+
+    /**
+     * Factory function to create a [comboboxValidationMessages].
+     *
+     * For more information refer to the
+     * [official documentation](https://www.fritz2.dev/headless/combobox/#comboboxValidationMessages)
+     */
+    fun <EV : HTMLElement> RenderContext.comboboxValidationMessages(
+        classes: String? = null,
+        scope: (ScopeContext.() -> Unit) = {},
+        tag: TagFactory<Tag<EV>>,
+        initialize: ValidationMessages<EV>.() -> Unit
+    ) {
+        value.validationMessages.renderIf({ it.isNotEmpty() }) {
+            addComponentStructureInfo("comboboxValidationMessages", this@comboboxValidationMessages.scope, this)
+            tag(this, classes, "$componentId-${ValidationMessages.ID_SUFFIX}", scope) {
+                initialize(ValidationMessages(value.validationMessages, this))
+            }
+        }
+    }
+
+    /**
+     * Factory function to create a [comboboxValidationMessages] with an [HTMLDivElement] as default root [Tag].
+     *
+     * For more information refer to the
+     * [official documentation](https://www.fritz2.dev/headless/combobox/#comboboxValidationMessages)
+     */
+    fun RenderContext.comboboxValidationMessages(
+        classes: String? = null,
+        scope: (ScopeContext.() -> Unit) = {},
+        initialize: ValidationMessages<HTMLDivElement>.() -> Unit
+    ) {
+        comboboxValidationMessages(classes, scope, tag = RenderContext::div, initialize)
+    }
+
+
+    fun render() {
+        attr("id", componentId)
+
+        if (!value.isSet) {
+            warnAboutMissingDatabinding(propertyName = "value", componentName = "combobox", componentId, domNode)
+        }
+
+        hook(items)
+
+
+        value.data.mapNotNull { it } handledBy internalState.select
+        value.handler?.invoke(this, internalState.select)
+
+        opened handledBy internalState.setOpened
+        openState.handler?.invoke(this, internalState.data.map { it.opened }.distinctUntilChanged())
+
+        internalState.data.map { null } handledBy activeIndexStore.update
+
+
+        label?.let {
+            attr(Aria.labelledby, it.id)
+        }
+    }
+}
+
+/**
+ * Factory function to create a [Combobox].
+ *
+ * API-Sketch:
+ * ```kotlin
+ * combobox<T> {
+ *     val items: ItemsHook()
+ *     // params: List<T> / Flow<List<T>>
+ *
+ *     var itemFormat: (T) -> String
+ *
+ *     val value: DatabindingProperty<T>
+ *
+ *     var filterBy: FilterFunctionProperty
+ *     // params: (Sequence<T>, String) -> Sequence<T> / T.() -> String
+ *
+ *     val selectionStrategy: SelectionStrategyProperty
+ *     // methods: autoSelectMatches() / manual()
+ *
+ *     var maximumDisplayedItems: Int = 20
+ *     var inputDebounceMillis: Long = 50L
+ *     var renderDebounceMillis: Long = 50L
+ *
+ *     comboboxPanelReference() { }
+ *     comboboxInput() { }
+ *     comboboxLabel() { }
+ *     comboboxItems() {
+ *         // inherited by `PopUpPanel`
+ *         var placement: Placement
+ *         var strategy: Strategy
+ *         var flip: Boolean
+ *         var skidding: Int
+ *         var distance: int
+ *
+ *         val results: Flow<QueryResult.ItemList<T>>
+ *
+ *         // state.render {
+ *             // for each QueryResult.ItemList<T>.Item<T> {
+ *                 comboboxItem(Item<T>) { }
+ *             // }
+ *         // }
+ *     }
+ *     comboboxValidationMessages() {
+ *         val msgs: Flow<List<ComponentValidationMessage>>
+ *     }
+ * }
+ * ```
+ *
+ * For more information refer to the [official documentation](https://www.fritz2.dev/headless/listbox/#listbox)
+ */
+fun <E : HTMLElement, T> RenderContext.combobox(
+    classes: String? = null,
+    id: String? = null,
+    scope: ScopeContext.() -> Unit = {},
+    tag: TagFactory<Tag<E>>,
+    initialize: Combobox<E, T>.() -> Unit
+): Tag<E> {
+    addComponentStructureInfo("combobox", this.scope, this)
+    return tag(this, classes, id, scope) {
+        with(Combobox<E, T>(this, id)) {
+            initialize()
+            render()
+        }
+    }
+}
+
+/**
+ * Factory function to create a [Combobox]  with an [HTMLDivElement] as default root [Tag].
+ *
+ * API-Sketch:
+ * ```kotlin
+ * combobox<T> {
+ *     val items: ItemsHook()
+ *     // params: List<T> / Flow<List<T>>
+ *
+ *     var itemFormat: (T) -> String
+ *
+ *     val value: DatabindingProperty<T>
+ *
+ *     var filterBy: FilterFunctionProperty
+ *     // params: (Sequence<T>, String) -> Sequence<T> / T.() -> String
+ *
+ *     val selectionStrategy: SelectionStrategyProperty
+ *     // methods: autoSelectMatches() / manual()
+ *
+ *     var maximumDisplayedItems: Int = 20
+ *     var inputDebounceMillis: Long = 50L
+ *     var renderDebounceMillis: Long = 50L
+ *
+ *     comboboxPanelReference() { }
+ *     comboboxInput() { }
+ *     comboboxLabel() { }
+ *     comboboxItems() {
+ *         // inherited by `PopUpPanel`
+ *         var placement: Placement
+ *         var strategy: Strategy
+ *         var flip: Boolean
+ *         var skidding: Int
+ *         var distance: int
+ *
+ *         val results: Flow<QueryResult.ItemList<T>>
+ *
+ *         // state.render {
+ *             // for each QueryResult.ItemList<T>.Item<T> {
+ *                 comboboxItem(Item<T>) { }
+ *             // }
+ *         // }
+ *     }
+ *     comboboxValidationMessages() {
+ *         val msgs: Flow<List<ComponentValidationMessage>>
+ *     }
+ * }
+ * ```
+ *
+ * For more information refer to the [official documentation](https://www.fritz2.dev/headless/listbox/#listbox)
+ */
+fun <T> RenderContext.combobox(
+    classes: String? = null,
+    id: String? = null,
+    scope: ScopeContext.() -> Unit = {},
+    initialize: Combobox<HTMLDivElement, T>.() -> Unit
+): Tag<HTMLDivElement> =
+    combobox(classes, id, scope, tag = RenderContext::div, initialize)

--- a/headless/src/jsMain/kotlin/dev/fritz2/headless/components/combobox.kt
+++ b/headless/src/jsMain/kotlin/dev/fritz2/headless/components/combobox.kt
@@ -528,7 +528,7 @@ class Combobox<E : HTMLElement, T>(tag: Tag<E>, id: String?) : Tag<E> by tag, Op
             inputs.values() handledBy internalState.updateQuery
 
 
-            focusins handledBy {
+            focuss handledBy {
                 open()
                 domNode.select()
             }

--- a/headless/src/jsMain/kotlin/dev/fritz2/headless/components/combobox.kt
+++ b/headless/src/jsMain/kotlin/dev/fritz2/headless/components/combobox.kt
@@ -528,17 +528,18 @@ class Combobox<E : HTMLElement, T>(tag: Tag<E>, id: String?) : Tag<E> by tag, Op
             inputs.values() handledBy internalState.updateQuery
 
 
-            focuss handledBy {
+            focuss.filterNot { domNode.readOnly } handledBy {
                 open()
                 domNode.select()
             }
+
+            selects.filterNot { domNode.readOnly }.map { true } handledBy internalState.setOpened
+
 
             Window.keydowns.mapNotNull { event ->
                 if (internalState.current.opened && shortcutOf(event) == Keys.Tab) false
                 else null
             } handledBy internalState.setOpened
-
-            selects.map { true } handledBy internalState.setOpened
 
             handleKeyboardSelections()
 

--- a/headless/src/jsMain/kotlin/dev/fritz2/headless/components/combobox.kt
+++ b/headless/src/jsMain/kotlin/dev/fritz2/headless/components/combobox.kt
@@ -445,10 +445,10 @@ class Combobox<E : HTMLElement, T>(tag: Tag<E>, id: String?) : Tag<E> by tag, Op
         classes: String? = null,
         scope: (ScopeContext.() -> Unit) = {},
         tag: TagFactory<Tag<ER>>,
-        content: Tag<ER>.() -> Unit
+        initialize: Tag<ER>.() -> Unit
     ): Tag<ER> =
         tag(this, classes, "", scope) {
-            content()
+            initialize()
         }.also {
             panelReference = it
         }

--- a/headless/src/jsMain/kotlin/dev/fritz2/headless/components/combobox.kt
+++ b/headless/src/jsMain/kotlin/dev/fritz2/headless/components/combobox.kt
@@ -208,7 +208,7 @@ class Combobox<E : HTMLElement, T>(tag: Tag<E>, id: String?) : Tag<E> by tag, Op
         /**
          * Helper function taking [n] elements from a [Sequence] and storing them in a [List].
          *
-         * The result is a [Pair] consisting of the actual list an a [Boolean] indicating whether the original sequence
+         * The result is a [Pair] consisting of the actual list and a [Boolean] indicating whether the original sequence
          * had more than `n` elements, i.e. has been _truncated_ during the conversion.
          *
          * This function aims to be as performant as possible in the context of computing query results. In most other

--- a/headless/src/jsMain/kotlin/dev/fritz2/headless/components/combobox.kt
+++ b/headless/src/jsMain/kotlin/dev/fritz2/headless/components/combobox.kt
@@ -435,8 +435,10 @@ class Combobox<E : HTMLElement, T>(tag: Tag<E>, id: String?) : Tag<E> by tag, Op
     /**
      * Factory function to create a [comboboxPanelReference].
      *
-     * This brick may be used to specify an alternative anchor for the combobox's dropdown. This may be useful when
-     * there are other decorative elements positioned around the input element.
+     * This brick may be used to specify an alternative anchor for the combobox's dropdown when other decorative
+     * elements are positioned around the actual input that are considered part of it.
+     *
+     * In those cases, the dropdown should position itself based on the wrapping element.
      *
      * For more information refer to the
      * [official documentation](https://www.fritz2.dev/headless/combobox/#comboboxItems)
@@ -456,8 +458,10 @@ class Combobox<E : HTMLElement, T>(tag: Tag<E>, id: String?) : Tag<E> by tag, Op
     /**
      * Factory function to create a [comboboxPanelReference] with an [HTMLDivElement] as default root [Tag].
      *
-     * This brick may be used to specify an alternative anchor for the combobox's dropdown. This is useful when
-     * there are other decorative elements positioned around the input element.
+     * This brick may be used to specify an alternative anchor for the combobox's dropdown when other decorative
+     * elements are positioned around the actual input that are considered part of it.
+     *
+     * In those cases, the dropdown should position itself based on the wrapping element.
      *
      * For more information refer to the
      * [official documentation](https://www.fritz2.dev/headless/combobox/#comboboxItems)
@@ -831,8 +835,11 @@ class Combobox<E : HTMLElement, T>(tag: Tag<E>, id: String?) : Tag<E> by tag, Op
  *     var inputDebounceMillis: Long = 50L
  *     var renderDebounceMillis: Long = 50L
  *
- *     comboboxPanelReference() { }
  *     comboboxInput() { }
+ *     comboboxPanelReference() {
+ *         // this brick is often used with a nested
+ *         // comboboxInput() { }
+ *     }
  *     comboboxLabel() { }
  *     comboboxItems() {
  *         // inherited by `PopUpPanel`
@@ -897,8 +904,11 @@ fun <E : HTMLElement, T> RenderContext.combobox(
  *     var inputDebounceMillis: Long = 50L
  *     var renderDebounceMillis: Long = 50L
  *
- *     comboboxPanelReference() { }
  *     comboboxInput() { }
+ *     comboboxPanelReference() {
+ *         // this brick is often used with a nested
+ *         // comboboxInput() { }
+ *     }
  *     comboboxLabel() { }
  *     comboboxItems() {
  *         // inherited by `PopUpPanel`

--- a/www/src/pages/headless/combobox.md
+++ b/www/src/pages/headless/combobox.md
@@ -17,7 +17,7 @@ demoHeight: 25rem
 ## Basic Example
 
 A combo box is created by the factory function `fun <T> combobox()`. `T` is the data type of the choices to be offered,
-such as a domain data type like movie characters.
+such as a country.
 
 When the input created via `comboboxInput` is focused, a dropdown with suggestions is shown and updated as you
 type. When focused, the input shows the current input. Otherwise, the currently selected item is displayed.
@@ -29,17 +29,23 @@ but also emits the updated selection to the outside via a `Handler`.
 You can navigate within the selection list using the keyboard. By [[Enter]], [[Space]] or a mouse click an item is
 selected. If the combo box input loses focus or the user clicks outside the selection list, the dropdown is hidden.
 
-The selection dropdown is populated via the `comboboxItems` brick. Within the scope of this function, individual items
-can be rendered via the `comboboxItem` brick.  
-The combo box constantly evaluates which items to show based on the user's query. The results are emitted to the
+As typical use cases may offer thousands of items to choose from, the component reduces and filters those in order to
+support the visual recognition of a user down to a feasible size, which can be configured via `maximumDisplayedItems`.
+
+As a result, the combo box constantly evaluates which items to show based on the user's query. The results are emitted
+by the
 `results` Flow available in the scope of the items brick.  
 The intended pattern is to iterate over the results and re-render all of them when the results change.
+
+The selection dropdown is populated via the `comboboxItems` brick. Within the scope of this function, individual items
+can be rendered via the `comboboxItem` brick.
 
 ::: warning
 __Beware:__ Due to the inner workings of the combobox, rendering items via `renderEach` _does not work_ and results in
 undefined behavior!
 
-Instead, render the `results` Flow and render the list of items via a combination of `render` and `forEach`.
+Instead, apply an ordinary `render` on the `results`-flow and create the items via a `forEach`-call on the provided
+`List<T>`.
 :::
 
 ```kotlin
@@ -143,7 +149,7 @@ comboboxItems {
 ## Truncated result list
 
 The `results` Flow only displays a fixed number of items at a time, configured via the `maximumDisplayedItems` property.
-If more items match the given query than configured to be displayed, the `truncated` property available in the `results`
+If more items match the given query than configured to be displayed, the `truncated` flag available in the `results`
 Flow is set to `true` so an appropriate hint can be displayed.
 
 ```kotlin
@@ -214,10 +220,16 @@ comboboxItems {
 ```
 
 ::: info
-In practice, the [`comboboxInput`](#comboboxinput) element might be wrapped in additional elements that are considered to be a part
-of it. Since by default the dropdown is positioned relative to the [`comboboxInput`](#comboboxinput) element, the dropdown may
+In practice, the [`comboboxInput`](#comboboxinput) element might be wrapped in additional elements that are considered
+to be a part
+of it. Since by default the dropdown is positioned relative to the [`comboboxInput`](#comboboxinput) element, the
+dropdown may
 appear out of place. In those cases, the outermost wrapping element can be created via the
 [`comboboxPanelReference`](#comboboxpanelreference) brick to fix the positioning.
+
+In order to see an example of the `comboboxPanelReference` in action, have a look at the source code of the combobox
+demo
+within the `headless-demo` module. You can observe the consequences of removing and re-adding it there.
 :::
 
 The anchor element of the dropdown is determined based on a number of conditions:
@@ -269,7 +281,7 @@ Clicking on an item when the list is open selects it and closes the list.
 
 ## Performance
 
-The combo box component used a sepcific internal pipeline to filter and display the selection items:
+The combo box component uses a specific internal pipeline to filter and display the selection items:
 
 1) Retrieve the user's input
 2) _Debounce_
@@ -277,7 +289,7 @@ The combo box component used a sepcific internal pipeline to filter and display 
 4) _Debounce_
 5) Render matches
 
-The debouncing is in place because the above worklfow consists of two relatively expensive operations: _filtering_ and
+The debouncing is in place because the above workflow consists of two relatively expensive operations: _filtering_ and
 _rendering_.
 
 While typing, the query may be manipulated multiple times per second. In order for the filter function to run as few
@@ -325,8 +337,11 @@ combobox<T> {
     var inputDebounceMillis: Long = 50L
     var renderDebounceMillis: Long = 50L
 
-    comboboxPanelReference() { }
     comboboxInput() { }
+    comboboxPanelReference() {
+        // this brick is often used with a nested
+        // comboboxInput() { }
+    }
     comboboxLabel() { }
     comboboxItems() {
         // inherited by `PopUpPanel`
@@ -339,9 +354,9 @@ combobox<T> {
         val results: Flow<QueryResult.ItemList<T>>
 
         // state.render {
-        // for each QueryResult.ItemList<T>.Item<T> {
-        comboboxItem(Item<T>) { }
-        // }
+            // for each QueryResult.ItemList<T>.Item<T> {
+                comboboxItem(Item<T>) { }
+            // }
         // }
     }
     comboboxValidationMessages() {
@@ -382,13 +397,13 @@ Default-Tag: `div`
 
 ### comboboxInput
 
-Available in the scope of: `combobox`
+Available in the scope of: `combobox`, `comboboxPanelReference`
 
 Parameters: `classes`, `scope`, `initialize`
 
 ### comboboxLabel
 
-Available in the scope of: `combobox`
+Available in the scope of: `combobox`, `comboboxPanelReference`
 
 Parameters: `classes`, `scope`, `tag`, `initialize`
 
@@ -396,7 +411,7 @@ Default-Tag: `label`
 
 ### listboxValidationMessages
 
-Available in the scope of: `combobox`
+Available in the scope of: `combobox`, `comboboxPanelReference`
 
 Parameters: `classes`, `scope`, `tag`, `initialize`
 

--- a/www/src/pages/headless/combobox.md
+++ b/www/src/pages/headless/combobox.md
@@ -1,0 +1,431 @@
+---
+title: Combobox
+description: "A robust component for selecting a single item from a list of options with suggestions as you type, 
+keyboard navigation, and more."
+layout: layouts/docs.njk
+permalink: /headless/combobox/
+eleventyNavigation:
+  key: combobox
+  title: Combobox
+  parent: headless
+  order: 11
+teaser: true
+demoHash: combobox
+demoHeight: 25rem
+---
+
+## Basic Example
+
+A combo box is created by the factory function `fun <T> combobox()`. `T` is the data type of the choices to be offered,
+such as a domain data type like movie characters.
+
+When the input created via `comboboxInput` is focused, a dropdown with suggestions is shown and updated as you
+type. When focused, the input shows the current input. Otherwise, the currently selected item is displayed.
+
+It is mandatory to specify a data stream or a store of type `T` as data binding via the `value` property. The component
+supports two-way data binding, i.e. it reflects a selected element from the outside by a `Flow<T>`
+but also emits the updated selection to the outside via a `Handler`.
+
+You can navigate within the selection list using the keyboard. By [[Enter]], [[Space]] or a mouse click an item is
+selected. If the combo box input loses focus or the user clicks outside the selection list, the dropdown is hidden.
+
+The selection dropdown is populated via the `comboboxItems` brick. Within the scope of this function, individual items
+can be rendered via the `comboboxItem` brick.  
+The combo box constantly evaluates which items to show based on the user's query. The results are emitted to the
+`results` Flow available in the scope of the items brick.  
+The intended pattern is to iterate over the results and re-render all of them when the results change.
+
+::: warning
+__Beware:__ Due to the inner workings of the combobox, rendering items via `renderEach` _does not work_ and results in
+undefined behavior!
+
+Instead, render the `results` Flow and render the list of items via a combination of `render` and `forEach`.
+:::
+
+```kotlin
+// some domain type for this example, a collection to choose from, and an external store
+val countries = listOf("Germany", "Netherlands", "France")
+val country = storeOf<String?>(null)
+
+combobox<String> {
+    items(countries)
+
+    // set up (two-way) data binding
+    value(country)
+
+    comboboxInput {}
+
+    comboboxItems("bg-white") {
+        // using a combination of 'render' and 'forEach' is the intended
+        // way of populating the dropdown
+        results.render { result ->
+            result.items.forEach { item ->
+                comboboxItem(item) {
+                    span {
+                        className(active.map { if (it) "underline" else "" })
+                        +item.value
+                    }
+                }
+            }
+        }
+    }
+}
+```
+
+::: info
+Do not forget to include a `portalRoot()`-call at the end of your initial `RenderContext` as explained
+[here](/headless/#portalling)!
+:::
+
+## Styling the active or selected Item
+
+A `comboboxItem` has two special states:
+
+- When the mouse is hovering above it or the user navigates to the item via keyboard, it is considered `active`.
+- A click or [[Enter]] selects the active item. It is then `selected`.
+
+In the scope of a `comboboxItem`, `active` and `selected` are available as a `Flow<Boolean>` to apply styling or to
+render or hide certain elements based on the state:
+
+```kotlin
+comboboxItem(item) {
+    //change fore- und background-color is item is active 
+    className(active.map {
+        if (it) "text-amber-900 bg-amber-100" else "text-gray-300"
+    })
+
+    span { +item.value }
+
+    //render checked-icon only if item is selected
+    selected.render {
+        if (it) {
+            svg { content(HeroIcons.check) }
+        }
+    }
+}
+```
+
+## Highlight matching items
+
+When rendering items based on the user's query, it is often a requirement to highlight the passages of each
+item's String representation that match the given query.
+For this purpose, the current `query` is part of the `results` Flow.
+
+```kotlin
+comboboxItems {
+    results.render { (query, items, _) ->
+        items.forEach { item ->
+            comboboxItem(item) {
+                // separate the item's String representation into matching and
+                // non-matching segments
+                val segments = item.value.split(
+                    Regex(
+                        "(?<=($highlight))|(?=($highlight))",
+                        RegexOption.IGNORE_CASE
+                    )
+                )
+
+                for (s in segments) {
+                    span(
+                        joinClasses(
+                            "underline".takeIf {
+                                s.contentEquals(query, ignoreCase = true)
+                            }
+                        )
+                    ) { +s }
+                }
+            }
+        }
+    }
+}
+```
+
+## Truncated result list
+
+The `results` Flow only displays a fixed number of items at a time, configured via the `maximumDisplayedItems` property.
+If more items match the given query than configured to be displayed, the `truncated` property available in the `results`
+Flow is set to `true` so an appropriate hint can be displayed.
+
+```kotlin
+comboboxItems {
+    results.render { (_, items, truncated) ->
+        items.forEach { item ->
+            comboboxItem(item) {
+                span { +item.value }
+            }
+        }
+        if (truncated) {
+            span {
+                +"Refine your query for more results"
+            }
+        }
+    }
+}
+```
+
+## Add a Label
+
+The combo box can be supplemented with a label using `comboboxLabel`, e.g. for use in forms or for a screen reader:
+
+```kotlin
+combobox<String> {
+    comboboxLabel {
+        span { +"Select a country" }
+    }
+}
+```
+
+## Open State
+
+Combobox is an [`OpenClose` component](#closable-content---openclose). There are different `Flow`s and `Handler`s
+like `opened` available in its scope to control the open state of the combo box based on state changes.
+
+Most of the time, the open state managed by the component itself should be enough for all use cases, though.
+
+## Transitions
+
+Showing and hiding the selection list can be easily animated with the help of `transition`:
+
+```kotlin
+comboboxItems {
+    transition(
+        opened,
+        enter = "transition duration-100 ease-out",
+        enterStart = "opacity-0 scale-95",
+        enterEnd = "opacity-100 scale-100",
+        leave = "transition duration-100 ease-in",
+        leaveStart = "opacity-100 scale-100",
+        leaveEnde = "opacity-0 scale-95"
+    )
+}
+```
+
+## Positioning
+
+`comboboxItems` is a [`PopUpPanel`](#floating-content---popuppanel) and therefore provides a set of
+configuration options to control the position or distance of the list box from the `listboxButton`
+as a reference element:
+
+```kotlin
+comboboxItems {
+    placement = PlacementValues.top
+    addMiddleware(offset(20))
+}
+```
+
+The exact placement of the dropdown is determined based on a number of conditions:
+
+1) If a [`comboboxInput`](#comboboxinput) is present, the panel is placed relative to it.
+2) If a [`comboboxPanelReference`](#comboboxpanelreference) is present, it is _used as the reference instead_.
+3) Otherwise, the dropdown references a minimal fallback input element.
+
+::: info
+In practice, the [`comboboxInput`](#comboboxinput) element might be wrapped in additional elements (e.g. for styling
+reasons) that may cause the dropdown to appear out of place. In those cases, the outer most wrapping element can be
+created via the [`comboboxPanelReference`](#comboboxpanelreference) brick to fix the positioning.
+:::
+
+## Validation
+
+The data-binding allows the Combobox component to process the validation messages and provide its own building
+block `lcomboboxValidationMessages` that can beused to render the messages if present. The messages are exposed within
+its scope as a `msgs` Flow.
+
+```kotlin
+combobox<String> {
+    value(country)
+
+    comboboxValidationMessages(tag = RenderContext::ul) {
+        msgs.renderEach {
+            li { +it.message }
+        }
+    }
+}
+```
+
+## Focus Management
+
+When the `comboboxInput` element is focused, the selection list (dropdown) is visible and can be used to select
+items. The input remains focused until a selection is made, even if the user navigates to an item via keyboard.  
+When an item is `active` and [[Enter]] is pressed, it will be selected and the dropdown is closed.  
+When the input elements loses focus, the dropdown will be closed as well and the displayed value is reset to match the
+last selection.
+
+## Mouse Interaction
+
+A click on the `comboboxInput` focuses the element and opens the selection dropdown as described above. A click outside
+the opened selection list closes it. If the mouse is moved over an item in the open list, it is marked as active.
+Clicking on an item when the list is open selects it and closes the list.
+
+## Keyboard Interaction
+
+| Command                                       | Description                    |
+|:----------------------------------------------|:-------------------------------|
+| [[⬆]] [[⬇]] when listbox is open              | Activates previous / next item |
+| [[Home]] [[End]] when listbox is open         | Activates first / last item    |
+| [[Esc]] when listbox is open                  | Closes the combobox            |
+| [[Enter]] [[Space]] when the combobox is open | Selects the active item        |
+
+## Performance
+
+The combo box component used a sepcific internal pipeline to filter and display the selection items:
+
+1) Retrieve the user's input
+2) _Debounce_
+3) Find matches
+4) _Debounce_
+5) Render matches
+
+The debouncing is in place because the above worklfow consists of two relatively expensive operations: _filtering_ and
+_rendering_.
+
+While typing, the query may be manipulated multiple times per second. In order for the filter function to run as few
+times as possible, the flow of inputs is debounced.
+
+The same goes for the actual rendering: It is by far the most expensive operation in the workflow so it is debounced to
+not be executed multiple times in a row.
+
+Adding to the above, the number of displayed items in the dropdown also has an impact on the rendering performance.
+
+::: info
+Most of the time, the default behavior should be working fine. There might be cases, however, where the implementing
+component has a consistently high/low amount of items or other niche scenarios. In those cases, the debouncing and
+other performance-related parameters can be configured via the DSL.
+:::
+
+| Property                | Type   | Default | Description                                                      |
+|:------------------------|:-------|:--------|:-----------------------------------------------------------------|
+| `maximumDisplayedItems` | `Int`  | `20`    | Maximum number of items to display                               |
+| `inputDebounceMillis`   | `Long` | `50L`   | Time to wait and debounce before the filter function is invoked  |
+| `renderDebounceMillis`  | `Long` | `50L`   | Time to wait and debounce before the filter results are rendered |
+
+See [`combobox`](#combobox) for more api information.
+
+## API
+
+### Summary / Sketch
+
+```kotlin
+combobox<T> {
+    val items: ItemsHook()
+    // params: List<T> / Flow<List<T>>
+
+    var itemFormat: (T) -> String
+
+    val value: DatabindingProperty<T>
+
+    var filterBy: FilterFunctionProperty
+    // params: (Sequence<T>, String) -> Sequence<T> / T.() -> String
+
+    val selectionStrategy: SelectionStrategyProperty
+    // methods: autoSelectMatches() / manual()
+
+    var maximumDisplayedItems: Int = 20
+    var inputDebounceMillis: Long = 50L
+    var renderDebounceMillis: Long = 50L
+
+    comboboxPanelReference() { }
+    comboboxInput() { }
+    comboboxLabel() { }
+    comboboxItems() {
+        // inherited by `PopUpPanel`
+        var placement: Placement
+        var strategy: Strategy
+        var flip: Boolean
+        var skidding: Int
+        var distance: int
+
+        val results: Flow<QueryResult.ItemList<T>>
+
+        // state.render {
+        // for each QueryResult.ItemList<T>.Item<T> {
+        comboboxItem(Item<T>) { }
+        // }
+        // }
+    }
+    comboboxValidationMessages() {
+        val msgs: Flow<List<ComponentValidationMessage>>
+    }
+}
+```
+
+### combobox
+
+Parameters: `classes`, `id`, `scope`, `tag`, `initialize`
+
+Default-Tag: `div`
+
+| Scope property          | Typ                            | Description                                                                                                                                                                                                                            |
+|:------------------------|:-------------------------------|:---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `items`                 | `Combobox<T>.ItemsHook`        | Mandatory `List<T>` or `Flow<List<T>>` of items to offer (invoke)                                                                                                                                                                      |
+| `itemFormat`            | `(T) -> String`                | Recommended formatting function used to display an item's String representation in the `comboboxInput`.                                                                                                                                |
+| `value`                 | `DatabindingProperty<T>`       | Mandatory (tow-way) data binding for a selected item.                                                                                                                                                                                  |
+| `filterBy`              | `FilterFunctionProperty`       | Recommended filter function to find matching items based on the query. Accepts either a String getter (`T.() -> String`) or a fully custom filter function (`(Sequence<T>, String) -> Sequence<T>`). _Mandatory for non-String items!_ |
+| `selectionStrategy`     | `SelectionStrategyProperty`    | Optional strategy to configure whether exact matches are automatically selected. Invoke either `autoSelectMatches()` or `manual()`                                                                                                     |
+| `maximumDisplayedItems` | `Int`                          | Maxmimum number of items to display in the dropdown. Defaults to 20                                                                                                                                                                    |
+| `inputDebounceMillis`   | `Long`                         | Time to wait and debounce before the filter function is invoked. Defaults to 50 milliseconds.                                                                                                                                          |
+| `renderDebounceMillis`  | `Long`                         | Time to wait and debounce before the filter results are rendered. Defaults to 50 milliseconds.                                                                                                                                         |
+| `openState`             | `DatabindingProperty<Boolean>` | Optional (two-way) data binding for opening and closing.                                                                                                                                                                               |
+| `opened`                | `Flow<Boolean>`                | Data stream that provides Boolean values related to the "open" state. Quite useless within a list box, as it is always `true`                                                                                                          |
+| `close`                 | `SimpleHandler<Unit>`          | Handler to close the list box from inside. Should not be used, as the component handles this internally.                                                                                                                               |
+| `open`                  | `SimpleHandler<Unit>`          | handler to open; does not make sense to use within a list box!                                                                                                                                                                         |
+| `toggle`                | `SimpleHandler<Unit>`          | handler for switching between open and closed; does not make sense to use within a list box.                                                                                                                                           |
+
+### comboboxPanelReference
+
+Available in the scope of: `combobox`
+
+Parameters: `classes`, `scope`, `tag`, `initialize`
+
+Default-Tag: `div`
+
+### comboboxInput
+
+Available in the scope of: `combobox`
+
+Parameters: `classes`, `scope`, `initialize`
+
+### comboboxLabel
+
+Available in the scope of: `combobox`
+
+Parameters: `classes`, `scope`, `tag`, `initialize`
+
+Default-Tag: `label`
+
+### listboxValidationMessages
+
+Available in the scope of: `combobox`
+
+Parameters: `classes`, `scope`, `tag`, `initialize`
+
+Default-Tag: `div`
+
+| Scope property | Typ                                      | Description                                                           |
+|:---------------|:-----------------------------------------|:----------------------------------------------------------------------|
+| `msgs`         | `Flow<List<ComponentValidationMessage>>` | provides a data stream with a list of ``ComponentValidationMessage``s |
+
+### comboboxItems
+
+Available in the scope of: `combobox`
+
+Parameters: `classes`, `scope`, `tag`, `initialize`
+
+Default-Tag: `div`
+
+| Scope property | Typ                             | Description                                                               |
+|:---------------|:--------------------------------|:--------------------------------------------------------------------------|
+| `results`      | `Flow<QueryResult.ItemList<T>>` | Emits the current list of items to be displayed in the selection dropdown |
+
+### comboboxItem
+
+Available in the scope of: `comboboxItems`
+
+Parameters: `item`, `classes`, `scope`, `tag`, `initialize`
+
+Default-Tag: `button`
+
+| Scope property | Typ             | Description                                                                                                                                  |
+|:---------------|:----------------|:---------------------------------------------------------------------------------------------------------------------------------------------|
+| `selected`     | `Flow<Boolean>` | This data stream provides the selection state of the managed option: `true` the option is selected, `false` if not.                          |
+| `active`       | `Flow<Boolean>` | This data stream indicates whether an item has focus: `true` the option has focus, `false` if not. Only one option can have focus at a time. |

--- a/www/src/pages/headless/combobox.md
+++ b/www/src/pages/headless/combobox.md
@@ -213,17 +213,18 @@ comboboxItems {
 }
 ```
 
-The exact placement of the dropdown is determined based on a number of conditions:
+::: info
+In practice, the [`comboboxInput`](#comboboxinput) element might be wrapped in additional elements that are considered to be a part
+of it. Since by default the dropdown is positioned relative to the [`comboboxInput`](#comboboxinput) element, the dropdown may
+appear out of place. In those cases, the outermost wrapping element can be created via the
+[`comboboxPanelReference`](#comboboxpanelreference) brick to fix the positioning.
+:::
+
+The anchor element of the dropdown is determined based on a number of conditions:
 
 1) If a [`comboboxInput`](#comboboxinput) is present, the panel is placed relative to it.
 2) If a [`comboboxPanelReference`](#comboboxpanelreference) is present, it is _used as the reference instead_.
 3) Otherwise, the dropdown references a minimal fallback input element.
-
-::: info
-In practice, the [`comboboxInput`](#comboboxinput) element might be wrapped in additional elements (e.g. for styling
-reasons) that may cause the dropdown to appear out of place. In those cases, the outer most wrapping element can be
-created via the [`comboboxPanelReference`](#comboboxpanelreference) brick to fix the positioning.
-:::
 
 ## Validation
 


### PR DESCRIPTION
This PR adds a headless `combobox` component inspired by the [HeadlessUI Combobox](https://headlessui.com/react/combobox).

The component can be created via the `combobox` factory.

For the full documentation visit the [online documentation](https://www.fritz2.dev/headless/combobox/).  
_During the review phase the documentation needs to be accessed through the locally running 11ty page, of course_.

API-sketch:

```kotlin
combobox<T> {
    val items: ItemsHook()
    // params: List<T> / Flow<List<T>>

    var itemFormat: (T) -> String

    val value: DatabindingProperty<T>

    var filterBy: FilterFunctionProperty
    // params: (Sequence<T>, String) -> Sequence<T> / T.() -> String

    val selectionStrategy: SelectionStrategyProperty
    // methods: autoSelectMatches() / manual()

    var maximumDisplayedItems: Int = 20
    var inputDebounceMillis: Long = 50L
    var renderDebounceMillis: Long = 50L

    comboboxInput() { }
    comboboxPanelReference() {
        // this brick is often used with a nested
        // comboboxInput() { }
    }
    comboboxLabel() { }
    comboboxItems() {
        // inherited by `PopUpPanel`
        var placement: Placement
        var strategy: Strategy
        var flip: Boolean
        var skidding: Int
        var distance: int

        val results: Flow<QueryResult.ItemList<T>>

        // state.render {
            // for each QueryResult.ItemList<T>.Item<T> {
                comboboxItem(Item<T>) { }
            // }
        // }
    }
    comboboxValidationMessages() {
        val msgs: Flow<List<ComponentValidationMessage>>
    }
}
```

---

Closes #674 
Closes #850