### PR TITLE
Simply the combobox's internal state handling of the open-state

### DIFF
--- a/headless-demo/src/jsMain/kotlin/dev/fritz2/headlessdemo/App.kt
+++ b/headless-demo/src/jsMain/kotlin/dev/fritz2/headlessdemo/App.kt
@@ -50,6 +50,7 @@ val pages: Map<String, Page> = mapOf(
             | robust support for keyboard naigation.""".trimMargin(),
         RenderContext::comboboxDemo
     ),
+    "comboboxTestdrive" to TestDrive(RenderContext::comboboxTestdrive),
     "menu" to DemoPage(
         "Headless Menu",
         """Menus offer an easy way to build custom, accessible dropdown components with robust support for keyboard

--- a/headless-demo/src/jsMain/kotlin/dev/fritz2/headlessdemo/components/Combobox.kt
+++ b/headless-demo/src/jsMain/kotlin/dev/fritz2/headlessdemo/components/Combobox.kt
@@ -4,8 +4,136 @@ import dev.fritz2.core.*
 import dev.fritz2.headless.components.combobox
 import dev.fritz2.headless.foundation.utils.floatingui.core.middleware.offset
 import dev.fritz2.headlessdemo.result
-import kotlinx.coroutines.flow.combine
-import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.*
+import org.w3c.dom.HTMLButtonElement
+
+
+private fun RenderContext.renderCombobox(
+    store: Store<Country?>,
+    autoSelect: Boolean = false,
+    lazy: Boolean = false,
+    readOnly: Flow<Boolean> = flowOf(false),
+    id: String? = null,
+): Flow<Boolean> {
+    lateinit var openState: Flow<Boolean>
+
+    combobox<Country>(id = id) {
+        items(COUNTRY_LIST)
+        itemFormat = Country::name
+        value(store)
+        filterBy(Country::name)
+
+        if (autoSelect) selectionStrategy.autoSelectMatch()
+        else selectionStrategy.manual()
+
+        if (lazy) openDropdown.lazily()
+        else openDropdown.eagerly()
+
+        maximumDisplayedItems = 20
+
+        openState = opened
+
+        comboboxLabel("sr-only") {
+            +"Select a Country"
+        }
+
+        comboboxPanelReference(
+            joinClasses(
+                "w-full py-2.5 px-4 flex items-center bg-white rounded border border-primary-600",
+                "cursor-default font-sans text-sm text-left text-primary-800 hover:border-primary-800",
+                "focus-within:outline-none focus-within:ring-4 focus-within:ring-primary-600",
+                "focus-within:border-primary-800"
+            ),
+        ) {
+            comboboxInput(
+                joinClasses(
+                    "w-full block flex-grow bg-transparent border-0 outline-0 placeholder-gray-700",
+                    "vui-label-4 p-0 focus:ring-transparent focus:shadow-none disabled:text-gray-400",
+                    "text-ellipsis",
+                ),
+            ) {
+                readOnly(readOnly)
+                placeholder("Country")
+            }
+
+            icon("pl-2w-5 h-5", content = HeroIcons.selector).clicks handledBy open
+        }
+
+        comboboxValidationMessages {
+            ul("list-disc list-inside") {
+                msgs.render(into = this) { messages ->
+                    messages.forEach { message ->
+                        li {
+                            +"(${message.severity}) ${message.message}"
+                        }
+                    }
+                }
+            }
+        }
+
+        comboboxItems(
+            joinClasses(
+                "max-h-60 py-1 overflow-auto origin-top z-30 bg-white rounded shadow-md divide-y divide-gray-100",
+                "ring-1 ring-primary-600 ring-opacity-5 focus:outline-none"
+            )
+        ) {
+            addMiddleware(offset(5))
+
+            transition(
+                opened,
+                enter = "transition duration-100 ease-out",
+                enterStart = "opacity-0 scale-95",
+                enterEnd = "opacity-100 scale-100",
+                leave = "transition duration-100 ease-in",
+                leaveStart = "opacity-100 scale-100",
+                leaveEnd = "opacity-0 scale-95"
+            )
+
+            results.render(into = this) { (query, results, truncated) ->
+                if (results.isEmpty()) {
+                    p("px-4 py-2 text-gray-400") {
+                        +"No results found"
+                    }
+                } else {
+                    results.forEach { item ->
+                        comboboxItem(
+                            item,
+                            "w-full relative py-2 pl-10 pr-4 cursor-default select-none disabled:opacity-50 text-sm"
+                        ) {
+                            className(active.map { active ->
+                                if (active) "bg-primary-600 text-white"
+                                else "text-primary-800"
+                            })
+
+                            highlightedText(item.value.name, query).run {
+                                className(selected.map {
+                                    if (it) "font-semibold"
+                                    else "font-normal"
+                                })
+                            }
+
+                            selected.render {
+                                if (it) {
+                                    span("absolute left-0 inset-y-0 flex items-center pl-3") {
+                                        icon("w-5 h-5", content = HeroIcons.check)
+                                    }
+                                }
+                            }
+                        }
+                    }
+                    if (truncated) {
+                        div("py-2 pl-10 pr-4 text-sm text-gray-400") {
+                            +"Refine your query for more results"
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    return openState
+}
+
 
 fun RenderContext.comboboxDemo() {
     val selectionStore = storeOf<Country?>(null)
@@ -21,132 +149,7 @@ fun RenderContext.comboboxDemo() {
             openDropdownLazilyStore.data,
             ::Pair
         ).render { (autoSelectMatch, openDropdownLazily) ->
-            combobox<Country>(id = "countries") {
-                items(COUNTRY_LIST)
-                itemFormat = Country::name
-                value(selectionStore)
-                filterBy(Country::name)
-
-                if (autoSelectMatch) selectionStrategy.autoSelectMatch()
-                else selectionStrategy.manual()
-
-                if (openDropdownLazily) openDropdown.lazily()
-                else openDropdown.eagerly()
-
-                maximumDisplayedItems = 20
-
-                comboboxLabel("sr-only") {
-                    +"Select a Country"
-                }
-
-                comboboxPanelReference(
-                    joinClasses(
-                        "w-full py-2.5 px-4 flex items-center bg-white rounded border border-primary-600",
-                        "cursor-default font-sans text-sm text-left text-primary-800 hover:border-primary-800",
-                        "focus-within:outline-none focus-within:ring-4 focus-within:ring-primary-600",
-                        "focus-within:border-primary-800"
-                    ),
-                ) {
-                    comboboxInput(
-                        joinClasses(
-                            "w-full block flex-grow bg-transparent border-0 outline-0 placeholder-gray-700",
-                            "vui-label-4 p-0 focus:ring-transparent focus:shadow-none disabled:text-gray-400",
-                            "text-ellipsis",
-                        ),
-                    ) {
-                        readOnly(readOnlyStore.data)
-                        placeholder("Country")
-                    }
-
-                    icon("pl-2w-5 h-5", content = HeroIcons.selector).clicks handledBy open
-                }
-
-                comboboxValidationMessages {
-                    ul("list-disc list-inside") {
-                        msgs.render(into = this) { messages ->
-                            messages.forEach { message ->
-                                li {
-                                    +"(${message.severity}) ${message.message}"
-                                }
-                            }
-                        }
-                    }
-                }
-
-                comboboxItems(
-                    joinClasses(
-                        "max-h-60 py-1 overflow-auto origin-top z-30 bg-white rounded shadow-md divide-y divide-gray-100",
-                        "ring-1 ring-primary-600 ring-opacity-5 focus:outline-none"
-                    )
-                ) {
-                    addMiddleware(offset(5))
-
-                    transition(
-                        opened,
-                        enter = "transition duration-100 ease-out",
-                        enterStart = "opacity-0 scale-95",
-                        enterEnd = "opacity-100 scale-100",
-                        leave = "transition duration-100 ease-in",
-                        leaveStart = "opacity-100 scale-100",
-                        leaveEnd = "opacity-0 scale-95"
-                    )
-
-                    results.render(into = this) { (query, results, truncated) ->
-                        if (results.isEmpty()) {
-                            p("px-4 py-2 text-gray-400") {
-                                +"No results found"
-                            }
-                        } else {
-                            results.forEach { item ->
-                                comboboxItem(
-                                    item,
-                                    "w-full relative py-2 pl-10 pr-4 cursor-default select-none disabled:opacity-50 text-sm"
-                                ) {
-                                    className(active.map { active->
-                                        if (active) "bg-primary-600 text-white"
-                                        else "text-primary-800"
-                                    })
-
-                                    highlightedText(item.value.name, query).run {
-                                        className(selected.map {
-                                            if (it) "font-semibold"
-                                            else "font-normal"
-                                        })
-                                    }
-
-                                    selected.render {
-                                        if (it) {
-                                            span("absolute left-0 inset-y-0 flex items-center pl-3") {
-                                                icon("w-5 h-5", content = HeroIcons.check)
-                                            }
-                                        }
-                                    }
-                                }
-                            }
-                            if (truncated) {
-                                div("py-2 pl-10 pr-4 text-sm text-gray-400") {
-                                    +"Refine your query for more results"
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        }
-
-        div("space-y-2") {
-            p("text-sm text-primary-800") {
-                +"Select via data-binding:"
-            }
-            div("flex flex-wrap gap-2") {
-                buildList {
-                    add(null)
-                    addAll(COUNTRY_LIST.take(2))
-                    addAll(COUNTRY_LIST.takeLast(2))
-                }.forEachIndexed { index, country ->
-                    quickSelectButton(country, selectionStore, id = "btn-select-$index")
-                }
-            }
+            renderCombobox(selectionStore, autoSelectMatch, openDropdownLazily, readOnlyStore.data)
         }
 
         checkbox("Read-only", readOnlyStore, "checkbox-enable-readonly")
@@ -164,6 +167,135 @@ fun RenderContext.comboboxDemo() {
     }
 }
 
+fun RenderContext.comboboxTestdrive() {
+    div("space-y-4") {
+        demoCard("Base Testdrive") {
+            val testId = "countries"
+
+            val selectionStore = storeOf<Country?>(null)
+
+            val configurationStore = storeOf(ComboboxDemoConfig())
+            val readOnlyStore = configurationStore.map(ComboboxDemoConfig.readOnly())
+            val autoSelectMatchStore = configurationStore.map(ComboboxDemoConfig.autoSelectMatch())
+            val openDropdownLazilyStore = configurationStore.map(ComboboxDemoConfig.openDropdownLazily())
+
+            val openingCount = storeOf(0)
+
+            div("space-y-4") {
+                combine(
+                    autoSelectMatchStore.data,
+                    openDropdownLazilyStore.data,
+                    ::Pair
+                ).render { (autoSelectMatch, openDropdownLazily) ->
+                    val opened = renderCombobox(
+                        selectionStore,
+                        autoSelectMatch,
+                        openDropdownLazily,
+                        readOnlyStore.data,
+                        testId,
+                    )
+                    opened.filter { it }.map { openingCount.current + 1 } handledBy openingCount.update
+                }
+
+                div("space-y-2") {
+                    p("text-sm text-primary-800") {
+                        +"Select via data-binding:"
+                    }
+                    div("flex flex-wrap gap-2") {
+                        buildList {
+                            add(null)
+                            addAll(COUNTRY_LIST.take(2))
+                            addAll(COUNTRY_LIST.takeLast(2))
+                        }.forEachIndexed { index, country ->
+                            quickSelectButton(country, selectionStore, id = "btn-select-$index")
+                        }
+                    }
+                }
+
+                checkbox("Read-only", readOnlyStore, "checkbox-enable-readonly")
+                checkbox("Auto-select exact matches (try 'oman')", autoSelectMatchStore, "checkbox-enable-autoselect")
+                checkbox("Open dropdown lazily", openDropdownLazilyStore, "checkbox-enable-lazy-opening")
+
+                result {
+                    p {
+                        span("font-semibold") { +"Opening count: " }
+                        span(id = "countries-opening-count") {
+                            openingCount.data.renderText(into = this)
+                        }
+                    }
+                }
+
+                result {
+                    p {
+                        span("font-semibold") { +"Selected: " }
+                        span(id = "$testId-selection") {
+                            selectionStore.data.renderText(into = this)
+                        }
+                    }
+                }
+            }
+        }
+        demoCard("With null-enabling Lens") {
+            val testId = "countries-null-enabling-lens"
+
+            val nullReplacement = Country("", "Unbekannt")
+            val store = storeOf(nullReplacement)
+            val nullableStore = store.map(
+                lensOf<Country, Country?>(
+                    id = "",
+                    getter = { if (it == nullReplacement) null else it },
+                    setter = { _, v -> v ?: nullReplacement }
+                )
+            )
+
+            val opened: Flow<Boolean> = renderCombobox(nullableStore, id = testId)
+            val openingCount = storeOf(0)
+            opened.filter { it }.map { openingCount.current + 1 } handledBy openingCount.update
+
+            demoButton("Reset").clicks.map { null } handledBy nullableStore.update
+
+            result {
+                p {
+                    span("font-semibold") { +"Opening count: " }
+                    span(id = "$testId-opening-count") {
+                        openingCount.data.renderText(into = this)
+                    }
+                }
+            }
+
+            result {
+                p {
+                    span("font-semibold") { +"Actual Store: " }
+                    span(id = "$testId-selection") {
+                        store.data.renderText(into = this)
+                    }
+                }
+            }
+
+            result {
+                p {
+                    span("font-semibold") { +"Mapped nullable Store: " }
+                    span(id = "$testId-selection") {
+                        nullableStore.data.renderText(into = this)
+                    }
+                }
+            }
+        }
+    }
+}
+
+
+private fun RenderContext.demoCard(title: String, content: RenderContext.() -> Unit) {
+    div("p-4 space-y-4 bg-primary-100 rounded border shadow") {
+        h2("font-semibold") {
+            +title
+        }
+        div("max-w-96 space-y-4") {
+            content()
+        }
+    }
+}
+
 private fun RenderContext.highlightedText(text: String, highlight: String) =
     span {
         val split = text.split(Regex("(?<=($highlight))|(?=($highlight))", RegexOption.IGNORE_CASE))
@@ -174,14 +306,17 @@ private fun RenderContext.highlightedText(text: String, highlight: String) =
         }
     }
 
-private fun RenderContext.quickSelectButton(country: Country?, store: Store<Country?>, id: String? = null) {
+private fun RenderContext.demoButton(text: String, id: String? = null): Tag<HTMLButtonElement> =
     button(
         "p-2 bg-primary-500 hover:bg-primary-600 shadow rounded text-sm text-primary-900",
         id
     ) {
         type("button")
-        +(country?.name ?: "Nothing")
-    }.clicks.map { country } handledBy store.update
+        +text
+    }
+
+private fun RenderContext.quickSelectButton(country: Country?, store: Store<Country?>, id: String? = null) {
+    demoButton(country?.name ?: "Nothing", id).clicks.map { country } handledBy store.update
 }
 
 private fun RenderContext.checkbox(text: String, value: Store<Boolean>, testId: String) {

--- a/headless-demo/tests/components/combobox.spec.ts
+++ b/headless-demo/tests/components/combobox.spec.ts
@@ -2,15 +2,15 @@ import { expect, Locator, Page, test } from "@playwright/test";
 
 
 test.beforeEach(async ({ page }) => {
-    await page.goto("#combobox");
+    await page.goto("#comboboxTestdrive");
     await expect(page.locator("#portal-root")).toBeAttached();
     await page.waitForTimeout(200);
 });
 
 
-async function createLocators(page: Page): Promise<[Locator, Locator]> {
-    const btn = page.locator("#countries-input")
-    const listBoxItems = page.locator("#countries-items")
+async function createLocators(testId: string, page: Page): Promise<[Locator, Locator]> {
+    const btn = page.locator(`#${testId}-input`)
+    const listBoxItems = page.locator(`#${testId}-items`)
     return [btn, listBoxItems]
 }
 
@@ -68,7 +68,7 @@ const openCloseArgs = [
 
 
 test("Dropdown is initially closed", async ({ page }) => {
-    const [input, items] = await createLocators(page);
+    const [input, items] = await createLocators("countries", page);
     await assertIsClosed(input, items);
 });
 
@@ -78,7 +78,7 @@ test.describe("Trying to open and close a combobox", () => {
     test.describe("with the dropdown opening eagerly", () => {
         for (const { desc, open, close } of openCloseArgs) {
             test(`by ${desc} opens and closes the dropdown`, async ({ page }) => {
-                const [input, items] = await createLocators(page);
+                const [input, items] = await createLocators("countries", page);
 
                 await open(page);
                 await assertIsOpen(input, items);
@@ -93,7 +93,7 @@ test.describe("Trying to open and close a combobox", () => {
 
         for (const { desc, open, close } of openCloseArgs) {
             test(`by ${desc} does not open the dropdown`, async ({ page }) => {
-                const [input, items] = await createLocators(page);
+                const [input, items] = await createLocators("countries", page);
 
                 await page.locator("#checkbox-enable-lazy-opening").check();
 
@@ -106,7 +106,7 @@ test.describe("Trying to open and close a combobox", () => {
         }
 
         test("by typing a query opens the dropdown", async ({ page }) => {
-            const [input, items] = await createLocators(page);
+            const [input, items] = await createLocators("countries", page);
 
             await page.locator("#checkbox-enable-lazy-opening").check();
 
@@ -123,7 +123,7 @@ test.describe("Entering an leaving the input", () => {
 
     for (const { desc, open, close } of openCloseArgs) {
         test(`by ${desc} resets the input`, async ({ page }) => {
-            const [input, items] = await createLocators(page);
+            const [input, items] = await createLocators("countries", page);
 
             await open(page);
 
@@ -137,7 +137,7 @@ test.describe("Entering an leaving the input", () => {
 });
 
 test("With a default value of 'null', the input is empty", async ({ page }) => {
-    const [input, _] = await createLocators(page);
+    const [input, _] = await createLocators("countries", page);
 
     const selection = page.locator("#countries-selection");
     await expect(selection).toContainText("null");
@@ -148,7 +148,7 @@ test("With a default value of 'null', the input is empty", async ({ page }) => {
 test.describe("When updating the value via the data-binding", () => {
 
     test("non-null values are reflected in the input element", async ({ page }) => {
-        const [input, _] = await createLocators(page);
+        const [input, _] = await createLocators("countries", page);
 
         const selection = page.locator("#countries-selection");
         await expect(selection).toContainText("null");
@@ -162,7 +162,7 @@ test.describe("When updating the value via the data-binding", () => {
     });
 
     test("null values are reflected in the input element", async ({ page }) => {
-        const [input, _] = await createLocators(page);
+        const [input, _] = await createLocators("countries", page);
 
         const selectionButton = await page.locator('#btn-select-2');
         await selectionButton.click();
@@ -189,7 +189,7 @@ test.describe("When the input is read-only", () => {
         },
     ]) {
         test(desc, async ({ page }) => {
-            const [input, items] = await createLocators(page);
+            const [input, items] = await createLocators("countries", page);
 
             await page.locator('#checkbox-enable-readonly').check();
 
@@ -212,7 +212,7 @@ test.describe("Activating an item", () => {
         },
     ]) {
         test(`${desc} sets 'aria-activedescendant'`, async ({ page }) => {
-            const [input, items] = await createLocators(page);
+            const [input, items] = await createLocators("countries", page);
             await input.click();
 
             await expect(items).not.toHaveAttribute("aria-activedescendant");
@@ -227,7 +227,7 @@ test.describe("Activating an item", () => {
 });
 
 test("Changing the active item updates 'aria-activedescendant'", async ({ page }) => {
-    const [input, items] = await createLocators(page);
+    const [input, items] = await createLocators("countries", page);
     await input.click();
 
     await expect(items).not.toHaveAttribute("aria-activedescendant");
@@ -252,7 +252,7 @@ test.describe("When activating an item via keyboard", () => {
         { key: "End", index: 19 }
     ]) {
         test(`'pressing ${{ key }}' jumps to the ${index}th item`, async ({ page }) => {
-            const [input, items] = await createLocators(page);
+            const [input, items] = await createLocators("countries", page);
             await input.click();
 
             const item = page.locator("#countries-item-0");
@@ -268,7 +268,7 @@ test.describe("When activating an item via keyboard", () => {
         { setupKey: "End", testKey: "ArrowDown", index: 19, indexName: "last" }
     ]) {
         test(`'pressing ${testKey}' on the ${indexName} item does nothing`, async ({ page }) => {
-            const [input, items] = await createLocators(page);
+            const [input, items] = await createLocators("countries", page);
             await input.click();
 
             await expect(page.locator("#countries-item-0")).toBeVisible();
@@ -285,7 +285,7 @@ test.describe("When activating an item via keyboard", () => {
 test.describe("Select an item", () => {
 
     test("by clicking on it", async ({ page }) => {
-        const [input, items] = await createLocators(page);
+        const [input, items] = await createLocators("countries", page);
         const selection = page.locator("#countries-selection");
 
         await expect(selection).toContainText("null");
@@ -300,7 +300,7 @@ test.describe("Select an item", () => {
     });
 
     test("by activating it via the keyboard and pressing Enter", async ({ page }) => {
-        const [input, items] = await createLocators(page);
+        const [input, items] = await createLocators("countries", page);
         const selection = page.locator("#countries-selection");
 
         await expect(selection).toContainText("null");
@@ -321,7 +321,7 @@ test.describe("Select an item", () => {
 test.describe("When typing a query", () => {
 
     test("the result dropdown is updated", async ({ page }) => {
-        const [input, items] = await createLocators(page);
+        const [input, items] = await createLocators("countries", page);
 
         await input.click();
         await expect(page.locator("#countries-item-0")).toBeVisible();
@@ -337,7 +337,7 @@ test.describe("When typing a query", () => {
     });
 
     test("closing the dropdown resets the input field", async ({ page }) => {
-        const [input, items] = await createLocators(page);
+        const [input, items] = await createLocators("countries", page);
 
         await input.click();
         await expect(page.locator("#countries-item-0")).toBeVisible();
@@ -351,7 +351,7 @@ test.describe("When typing a query", () => {
     });
 
     test("by default, exact matches are not auto-selected", async ({ page }) => {
-        const [input, items] = await createLocators(page);
+        const [input, items] = await createLocators("countries", page);
 
         await input.click();
         await expect(page.locator("#countries-item-0")).toBeVisible();
@@ -365,7 +365,7 @@ test.describe("When typing a query", () => {
     });
 
     test("exact matches are auto-selected if configured", async ({ page }) => {
-        const [input, items] = await createLocators(page);
+        const [input, items] = await createLocators("countries", page);
 
         await page.locator("#checkbox-enable-autoselect").check();
 
@@ -380,7 +380,7 @@ test.describe("When typing a query", () => {
     });
 
     test("in lazy dropdown opening mode, the dropdown is first hidden and then opened", async ({ page }) => {
-        const [input, items] = await createLocators(page);
+        const [input, items] = await createLocators("countries", page);
 
         await page.locator("#checkbox-enable-lazy-opening").check();
 
@@ -407,7 +407,7 @@ test.describe("When typing a query", () => {
  * Keyboard selections should not be possible when the dropdown is closed.
  */
 test("Keyboard selection in lazy mode does nothing when the dropdown is closed", async ({ page }) => {
-    const [input, items] = await createLocators(page);
+    const [input, items] = await createLocators("countries", page);
 
     await page.locator("#checkbox-enable-lazy-opening").check();
 
@@ -431,4 +431,33 @@ test("Keyboard selection in lazy mode does nothing when the dropdown is closed",
 
     await expect(input).toBeEmpty();
     await expect(page.locator("#countries-selection")).toContainText("null");
+});
+
+test.describe("Selecting an item via mouse twice does not result in looping", () => {
+
+    for (const { testId, desc } of [
+        { testId: "countries", desc: "when using a regular store" },
+        { testId: "countries-null-enabling-lens", desc: "when using a non-nullable Store with a null-enabling lens" }
+    ]) {
+        test(desc, async ({ page }) => {
+            const [input, items] = await createLocators(testId, page);
+
+            const openingCount = page.locator(`#${testId}-opening-count`);
+            await expect(openingCount).toHaveText("0");
+
+            await input.click();
+            await expect(items).toBeVisible();
+            await expect(openingCount).toHaveText("1");
+
+            const firstItem = page.locator(`#${testId}-item-0`);
+            await expect(firstItem).toBeVisible();
+            await firstItem.click();
+
+            // Using timeout is okay here as the test needs to check the number of times the dropdown has been opened 
+            // after a given amount of time (similar to debouncing). Since the issue that is reproduced is typically 
+            // based on race conditions, there is no other way to check.
+            await page.waitForTimeout(2000);
+            await expect(openingCount).toHaveText("1");
+        });
+    }
 });

--- a/headless/src/jsMain/kotlin/dev/fritz2/headless/components/Combobox.kt
+++ b/headless/src/jsMain/kotlin/dev/fritz2/headless/components/Combobox.kt
@@ -248,8 +248,16 @@ class Combobox<E : HTMLElement, T>(tag: Tag<E>, id: String?) : Tag<E> by tag, Op
 
     inner class SelectionStrategyProperty : Property<(String, Sequence<T>) -> QueryResult<T>>() {
 
-        private fun isExactMatch(item: T, query: String) =
-            itemFormat(item).contentEquals(query, ignoreCase = true)
+        /**
+         * Returns `true` if the given [item] produces an _exact match_.
+         *
+         * An item is an exact match iff its formatted value is the same as the provided [query].
+         * Empty formatted values are not considered exact matches regardless whether they are matches or not.
+         */
+        private fun isExactMatch(item: T, query: String): Boolean {
+            val formatted = itemFormat(item)
+            return formatted.isNotEmpty() && formatted.contentEquals(query, ignoreCase = true)
+        }
 
         /**
          * Helper function taking [n] elements from a [Sequence] and storing them in a [List].

--- a/headless/src/jsMain/kotlin/dev/fritz2/headless/components/Combobox.kt
+++ b/headless/src/jsMain/kotlin/dev/fritz2/headless/components/Combobox.kt
@@ -208,9 +208,7 @@ class Combobox<E : HTMLElement, T>(tag: Tag<E>, id: String?) : Tag<E> by tag, Op
     inner class DropdownOpeningHook : Hook<Tag<HTMLInputElement>, Unit, Unit>() {
 
         private val openOnFocus: Effect<Tag<HTMLInputElement>, Unit, Unit> = { _, _ ->
-            // TODO Open on focus when focus is obtained non-programmatically
-            //  (previous implementation results in infinite open-close loop)
-            focuss.filterNot { domNode.readOnly } handledBy open
+            merge(focuss, selects).filterNot { domNode.readOnly } handledBy open
         }
 
         init {

--- a/headless/src/jsMain/kotlin/dev/fritz2/headless/components/Combobox.kt
+++ b/headless/src/jsMain/kotlin/dev/fritz2/headless/components/Combobox.kt
@@ -6,7 +6,9 @@ import dev.fritz2.headless.components.Combobox.QueryResult.ItemList
 import dev.fritz2.headless.foundation.*
 import dev.fritz2.headless.foundation.utils.floatingui.utils.PlacementValues
 import dev.fritz2.headless.foundation.utils.scrollintoview.HeadlessScrollOptions
+import kotlinx.browser.window
 import kotlinx.coroutines.FlowPreview
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.*
 import org.w3c.dom.HTMLDivElement
 import org.w3c.dom.HTMLElement
@@ -606,6 +608,10 @@ class Combobox<E : HTMLElement, T>(tag: Tag<E>, id: String?) : Tag<E> by tag, Op
 
         private fun format(value: T?): String = value?.let(itemFormat) ?: ""
 
+        private fun clearSelection() {
+            window.asDynamic().getSelection().empty()
+        }
+
         @OptIn(FlowPreview::class)
         fun render() {
             value(
@@ -630,6 +636,10 @@ class Combobox<E : HTMLElement, T>(tag: Tag<E>, id: String?) : Tag<E> by tag, Op
             focuss.filterNot { domNode.readOnly } handledBy {
                 domNode.select()
             }
+            internalState.select handledBy {
+                clearSelection()
+            }
+
             hook(openDropdown)
 
 


### PR DESCRIPTION
This PR simplifies the combobox's internal state handling in order to fix an issue related to its open-state and make it more robust in general:

- The open state of the combobox is no longer managed inside the component itself but instead fully controlled by the `OpenClose` mixin, making it more robust
- A regression test for an issue resulting in infinite opening and closing of the dropdown is added
- The component demo is restructured to allow more complex testing in the future: It is now split in two parts - the public demo and internal test drives. Some parts of the demo are moved from the public example to the internal testdrive.