### PR TITLE
Fixes the combobox deleting input when the rendering is slow

### DIFF
--- a/headless-demo/tests/components/combobox.spec.ts
+++ b/headless-demo/tests/components/combobox.spec.ts
@@ -412,10 +412,11 @@ test("Keyboard selection in lazy mode does nothing when the dropdown is closed",
     await page.locator("#checkbox-enable-lazy-opening").check();
 
     await input.click();
-
     await input.pressSequentially("oma");
+    await expect(items).toBeVisible();
 
     await page.mouse.click(0, 0);
+    await expect(items).toBeHidden();
 
     await input.click();
     await expect(input).toBeFocused();


### PR DESCRIPTION
This PR fixes a bug in the headless combobox component where parts of the input are deleted/reset when the user types fast and the rendering is slow.

Additionally, a few compiler warnings introduced with the Kotlin 2.0 upgrade are resolved.