### PR TITLE
Implements various smaller combobox improvements

### DIFF
--- a/headless-demo/src/commonMain/kotlin/dev/fritz2/headlessdemo/components/ComboboxDemoConfig.kt
+++ b/headless-demo/src/commonMain/kotlin/dev/fritz2/headlessdemo/components/ComboboxDemoConfig.kt
@@ -1,0 +1,12 @@
+package dev.fritz2.headlessdemo.components
+
+import dev.fritz2.core.Lenses
+
+@Lenses
+data class ComboboxDemoConfig(
+    val readOnly: Boolean = false,
+    val autoSelectMatches: Boolean = false,
+    val openDropdownLazily: Boolean = false,
+) {
+    companion object
+}

--- a/headless/src/jsMain/kotlin/dev/fritz2/headless/components/combobox.kt
+++ b/headless/src/jsMain/kotlin/dev/fritz2/headless/components/combobox.kt
@@ -318,10 +318,11 @@ class Combobox<E : HTMLElement, T>(tag: Tag<E>, id: String?) : Tag<E> by tag, Op
      * match in the combobox's input or not.
      *
      * The following strategies can be configured:
-     * - [autoSelectMatch()][SelectionStrategyProperty.autoSelectMatch] (__default__): Automatically select elements if
+     * - [autoSelectMatch()][SelectionStrategyProperty.autoSelectMatch]: Automatically select elements if
      *   they are an exact match
-     * - [manual()][SelectionStrategyProperty.manual]: Render exact matches as part of the regular dropdown for the user
-     *   to manually select. If no selection is made, the input is reset to the last selected value.
+     * - [manual()][SelectionStrategyProperty.manual] (__default__): Render exact matches as part of the regular
+     *   dropdown for the user to manually select. If no selection is made, the input is reset to the last selected
+     *   value.
      *
      * Example:
      * ```kotlin

--- a/headless/src/jsMain/kotlin/dev/fritz2/headless/components/combobox.kt
+++ b/headless/src/jsMain/kotlin/dev/fritz2/headless/components/combobox.kt
@@ -488,9 +488,10 @@ class Combobox<E : HTMLElement, T>(tag: Tag<E>, id: String?) : Tag<E> by tag, Op
                 // All subsequent states are computed based on the changing internal state:
                 data
                     .drop(1)
-                    .filter { it.opened }
+                    .map { it.items to it.query }
+                    .distinctUntilChanged()
                     .debounce(inputDebounceMillis)
-                    .mapLatest { state -> computeQueryResult(state.items, state.query) }
+                    .mapLatest { (items, query) -> computeQueryResult(items, query) }
                     .debounce(renderDebounceMillis)
             )
 

--- a/www/src/pages/headless/combobox.md
+++ b/www/src/pages/headless/combobox.md
@@ -217,6 +217,27 @@ combobox {
 }
 ```
 
+## Auto-Selecting Items
+
+By default, the user needs to manually select an item for it to be accepted as the combo box's value.
+It can, however, also be configured to automatically select matching items for a query via the `selectionStrategy`
+property.
+
+The following modes are offered:
+
+| Configuration method  | Description                                 |
+|-----------------------|---------------------------------------------|
+| `autoSelectMatches()` | Matching items are automatically selected   |
+| `manual()`            | Matching items need to be selected manually |
+
+```kotlin
+combobox {
+    selectionStrategy.autoSelectMatches()
+    // OR
+    selectionStrategy.manual()
+}
+```
+
 ## Transitions
 
 Showing and hiding the selection list can be easily animated with the help of `transition`:

