### PR TITLE
Headless disclosure: Fixes `aria-controls` attribute

### DIFF
--- a/headless-demo/src/jsMain/kotlin/dev/fritz2/headlessdemo/components/disclosure.kt
+++ b/headless-demo/src/jsMain/kotlin/dev/fritz2/headlessdemo/components/disclosure.kt
@@ -2,7 +2,6 @@ package dev.fritz2.headlessdemo.components
 
 import dev.fritz2.core.*
 import dev.fritz2.headless.components.disclosure
-import kotlinx.coroutines.flow.map
 
 fun RenderContext.disclosureDemo() {
     val faqs = listOf<Pair<String, RenderContext.() -> Unit>>(
@@ -86,7 +85,6 @@ fun RenderContext.disclosureDemo() {
                                 initialClasses = "hidden"
                             )
                             div("text-base text-gray-700") { answer(this) }
-                            disclosureCloseButton { +"Close" }
                         }
                     }
                 }

--- a/headless-demo/src/jsMain/kotlin/dev/fritz2/headlessdemo/components/disclosure.kt
+++ b/headless-demo/src/jsMain/kotlin/dev/fritz2/headlessdemo/components/disclosure.kt
@@ -86,6 +86,7 @@ fun RenderContext.disclosureDemo() {
                                 initialClasses = "hidden"
                             )
                             div("text-base text-gray-700") { answer(this) }
+                            disclosureCloseButton { +"Close" }
                         }
                     }
                 }

--- a/headless/src/jsMain/kotlin/dev/fritz2/headless/components/disclosure.kt
+++ b/headless/src/jsMain/kotlin/dev/fritz2/headless/components/disclosure.kt
@@ -5,9 +5,6 @@ import dev.fritz2.headless.foundation.Aria
 import dev.fritz2.headless.foundation.OpenClose
 import dev.fritz2.headless.foundation.TagFactory
 import dev.fritz2.headless.foundation.addComponentStructureInfo
-import kotlinx.coroutines.flow.filter
-import kotlinx.coroutines.flow.map
-import kotlinx.coroutines.flow.take
 import org.w3c.dom.HTMLButtonElement
 import org.w3c.dom.HTMLDivElement
 import org.w3c.dom.HTMLElement

--- a/headless/src/jsMain/kotlin/dev/fritz2/headless/components/disclosure.kt
+++ b/headless/src/jsMain/kotlin/dev/fritz2/headless/components/disclosure.kt
@@ -5,8 +5,9 @@ import dev.fritz2.headless.foundation.Aria
 import dev.fritz2.headless.foundation.OpenClose
 import dev.fritz2.headless.foundation.TagFactory
 import dev.fritz2.headless.foundation.addComponentStructureInfo
-import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.take
 import org.w3c.dom.HTMLButtonElement
 import org.w3c.dom.HTMLDivElement
 import org.w3c.dom.HTMLElement
@@ -24,9 +25,13 @@ class Disclosure<C : HTMLElement>(tag: Tag<C>, id: String?) : Tag<C> by tag, Ope
     val componentId: String by lazy { id ?: Id.next() }
 
     private var button: Tag<HTMLElement>? = null
+    private var closeButton: Tag<HTMLElement>? = null
+    private var panel: Tag<HTMLElement>? = null
 
     fun render() {
         attr("id", componentId)
+        button?.attr(Aria.controls, panel?.id)
+        closeButton?.attr(Aria.controls, panel?.id)
     }
 
     /**
@@ -67,10 +72,6 @@ class Disclosure<C : HTMLElement>(tag: Tag<C>, id: String?) : Tag<C> by tag, Ope
 
     inner class DisclosurePanel<CP : HTMLElement>(tag: Tag<CP>) : Tag<CP> by tag {
 
-        fun render() {
-            button?.attr(Aria.controls, id.whenever(opened))
-        }
-
         /**
          * Factory function to create a [disclosureCloseButton].
          *
@@ -87,7 +88,7 @@ class Disclosure<C : HTMLElement>(tag: Tag<C>, id: String?) : Tag<C> by tag, Ope
             return tag(this, classes, "$componentId-close-button", scope) {
                 content()
                 clicks handledBy close
-            }
+            }.also { closeButton = it }
         }
 
         /**
@@ -118,11 +119,8 @@ class Disclosure<C : HTMLElement>(tag: Tag<C>, id: String?) : Tag<C> by tag, Ope
         initialize: DisclosurePanel<CP>.() -> Unit
     ) {
         addComponentStructureInfo("disclosurePanel", this@disclosurePanel.scope, this)
-        tag(this, classes, "$componentId-panel", scope) {
-            DisclosurePanel(this).run {
-                initialize()
-                render()
-            }
+        panel = tag(this, classes, "$componentId-panel", scope) {
+            DisclosurePanel(this).run(initialize)
         }
     }
 


### PR DESCRIPTION
This PR fixes the disclosure's `aria-controls` attribute so that it's set on both the button and the close-button.

As a side effect, the attribute is now always present (instead of being rendered dynamically), reducing Flow overhead.

Closes #753 