### PR TITLE
Standardizes the combobox selectionStrategy name to autoSelectMatch

### DIFF
--- a/headless-demo/src/commonMain/kotlin/dev/fritz2/headlessdemo/components/ComboboxDemoConfig.kt
+++ b/headless-demo/src/commonMain/kotlin/dev/fritz2/headlessdemo/components/ComboboxDemoConfig.kt
@@ -5,7 +5,7 @@ import dev.fritz2.core.Lenses
 @Lenses
 data class ComboboxDemoConfig(
     val readOnly: Boolean = false,
-    val autoSelectMatches: Boolean = false,
+    val autoSelectMatch: Boolean = false,
     val openDropdownLazily: Boolean = false,
 ) {
     companion object

--- a/headless-demo/src/jsMain/kotlin/dev/fritz2/headlessdemo/components/combobox.kt
+++ b/headless-demo/src/jsMain/kotlin/dev/fritz2/headlessdemo/components/combobox.kt
@@ -12,22 +12,22 @@ fun RenderContext.comboboxDemo() {
 
     val configurationStore = storeOf(ComboboxDemoConfig())
     val readOnlyStore = configurationStore.map(ComboboxDemoConfig.readOnly())
-    val autoSelectMatchesStore = configurationStore.map(ComboboxDemoConfig.autoSelectMatches())
+    val autoSelectMatchStore = configurationStore.map(ComboboxDemoConfig.autoSelectMatch())
     val openDropdownLazilyStore = configurationStore.map(ComboboxDemoConfig.openDropdownLazily())
 
     div("max-w-96 flex flex-col gap-4") {
         combine(
-            autoSelectMatchesStore.data,
+            autoSelectMatchStore.data,
             openDropdownLazilyStore.data,
             ::Pair
-        ).render { (autoSelectMatches, openDropdownLazily) ->
+        ).render { (autoSelectMatch, openDropdownLazily) ->
             combobox<Country>(id = "countries") {
                 items(COUNTRY_LIST)
                 itemFormat = Country::name
                 value(selectionStore)
                 filterBy(Country::name)
 
-                if (autoSelectMatches) selectionStrategy.autoSelectMatch()
+                if (autoSelectMatch) selectionStrategy.autoSelectMatch()
                 else selectionStrategy.manual()
 
                 if (openDropdownLazily) openDropdown.lazily()
@@ -150,7 +150,7 @@ fun RenderContext.comboboxDemo() {
         }
 
         checkbox("Read-only", readOnlyStore, "checkbox-enable-readonly")
-        checkbox("Auto-select exact matches (try 'oman')", autoSelectMatchesStore, "checkbox-enable-autoselect")
+        checkbox("Auto-select exact matches (try 'oman')", autoSelectMatchStore, "checkbox-enable-autoselect")
         checkbox("Open dropdown lazily", openDropdownLazilyStore, "checkbox-enable-lazy-opening")
 
         result {

--- a/headless/src/jsMain/kotlin/dev/fritz2/headless/components/combobox.kt
+++ b/headless/src/jsMain/kotlin/dev/fritz2/headless/components/combobox.kt
@@ -334,7 +334,7 @@ class Combobox<E : HTMLElement, T>(tag: Tag<E>, id: String?) : Tag<E> by tag, Op
      * Example:
      * ```kotlin
      * combobox {
-     *     selectionStrategy.autoSelectMatches()
+     *     selectionStrategy.autoSelectMatch()
      *     // OR
      *     selectionStrategy.manual()
      * }
@@ -960,7 +960,7 @@ class Combobox<E : HTMLElement, T>(tag: Tag<E>, id: String?) : Tag<E> by tag, Op
  *     // methods: lazily() / eagerly()
  *
  *     val selectionStrategy: SelectionStrategyProperty
- *     // methods: autoSelectMatches() / manual()
+ *     // methods: autoSelectMatch() / manual()
  *
  *     var maximumDisplayedItems: Int = 20
  *     var inputDebounceMillis: Long = 50L
@@ -1032,7 +1032,7 @@ fun <E : HTMLElement, T> RenderContext.combobox(
  *     // methods: lazily() / eagerly()
  *
  *     val selectionStrategy: SelectionStrategyProperty
- *     // methods: autoSelectMatches() / manual()
+ *     // methods: autoSelectMatch() / manual()
  *
  *     var maximumDisplayedItems: Int = 20
  *     var inputDebounceMillis: Long = 50L

--- a/www/src/pages/headless/combobox.md
+++ b/www/src/pages/headless/combobox.md
@@ -225,14 +225,14 @@ property.
 
 The following modes are offered:
 
-| Configuration method  | Description                                 |
-|-----------------------|---------------------------------------------|
-| `autoSelectMatches()` | Matching items are automatically selected   |
-| `manual()`            | Matching items need to be selected manually |
+| Configuration method | Description                                 |
+|----------------------|---------------------------------------------|
+| `autoSelectMatch()`  | Matching items are automatically selected   |
+| `manual()`           | Matching items need to be selected manually |
 
 ```kotlin
 combobox {
-    selectionStrategy.autoSelectMatches()
+    selectionStrategy.autoSelectMatch()
     // OR
     selectionStrategy.manual()
 }
@@ -384,7 +384,7 @@ combobox<T> {
     // methods: lazily() / eagerly()
 
     val selectionStrategy: SelectionStrategyProperty
-    // methods: autoSelectMatches() / manual()
+    // methods: autoSelectMatch() / manual()
 
     var maximumDisplayedItems: Int = 20
     var inputDebounceMillis: Long = 50L
@@ -431,7 +431,7 @@ Default-Tag: `div`
 | `value`                 | `DatabindingProperty<T>`       | Mandatory (tow-way) data binding for a selected item.                                                                                                                                                                                  |
 | `filterBy`              | `FilterFunctionProperty`       | Recommended filter function to find matching items based on the query. Accepts either a String getter (`T.() -> String`) or a fully custom filter function (`(Sequence<T>, String) -> Sequence<T>`). _Mandatory for non-String items!_ |
 | `openDropdown`          | `DropdownOpeningHook`          | Optional strategy to configure when the combo box's dropdown should open (lazily or eagerly)                                                                                                                                           |                     
-| `selectionStrategy`     | `SelectionStrategyProperty`    | Optional strategy to configure whether exact matches are automatically selected. Invoke either `autoSelectMatches()` or `manual()`                                                                                                     |
+| `selectionStrategy`     | `SelectionStrategyProperty`    | Optional strategy to configure whether exact matches are automatically selected. Invoke either `autoSelectMatch()` or `manual()`                                                                                                       |
 | `maximumDisplayedItems` | `Int`                          | Maxmimum number of items to display in the dropdown. Defaults to 20                                                                                                                                                                    |
 | `inputDebounceMillis`   | `Long`                         | Time to wait and debounce before the filter function is invoked. Defaults to 50 milliseconds.                                                                                                                                          |
 | `renderDebounceMillis`  | `Long`                         | Time to wait and debounce before the filter results are rendered. Defaults to 50 milliseconds.                                                                                                                                         |


### PR DESCRIPTION
This PR unifies the naming of one of the `selectionStrategy` options in the `combobox` to` autoSelectMatch`. I noticed that the Fritz2 documentation referred to this strategy as `autoSelectMatches`, which is incorrect. To prevent future inconsistencies, I decided to standardize the terminology across the entire project.