--- a/www/src/pages/headless/combobox.md
+++ b/www/src/pages/headless/combobox.md
@@ -174,7 +174,7 @@ comboboxItems {
 }
 ```
 
-## Add a Label
+## Adding a Label
 
 The combo box can be supplemented with a label using `comboboxLabel`, e.g. for use in forms or for a screen reader:
 
@@ -192,6 +192,30 @@ Combobox is an [`OpenClose` component](#closable-content---openclose). There are
 like `opened` available in its scope to control the open state of the combo box based on state changes.
 
 Most of the time, the open state managed by the component itself should be enough for all use cases, though.
+
+### Automatic Opening Behavior
+
+The combo box's dropdown can be configured to automatically open based on different events:
+
+| Configuration method | Description                                                                      |
+|----------------------|----------------------------------------------------------------------------------|
+| `lazily()`           | The dropdown is opened when the user starts typing.                              |
+| `eagerly()`          | The dropdown is opened as soon as the user focuses the combo box's input element |
+
+The configuration is done via the `openDropdown` hook available in the configuration scope.
+
+Both strategies are good choices and mostly depend on subjective preferences. By __default__, the dropdown opens 
+itself _eagerly_.
+
+Example:
+
+```kotlin
+combobox {
+    openDropdown.lazily()
+    // OR
+    openDropdown.eagerly()
+}
+```
 
 ## Transitions
 
@@ -335,6 +359,9 @@ combobox<T> {
     var filterBy: FilterFunctionProperty
     // params: (Sequence<T>, String) -> Sequence<T> / T.() -> String
 
+    val openDropdown: DropdownOpeningHook
+    // methods: lazily() / eagerly()
+
     val selectionStrategy: SelectionStrategyProperty
     // methods: autoSelectMatches() / manual()
 
@@ -376,12 +403,13 @@ Parameters: `classes`, `id`, `scope`, `tag`, `initialize`
 
 Default-Tag: `div`
 
-| Scope property          | Typ                            | Description                                                                                                                                                                                                                            |
+| Scope property          | Type                           | Description                                                                                                                                                                                                                            |
 |:------------------------|:-------------------------------|:---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | `items`                 | `Combobox<T>.ItemsHook`        | Mandatory `List<T>` or `Flow<List<T>>` of items to offer (invoke)                                                                                                                                                                      |
 | `itemFormat`            | `(T) -> String`                | Recommended formatting function used to display an item's String representation in the `comboboxInput`.                                                                                                                                |
 | `value`                 | `DatabindingProperty<T>`       | Mandatory (tow-way) data binding for a selected item.                                                                                                                                                                                  |
 | `filterBy`              | `FilterFunctionProperty`       | Recommended filter function to find matching items based on the query. Accepts either a String getter (`T.() -> String`) or a fully custom filter function (`(Sequence<T>, String) -> Sequence<T>`). _Mandatory for non-String items!_ |
+| `openDropdown`          | `DropdownOpeningHook`          | Optional strategy to configure when the combo box's dropdown should open (lazily or eagerly)                                                                                                                                           |                     
 | `selectionStrategy`     | `SelectionStrategyProperty`    | Optional strategy to configure whether exact matches are automatically selected. Invoke either `autoSelectMatches()` or `manual()`                                                                                                     |
 | `maximumDisplayedItems` | `Int`                          | Maxmimum number of items to display in the dropdown. Defaults to 20                                                                                                                                                                    |
 | `inputDebounceMillis`   | `Long`                         | Time to wait and debounce before the filter function is invoked. Defaults to 50 milliseconds.                                                                                                                                          |


### PR DESCRIPTION
This PR implements various smaller improvements for the headless combobox.
Check out the linked individual commits below to see the changes in smaller, more concise diffs:

- [Adds a hook to control whether the combobox's dropdown opens lazily or eagerly](https://github.com/jwstegemann/fritz2/commit/b9c255c421f3b371fcb116a30665b8995eb3f568)
    - i.e.: When the user starts typing vs as soon as the user focuses the input
- [Reduces flickering when re-opening a combobox](https://github.com/jwstegemann/fritz2/commit/67eff8eb0b0dc625ae79401135d36850759c9c63)
- [Adds missing documentation regarding the combobox's selection mode](https://github.com/jwstegemann/fritz2/pull/891/commits/df743f50945a48b23335520e2d612838e545066c)