### PR TITLE
Combobox: Only accept distinct values via data-binding

### DIFF
--- a/headless/src/jsMain/kotlin/dev/fritz2/headless/components/combobox.kt
+++ b/headless/src/jsMain/kotlin/dev/fritz2/headless/components/combobox.kt
@@ -281,7 +281,10 @@ class Combobox<E : HTMLElement, T>(tag: Tag<E>, id: String?) : Tag<E> by tag, Op
          * > be used with caution here.
          */
         private fun buildItemListResult(query: String, itemSequence: Sequence<T>): ItemList<T> {
-            val (resultList, truncated) = itemSequence.mapIndexed(::Item).toListTruncating(maximumDisplayedItems)
+            val (resultList, truncated) = itemSequence
+                .mapIndexed(::Item)
+                .toListTruncating(maximumDisplayedItems)
+
             return ItemList(
                 query,
                 resultList,
@@ -401,7 +404,8 @@ class Combobox<E : HTMLElement, T>(tag: Tag<E>, id: String?) : Tag<E> by tag, Op
     private data class InternalState<T>(
         val items: List<T> = emptyList(),
         val query: String = "",
-        val opened: Boolean = false
+        val opened: Boolean = false,
+        val lastSelection: T? = null,
     )
 
 
@@ -484,11 +488,24 @@ class Combobox<E : HTMLElement, T>(tag: Tag<E>, id: String?) : Tag<E> by tag, Op
             current.copy(opened = false)
         }
 
+
+        private fun InternalState<T>.select(selection: T?): InternalState<T> =
+            copy(query = "", opened = false, lastSelection = selection)
+
         val select: EmittingHandler<T?, T?> = handleAndEmit { current, selection ->
-            current.copy(query = "", opened = false).also {
+            current.select(selection).also {
                 emit(selection)
             }
         }
+
+        val selectIfDifferent: EmittingHandler<T?, T?> = handleAndEmit { current, selection ->
+            if (selection != current.lastSelection) {
+                emit(selection)
+                current.select(selection)
+            } else current
+        }
+
+        val selections: Flow<T?> = merge(select, selectIfDifferent)
 
 
         private fun computeQueryResult(items: List<T>, query: String): QueryResult<T> =
@@ -620,8 +637,8 @@ class Combobox<E : HTMLElement, T>(tag: Tag<E>, id: String?) : Tag<E> by tag, Op
         fun render() {
             value(
                 merge(
-                    internalState.select.map { format(it) },
-                    value.data.flatMapLatest { value ->
+                    internalState.selections.map { format(it) },
+                    internalState.data.map { it.lastSelection }.distinctUntilChanged().flatMapLatest { value ->
                         internalState.resetQuery.transform {
                             // Before the input's value can be reset to the previous one we need to set it to
                             // the current typed value. This is needed because the underlying `mountSimple` function
@@ -905,8 +922,8 @@ class Combobox<E : HTMLElement, T>(tag: Tag<E>, id: String?) : Tag<E> by tag, Op
         hook(items)
 
 
-        value.data handledBy internalState.select
-        value.handler?.invoke(this, internalState.select)
+        value.data handledBy internalState.selectIfDifferent
+        value.handler?.invoke(this, internalState.selections)
 
         opened handledBy internalState.setOpened
         openState.handler?.invoke(this, internalState.data.map { it.opened }.distinctUntilChanged())


### PR DESCRIPTION
This PR adjusts the combobox's data-binding to only accept values that are different from the previous selection.

In most cases, this should make no difference. There are corner cases, however, where the value is quickly updated multiple times in a row, causing the internals to run into race-conditions.

Fixes #912 