### PR TITLE
Fixes some bug with modals and reactive renderings

### DIFF
--- a/headless-demo/src/jsMain/kotlin/dev/fritz2/headlessdemo/app.kt
+++ b/headless-demo/src/jsMain/kotlin/dev/fritz2/headlessdemo/app.kt
@@ -137,12 +137,14 @@ fun main() {
     val router = routerOf("")
 
     render {
-        router.data.render { route ->
-            div("p-4", scope = { set(SHOW_COMPONENT_STRUCTURE, true) }) {
-                (pages[route]?.content ?: RenderContext::overview)()
+        main(scope = { set(SHOW_COMPONENT_STRUCTURE, true) }) {
+            router.data.render { route ->
+                div("p-4") {
+                    (pages[route]?.content ?: RenderContext::overview)()
+                }
             }
-        }
 
-        portalRoot()
+            portalRoot()
+        }
     }
 }


### PR DESCRIPTION
The combination of a trigger inside some reactive scope and a headless modal would lead to corrupt application state before this fix.

Due to the natur of portalling, portalled portions of components are not automatically coupled to the reactive rendering of fritz2's mountpoint-concept. The portal-root container resides out of its scope.

That is why we forward the scope to each portal-container and could use the latter to register some lifecycle-hooks in order to remove obsolete portals based upon the re-rendering happening inside fritz2's main `RenderContext`.

As modals do not have any relation to its trigger(s) and do not reside inside the same mount-point, they were not coupled to the trigger-flow and its cancellation.

This is now fixed!

If the trigger is removed due to some reactive rendering, also the triggered modal will be removed. This holds also for the usage from within some `Router`-based reactive render-context! So if one manipulates the hash-routing segment, the modal will also be closed now.

Notice: Even though toasts are rendered in a similar fashion like modals, the former are handled totally agnostic from any reactive coupled trigger! As the triggering is decoupled from the destruction of a toast, the described bug did not affect toasts!

- fixes #906