### PR TITLE
Resolves various minor issues

### DIFF
--- a/core/api/core.api
+++ b/core/api/core.api
@@ -6,6 +6,11 @@ public final class dev/fritz2/core/CollectionLensSetException : java/lang/Except
 	public fun <init> (Ljava/lang/String;)V
 }
 
+public final class dev/fritz2/core/FlowsKt {
+	public static final fun whenever (Ljava/lang/Object;Lkotlinx/coroutines/flow/Flow;)Lkotlinx/coroutines/flow/Flow;
+	public static final fun whenever (Lkotlinx/coroutines/flow/Flow;Lkotlinx/coroutines/flow/Flow;)Lkotlinx/coroutines/flow/Flow;
+}
+
 public final class dev/fritz2/core/Id {
 	public static final field INSTANCE Ldev/fritz2/core/Id;
 	public final fun next (I)Ljava/lang/String;

--- a/core/src/commonMain/kotlin/dev/fritz2/core/flows.kt
+++ b/core/src/commonMain/kotlin/dev/fritz2/core/flows.kt
@@ -1,0 +1,36 @@
+package dev.fritz2.core
+
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flatMapLatest
+import kotlinx.coroutines.flow.map
+
+/**
+ * This extension method takes a boolean [Flow] that controls the forwarding of the initial value:
+ * If it is `true` the value will be passed further on the result flow, if it is `false` a `null` will appear instead.
+ *
+ * This is especially useful for DOM node attributes, that should only appear if a certain condition is true.
+ *
+ * Take the `aria-controls` attribute as example. This should only be set, if there is an area active / visible
+ * to control. Within a dynamic component - like some disclosure based one - the latter is only shown, if a state-flow
+ * is `true`:
+ * ```kotlin
+ * // `open`: Flow<Boolean>
+ * button.attr("aria-controls", "panelId".whenever(open))
+ * //                                     ^^^^^^^^^^^^^^
+ * //                                     if open == true -> result flow provides "panelId" String
+ * //                                     if open == false -> result flow provides `null` -> whole attribute is removed
+ * ```
+ *
+ *  @param condition the boolean flow that decides whether to forward [T] or `null`
+ */
+fun <T> T.whenever(condition: Flow<Boolean>): Flow<T?> = condition.map { if (it) this else null }
+
+/**
+ * This extension method takes a boolean [Flow] that controls the forwarding of an initial flow:
+ * If it is `true` the current value will be passed further on the result flow, if it is `false` a `null` will appear
+ * instead.
+ *
+ * @see whenever
+ */
+fun <T> Flow<T>.whenever(condition: Flow<Boolean>): Flow<T?> =
+    condition.flatMapLatest { cond -> this.map { value -> if (cond) value else null } }

--- a/core/src/jsMain/kotlin/dev/fritz2/core/tags.kt
+++ b/core/src/jsMain/kotlin/dev/fritz2/core/tags.kt
@@ -291,37 +291,6 @@ interface Tag<out E : Element> : RenderContext, WithDomNode<E>, WithEvents<E> {
     }
 
     /**
-     * This extension method takes a boolean [Flow] that controls the forwarding of the initial value:
-     * If it is `true` the value will be passed further on the result flow, if it is `false` a `null` will appear instead.
-     *
-     * This is especially useful for DOM node attributes, that should only appear if a certain condition is true.
-     *
-     * Take the `aria-controls` attribute as example. This should only be set, if there is an area active / visible
-     * to control. Within a dynamic component - like some disclosure based one - the latter is only shown, if a state-flow
-     * is `true`:
-     * ```kotlin
-     * // `open`: Flow<Boolean>
-     * button.attr("aria-controls", "panelId".whenever(open))
-     * //                                     ^^^^^^^^^^^^^^
-     * //                                     if open == true -> result flow provides "panelId" String
-     * //                                     if open == false -> result flow provides `null` -> whole attribute is removed
-     * ```
-     *
-     *  @param condition the boolean flow that decides whether to forward [T] or `null`
-     */
-    fun <T> T.whenever(condition: Flow<Boolean>): Flow<T?> = condition.map { if (it) this else null }
-
-    /**
-     * This extension method takes a boolean [Flow] that controls the forwarding of an initial flow:
-     * If it is `true` the current value will be passed further on the result flow, if it is `false` a `null` will appear
-     * instead.
-     *
-     * @see whenever
-     */
-    fun <T> Flow<T>.whenever(condition: Flow<Boolean>): Flow<T?> =
-        condition.flatMapLatest { cond -> this.map { value -> if (cond) value else null } }
-
-    /**
      * provides [RenderContext] next to this [Tag] on the same DOM-level.
      */
     val annex: RenderContext

--- a/headless-demo/src/jsMain/kotlin/dev/fritz2/headlessdemo/components/disclosure.kt
+++ b/headless-demo/src/jsMain/kotlin/dev/fritz2/headlessdemo/components/disclosure.kt
@@ -2,7 +2,6 @@ package dev.fritz2.headlessdemo.components
 
 import dev.fritz2.core.*
 import dev.fritz2.headless.components.disclosure
-import kotlinx.coroutines.flow.map
 
 fun RenderContext.disclosureDemo() {
     val faqs = listOf<Pair<String, RenderContext.() -> Unit>>(

--- a/headless-demo/src/jsMain/kotlin/dev/fritz2/headlessdemo/components/disclosure.kt
+++ b/headless-demo/src/jsMain/kotlin/dev/fritz2/headlessdemo/components/disclosure.kt
@@ -75,10 +75,10 @@ fun RenderContext.disclosureDemo() {
                         ) {
                             transition(
                                 opened,
-                                enter = "transition duration-300 ease-out",
+                                enter = "transition duration-300 ease-in",
                                 enterStart = "opacity-0 scale-y-95",
                                 enterEnd = "opacity-100 scale-y-100",
-                                leave = "transition duration-300 ease-in",
+                                leave = "transition duration-300 ease-out",
                                 leaveStart = "opacity-100 scale-y-100",
                                 leaveEnd = "opacity-0 scale-y-95",
                                 hasLeftClasses = "hidden",

--- a/headless/src/jsMain/kotlin/dev/fritz2/headless/components/disclosure.kt
+++ b/headless/src/jsMain/kotlin/dev/fritz2/headless/components/disclosure.kt
@@ -5,8 +5,6 @@ import dev.fritz2.headless.foundation.Aria
 import dev.fritz2.headless.foundation.OpenClose
 import dev.fritz2.headless.foundation.TagFactory
 import dev.fritz2.headless.foundation.addComponentStructureInfo
-import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.map
 import org.w3c.dom.HTMLButtonElement
 import org.w3c.dom.HTMLDivElement
 import org.w3c.dom.HTMLElement
@@ -24,9 +22,13 @@ class Disclosure<C : HTMLElement>(tag: Tag<C>, id: String?) : Tag<C> by tag, Ope
     val componentId: String by lazy { id ?: Id.next() }
 
     private var button: Tag<HTMLElement>? = null
+    private var closeButton: Tag<HTMLElement>? = null
+    private var panel: Tag<HTMLElement>? = null
 
     fun render() {
         attr("id", componentId)
+        button?.attr(Aria.controls, panel?.id)
+        closeButton?.attr(Aria.controls, panel?.id)
     }
 
     /**
@@ -67,10 +69,6 @@ class Disclosure<C : HTMLElement>(tag: Tag<C>, id: String?) : Tag<C> by tag, Ope
 
     inner class DisclosurePanel<CP : HTMLElement>(tag: Tag<CP>) : Tag<CP> by tag {
 
-        fun render() {
-            button?.attr(Aria.controls, id.whenever(opened))
-        }
-
         /**
          * Factory function to create a [disclosureCloseButton].
          *
@@ -87,7 +85,7 @@ class Disclosure<C : HTMLElement>(tag: Tag<C>, id: String?) : Tag<C> by tag, Ope
             return tag(this, classes, "$componentId-close-button", scope) {
                 content()
                 clicks handledBy close
-            }
+            }.also { closeButton = it }
         }
 
         /**
@@ -118,11 +116,8 @@ class Disclosure<C : HTMLElement>(tag: Tag<C>, id: String?) : Tag<C> by tag, Ope
         initialize: DisclosurePanel<CP>.() -> Unit
     ) {
         addComponentStructureInfo("disclosurePanel", this@disclosurePanel.scope, this)
-        tag(this, classes, "$componentId-panel", scope) {
-            DisclosurePanel(this).run {
-                initialize()
-                render()
-            }
+        panel = tag(this, classes, "$componentId-panel", scope) {
+            DisclosurePanel(this).run(initialize)
         }
     }
 


### PR DESCRIPTION
This PR resolves various minor issues:

#### Fixes `aria-controls` attribute in headless disclusre
Closes #753

#### Fixes the headless disclosure's panel animation
Closes #867

#### Moves `whenever` function out of `Tag` interface
As the extension functions remain in the same package, this change should practically always be non be api-breaking.

Closes #873 