### PR TITLE
Removes obsolete TodoMVC examples, fixes broken GitHub links

### DIFF
--- a/examples/gettingstarted/src/jsMain/resources/index.html
+++ b/examples/gettingstarted/src/jsMain/resources/index.html
@@ -39,9 +39,9 @@
         "ref": "master",
         "embed": [
             {
-                "path": "/examples/gettingstarted/src/jsMain/kotlin/dev/fritz2/examples/gettingstarted/gettingstarted.kt",
+                "path": "/examples/gettingstarted/src/jsMain/kotlin/dev/fritz2/examples/gettingstarted/GettingStarted.kt",
                 "type": "kotlin",
-                "label": "gettingstarted.kt"
+                "label": "GettingStarted.kt"
             },
             {
                 "path": "/examples/gettingstarted/src/jsMain/resources/index.html",

--- a/examples/masterdetail/src/jsMain/resources/index.html
+++ b/examples/masterdetail/src/jsMain/resources/index.html
@@ -46,14 +46,14 @@
         "ref": "master",
         "embed": [
             {
-                "path": "/examples/masterdetail/src/jsMain/kotlin/dev/fritz2/examples/masterdetail/masterdetail.kt",
+                "path": "/examples/masterdetail/src/jsMain/kotlin/dev/fritz2/examples/masterdetail/MasterDetail.kt",
                 "type": "kotlin",
-                "label": "masterdetail.kt"
+                "label": "MasterDetail.kt"
             },
             {
-                "path": "/examples/masterdetail/src/commonMain/kotlin/dev/fritz2/examples/masterdetail/model.kt",
+                "path": "/examples/masterdetail/src/commonMain/kotlin/dev/fritz2/examples/masterdetail/Model.kt",
                 "type": "kotlin",
-                "label": "model.kt"
+                "label": "Model.kt"
             },
             {
                 "path": "/examples/masterdetail/src/jsMain/resources/index.html",

--- a/examples/nestedmodel/src/jsMain/resources/index.html
+++ b/examples/nestedmodel/src/jsMain/resources/index.html
@@ -43,14 +43,14 @@
         "ref": "master",
         "embed": [
             {
-                "path": "/examples/nestedmodel/src/jsMain/kotlin/dev/fritz2/examples/nestedmodel/nestedmodel.kt",
+                "path": "/examples/nestedmodel/src/jsMain/kotlin/dev/fritz2/examples/nestedmodel/NestedModel.kt",
                 "type": "kotlin",
-                "label": "nestedmodel.kt"
+                "label": "NestedModel.kt"
             },
             {
-                "path": "/examples/nestedmodel/src/commonMain/kotlin/dev/fritz2/examples/nestedmodel/model.kt",
+                "path": "/examples/nestedmodel/src/commonMain/kotlin/dev/fritz2/examples/nestedmodel/Model.kt",
                 "type": "kotlin",
-                "label": "model.kt"
+                "label": "Model.kt"
             },
             {
                 "path": "/examples/nestedmodel/src/jsMain/resources/index.html",

--- a/examples/performance/src/jsMain/resources/index.html
+++ b/examples/performance/src/jsMain/resources/index.html
@@ -44,9 +44,9 @@
         "ref": "master",
         "embed": [
             {
-                "path": "/examples/performance/src/jsMain/kotlin/dev/fritz2/examples/performance/performance.kt",
+                "path": "/examples/performance/src/jsMain/kotlin/dev/fritz2/examples/performance/Performance.kt",
                 "type": "kotlin",
-                "label": "performance.kt"
+                "label": "Performance.kt"
             },
             {
                 "path": "/examples/performance/src/jsMain/resources/index.html",

--- a/examples/remote/src/jsMain/resources/index.html
+++ b/examples/remote/src/jsMain/resources/index.html
@@ -43,9 +43,9 @@
         "ref": "master",
         "embed": [
             {
-                "path": "/examples/remote/src/jsMain/kotlin/dev/fritz2/examples/remote/remote.kt",
+                "path": "/examples/remote/src/jsMain/kotlin/dev/fritz2/examples/remote/Remote.kt",
                 "type": "kotlin",
-                "label": "remote.kt"
+                "label": "Remote.kt"
             },
             {
                 "path": "/examples/remote/src/jsMain/resources/index.html",

--- a/examples/routing/src/jsMain/resources/index.html
+++ b/examples/routing/src/jsMain/resources/index.html
@@ -43,9 +43,9 @@
         "ref": "master",
         "embed": [
             {
-                "path": "/examples/routing/src/jsMain/kotlin/dev/fritz2/examples/routing/routing.kt",
+                "path": "/examples/routing/src/jsMain/kotlin/dev/fritz2/examples/routing/Routing.kt",
                 "type": "kotlin",
-                "label": "routing.kt"
+                "label": "Routing.kt"
             },
             {
                 "path": "/examples/routing/src/jsMain/resources/index.html",

--- a/examples/tictactoe/src/jsMain/resources/index.html
+++ b/examples/tictactoe/src/jsMain/resources/index.html
@@ -39,19 +39,19 @@
         "ref": "master",
         "embed": [
             {
-                "path": "/examples/tictactoe/src/jsMain/kotlin/dev/fritz2/examples/tictactoe/tictactoe.kt",
+                "path": "/examples/tictactoe/src/jsMain/kotlin/dev/fritz2/examples/tictactoe/TicTacToe.kt",
                 "type": "kotlin",
-                "label": "tictactoe.kt"
+                "label": "TicTacToe.kt"
             },
             {
-                "path": "/examples/tictactoe/src/commonMain/kotlin/dev/fritz2/examples/tictactoe/model.kt",
+                "path": "/examples/tictactoe/src/commonMain/kotlin/dev/fritz2/examples/tictactoe/Model.kt",
                 "type": "kotlin",
-                "label": "model.kt"
+                "label": "Model.kt"
             },
             {
-                "path": "/examples/tictactoe/src/commonMain/kotlin/dev/fritz2/examples/tictactoe/logic.kt",
+                "path": "/examples/tictactoe/src/commonMain/kotlin/dev/fritz2/examples/tictactoe/Logic.kt",
                 "type": "kotlin",
-                "label": "logic.kt"
+                "label": "Logic.kt"
             },
             {
                 "path": "/examples/tictactoe/src/jsMain/resources/index.html",

--- a/examples/validation/src/jsMain/resources/index.html
+++ b/examples/validation/src/jsMain/resources/index.html
@@ -51,19 +51,19 @@
         "ref": "master",
         "embed": [
             {
-                "path": "/examples/validation/src/jsMain/kotlin/dev/fritz2/examples/validation/validation.kt",
+                "path": "/examples/validation/src/jsMain/kotlin/dev/fritz2/examples/validation/Validation.kt",
                 "type": "kotlin",
-                "label": "validation.kt",
+                "label": "Validation.kt",
             },
             {
-                "path": "/examples/validation/src/commonMain/kotlin/dev/fritz2/examples/validation/model.kt",
+                "path": "/examples/validation/src/commonMain/kotlin/dev/fritz2/examples/validation/Model.kt",
                 "type": "kotlin",
-                "label": "model.kt"
+                "label": "Model.kt"
             },
             {
-                "path": "/examples/validation/src/commonMain/kotlin/dev/fritz2/examples/validation/validator.kt",
+                "path": "/examples/validation/src/commonMain/kotlin/dev/fritz2/examples/validation/Validator.kt",
                 "type": "kotlin",
-                "label": "validator.kt"
+                "label": "Validator.kt"
             },
             {
                 "path": "/examples/validation/src/jsMain/resources/index.html",

--- a/examples/webcomponent/src/jsMain/resources/index.html
+++ b/examples/webcomponent/src/jsMain/resources/index.html
@@ -45,9 +45,9 @@
         "ref": "master",
         "embed": [
             {
-                "path": "/examples/webcomponent/src/jsMain/kotlin/dev/fritz2/examples/webcomponent/webcomponent.kt",
+                "path": "/examples/webcomponent/src/jsMain/kotlin/dev/fritz2/examples/webcomponent/WebComponent.kt",
                 "type": "kotlin",
-                "label": "webcomponent.kt"
+                "label": "WebComponent.kt"
             },
             {
                 "path": "/examples/webcomponent/src/jsMain/resources/index.html",

--- a/www/src/_data/examples.json
+++ b/www/src/_data/examples.json
@@ -1,72 +1,56 @@
-{
-  "internal": [
-    {
-      "title": "Getting Started",
-      "description": "Create HTML, handle events, and bind data the fritz2 way.",
-      "route":"/gettingstarted",
-      "icon": "trending-up"
-    },
-    {
-      "title": "Nested Model",
-      "description": "Data binding of elements in deep nested models and lists is easy as pie in fritz2. See how to do so using lenses.",
-      "route": "/nestedmodel",
-      "icon": "collection"
-    },
-    {
-      "title": "Validation",
-      "description": "Include reusable validation in your stores and show the results - at your form elements for example.",
-      "route": "/validation",
-      "icon": "light-bulb"
-    },
-    {
-      "title": "Routing",
-      "description": "Create routing through your single-page-app and handle parameters (deep links).",
-      "route": "/routing",
-      "icon": "map"
-    },
-    {
-      "title": "Remote",
-      "description": "Wraps the browser's api to asynchronously communicate with your backend in a more Kotlin-like way.",
-      "route": "/remote",
-      "icon": "cloud-upload"
-    },
-    {
-      "title": "Master Detail",
-      "description": "Use the master detail pattern to separate the details section from the collection view. Includes undo and spinner.",
-      "route": "/masterdetail",
-      "icon": "archive"
-    },
-    {
-      "title": "WebComponent",
-      "description": "Build WebComponents with fritz2 or use WebComponents provided by others in your projects.",
-      "route": "/webcomponent",
-      "icon": "puzzle"
-    },
-    {
-      "title": "Todo MVC",
-      "description": "Our implementation of the TodoMVC specification. Compare fritz2 with react, vue.js, etc.",
-      "route": "/todomvc",
-      "icon": "clipboard-list"
-    },
-    {
-      "title": "Tic-Tac-Toe",
-      "description": "Demonstrates the combination of UI, logic, and state with fritz2.",
-      "route": "/tictactoe",
-      "icon": "view-grid"
-    }
-  ],
-  "external": [
-    {
-      "title": "Spring TodoMVC",
-      "description": "TodoMVC fullstack web-application built with Spring backend.",
-      "route":"https://github.com/jamowei/fritz2-spring-todomvc",
-      "icon": "globe"
-    },
-    {
-      "title": "Ktor TodoMVC",
-      "description": "TodoMVC fullstack web-application built with Ktor backend.",
-      "route":"https://github.com/jamowei/fritz2-ktor-todomvc",
-      "icon": "globe"
-    }
-  ]
-}
+[
+  {
+    "title": "Getting Started",
+    "description": "Create HTML, handle events, and bind data the fritz2 way.",
+    "route":"/gettingstarted",
+    "icon": "trending-up"
+  },
+  {
+    "title": "Nested Model",
+    "description": "Data binding of elements in deep nested models and lists is easy as pie in fritz2. See how to do so using lenses.",
+    "route": "/nestedmodel",
+    "icon": "collection"
+  },
+  {
+    "title": "Validation",
+    "description": "Include reusable validation in your stores and show the results - at your form elements for example.",
+    "route": "/validation",
+    "icon": "light-bulb"
+  },
+  {
+    "title": "Routing",
+    "description": "Create routing through your single-page-app and handle parameters (deep links).",
+    "route": "/routing",
+    "icon": "map"
+  },
+  {
+    "title": "Remote",
+    "description": "Wraps the browser's api to asynchronously communicate with your backend in a more Kotlin-like way.",
+    "route": "/remote",
+    "icon": "cloud-upload"
+  },
+  {
+    "title": "Master Detail",
+    "description": "Use the master detail pattern to separate the details section from the collection view. Includes undo and spinner.",
+    "route": "/masterdetail",
+    "icon": "archive"
+  },
+  {
+    "title": "WebComponent",
+    "description": "Build WebComponents with fritz2 or use WebComponents provided by others in your projects.",
+    "route": "/webcomponent",
+    "icon": "puzzle"
+  },
+  {
+    "title": "Todo MVC",
+    "description": "Our implementation of the TodoMVC specification. Compare fritz2 with react, vue.js, etc.",
+    "route": "/todomvc",
+    "icon": "clipboard-list"
+  },
+  {
+    "title": "Tic-Tac-Toe",
+    "description": "Demonstrates the combination of UI, logic, and state with fritz2.",
+    "route": "/tictactoe",
+    "icon": "view-grid"
+  }
+]

--- a/www/src/pages/examples.njk
+++ b/www/src/pages/examples.njk
@@ -14,7 +14,7 @@ eleventyNavigation:
 <div class="text-center px-4 sm:px-6 lg:px-8 py-12 grow overflow-y-auto overscroll-none">
     <div class="mx-auto max-w-md sm:max-w-3xl lg:max-w-7xl">
         <div class="grid grid-cols-1 gap-12 sm:grid-cols-2 lg:grid-cols-3">
-        {% for example in examples.internal %}
+        {% for example in examples %}
             <a href="/examples{{ example.route }}" target="_blank" class="pt-6 bg-gray-800 hover:bg-gray-700 rounded-lg">
                 <div class="flow-root px-6 pb-8">
                     <div class="-mt-10">
@@ -33,27 +33,6 @@ eleventyNavigation:
                 </div>
             </a>
         {% endfor %}
-        </div>
-        <div class="mt-12 grid grid-cols-1 gap-8 sm:grid-cols-2 lg:grid-cols-3">
-            {% for example in examples.external %}
-                <a href="{{ example.route }}" target="_blank" class="pt-6  bg-gray-800 hover:bg-gray-700 rounded-lg">
-                    <div class="flow-root px-6 pb-8">
-                        <div class="-mt-10">
-                            <div>
-                              <span class="inline-flex items-center justify-center p-3 bg-gradient-to-r from-bg-start to-bg-end rounded-md shadow-lg">
-                                <span class="h-6 w-6 text-white">
-                                    {% heroicon "outline", example.icon %}
-                                </span>
-                              </span>
-                            </div>
-                            <h3 class="mt-5 text-lg font-medium text-white tracking-tight">{{ example.title }}</h3>
-                            <p class="mt-5 text-base text-gray-400">
-                                {{ example.description }}
-                            </p>
-                        </div>
-                    </div>
-                </a>
-            {% endfor %}
         </div>
     </div>
 </div>


### PR DESCRIPTION
This PR removes the Spring TodoMVC and Ktor TodoMVC examples as they are severely outdated. As their code is hosted in separate repos and should no longer be used as a reference for newcomers we decided to remove them.

Additionally, this PR fixes the embedded GitHub links used in the examples pages as they are still referencing old files from before #860.