### PR TITLE
Allows event propagation of headless component toggles, fixes headless popover demo

### DIFF
--- a/headless-demo/src/jsMain/kotlin/dev/fritz2/headlessdemo/components/popOver.kt
+++ b/headless-demo/src/jsMain/kotlin/dev/fritz2/headlessdemo/components/popOver.kt
@@ -39,7 +39,12 @@ fun RenderContext.popOverDemo() {
             className(opened.map { if (it) "" else "text-opacity-90" })
             opened.map { if (it) "Close Popover" else "Open Popover" }.renderText()
             opened.render { isOpen ->
-                icon("w-5 h-5 ml-2 -mr-1", content = if (isOpen) HeroIcons.chevron_up else HeroIcons.chevron_down)
+                icon(
+                    "w-5 h-5 ml-2 -mr-1",
+                    content = if (isOpen) HeroIcons.chevron_up else HeroIcons.chevron_down
+                ).run {
+                    clicks { stopPropagation() } handledBy toggle
+                }
             }
         }
 

--- a/headless/src/jsMain/kotlin/dev/fritz2/headless/components/disclosure.kt
+++ b/headless/src/jsMain/kotlin/dev/fritz2/headless/components/disclosure.kt
@@ -49,7 +49,7 @@ class Disclosure<C : HTMLElement>(tag: Tag<C>, id: String?) : Tag<C> by tag, Ope
             content()
             attr(Aria.expanded, opened.asString())
             attr("tabindex", "0")
-            activations { preventDefault(); stopPropagation() } handledBy toggle
+            activations() handledBy toggle
         }.also { button = it }
     }
 

--- a/headless/src/jsMain/kotlin/dev/fritz2/headless/components/listbox.kt
+++ b/headless/src/jsMain/kotlin/dev/fritz2/headless/components/listbox.kt
@@ -76,7 +76,7 @@ class Listbox<T, C : HTMLElement>(tag: Tag<C>, id: String?) : Tag<C> by tag, Ope
             if (!openState.isSet) openState(storeOf(false))
             content()
             attr(Aria.expanded, opened.asString())
-            activations { preventDefault(); stopPropagation() } handledBy toggle
+            activations() handledBy toggle
         }.also { button = it }
     }
 

--- a/headless/src/jsMain/kotlin/dev/fritz2/headless/components/menu.kt
+++ b/headless/src/jsMain/kotlin/dev/fritz2/headless/components/menu.kt
@@ -71,7 +71,7 @@ class Menu<C : HTMLElement>(tag: Tag<C>, id: String?) : Tag<C> by tag, OpenClose
             if (!openState.isSet) openState(storeOf(false))
             content()
             attr(Aria.expanded, opened.asString())
-            activations { preventDefault(); stopPropagation() } handledBy toggle
+            activations() handledBy toggle
         }.also { button = it }
     }
 

--- a/headless/src/jsMain/kotlin/dev/fritz2/headless/foundation/OpenClose.kt
+++ b/headless/src/jsMain/kotlin/dev/fritz2/headless/foundation/OpenClose.kt
@@ -40,23 +40,21 @@ abstract class OpenClose : WithJob {
     }
 
     /**
-     * Combines all events relevant for toggling an element that implements the [OpenClose] behavior. By default, these
-     * events are clicking the left mouse button or pressing the Enter or Space keys.
+     * Combines all events relevant for toggling an element that implements the [OpenClose] behavior.
      *
-     * @param init pass an optional lambda to execute event handling manipulations, like calling
-     * `stopPropagation` or alike
+     * Events included in the returned [Flow] are:
+     * - clicks on the wrapped element
+     * - pressing the Enter or Space keys on the wrapped element
      */
-    internal fun Tag<*>.activations(init: Event.() -> Unit = {}): Flow<Event> =
+    internal fun Tag<*>.activations(): Flow<Event> =
         // If the wrapped element is a button, click events are already triggered by the Enter and Space keys.
         if (domNode is HTMLButtonElement) {
-            clicks { init() }
+            clicks
         } else {
             merge(
-                clicks { init() },
+                clicks,
                 keydownsIf {
-                    (shortcutOf(this) in setOf(Keys.Space, Keys.Enter)).also {
-                        if(it) init()
-                    }
+                    shortcutOf(this) in setOf(Keys.Space, Keys.Enter)
                 })
         }
 


### PR DESCRIPTION
This PR allows event propagation of headless component toggles.

In some headless component toggles, events were explicitly filtered by calling `stopPropagation()` and `preventDefault()` on their click events.

This caused issues when multiple overlay-components are open at the same time as overlays would not close automatically when another toggle has been clicked.

Removing the above calls enables the implementor to choose the right event handling strategy for their component but also fixes the described issues.

See https://github.com/jwstegemann/fritz2/commit/1358563c8ef5c90a15a6dd070677bb4243eb32c5

---

Additionally, a bug in the headless popOver demo is fixed where the dropdown would immediately be closed when the toggle's button was clicked.

See https://github.com/jwstegemann/fritz2/commit/40874749c2a393aa0d521cd28c4f4f2c737be2d2

---

Closes #897 