### PR TITLE
Fix setting an initial value for the ComboBox

### DIFF
--- a/headless/src/jsMain/kotlin/dev/fritz2/headless/components/Combobox.kt
+++ b/headless/src/jsMain/kotlin/dev/fritz2/headless/components/Combobox.kt
@@ -638,7 +638,7 @@ class Combobox<E : HTMLElement, T>(tag: Tag<E>, id: String?) : Tag<E> by tag, Op
             value(
                 merge(
                     internalState.selections.map { format(it) },
-                    internalState.data.map { it.lastSelection }.distinctUntilChanged().flatMapLatest { value ->
+                    internalState.data.drop(1).map { it.lastSelection }.distinctUntilChanged().flatMapLatest { value ->
                         internalState.resetQuery.transform {
                             // Before the input's value can be reset to the previous one we need to set it to
                             // the current typed value. This is needed because the underlying `mountSimple` function


### PR DESCRIPTION
Currently the ComboBox dismissed an initial value. This is now fixed.

Remark: There is no test yet, that would test this behaviour. We need to extend our demo app to make this possible. We need another, dedicated issue for that.