### PR TITLE
Fixes some potential bug with mapping lenses

### DIFF
--- a/core/src/jsMain/kotlin/dev/fritz2/core/tags.kt
+++ b/core/src/jsMain/kotlin/dev/fritz2/core/tags.kt
@@ -361,7 +361,10 @@ open class HtmlTag<out E : Element>(
     }
 
     override fun className(value: Flow<String>, initial: String) {
-        classesStateFlow.value += value.stateIn(MainScope() + job, SharingStarted.Eagerly, initial)
+        classesStateFlow.value += value
+            .catch { printErrorIgnoreLensException(it) }
+            .stateIn(MainScope() + job, SharingStarted.Eagerly, initial)
+
         // this ensures that the set state is applied *immediately* without `Flow`-"delay".
         // in this case, the `initial` value gets applied as "promised".
         attr("class", buildClasses())


### PR DESCRIPTION
The pimped `className`-function (introduced by PR #823 in `1.0-RC15` release) did not apply exception handling. That could lead to errors, if there is code that removes some element:

The independent reactive renderings could simply lead to corner cases, where a lens will try to access its mapped object (e.g. by `mapByElement`) that is no longer part of the stored model. So a
`CollectionLensGetException` will be thrown and must be handled by the consuming code.

This PR adds such exception handling code and a unit test to verify the new, correct behaviour.