### PR TITLE
update footer year from 2022 to 2024

### DIFF
--- a/www/src/index.njk
+++ b/www/src/index.njk
@@ -630,7 +630,7 @@ layout: layouts/page.njk
                 </div>
                 <div class="mt-12 border-t border-gray-200 py-8">
                     <p class="text-base text-gray-400 xl:text-center">
-                        &copy; 2022 fritz2 dev team
+                        &copy; 2024 fritz2 dev team
                     </p>
                 </div>
             </div>


### PR DESCRIPTION
### PR Description

This pull request updates the footer to reflect the current year. The date has been modified from **2022** to **2024** to ensure the footer is up to date.

This is a simple change to keep the site’s information current.  review and let me know if any further adjustments are needed. 
