### PR TITLE
Upgrades publishing pipeline `upload-artifact` task to v4

### DIFF
--- a/.github/workflows/libs.yml
+++ b/.github/workflows/libs.yml
@@ -28,14 +28,14 @@ jobs:
 
     - name: Archive test-results
       if: always()
-      uses: actions/upload-artifact@v1.0.0
+      uses: actions/upload-artifact@v4
       with:
         name: Test-Results
         path: core/build/reports/tests/allTests
 
     - name: Archive server log
       if: always()
-      uses: actions/upload-artifact@v1.0.0
+      uses: actions/upload-artifact@v4
       with:
         name: Server-Logs
         path: test-server/build/server.log


### PR DESCRIPTION
This fix is necessary due to the deprecation described in PR #881 / commit 446d339ae58f586ed6213707633d2b5713aafb0e and was previously overseen.