### PR TITLE
Fixes a small potential bug on headless switch component

### DIFF
--- a/headless/src/jsMain/kotlin/dev/fritz2/headless/components/Switch.kt
+++ b/headless/src/jsMain/kotlin/dev/fritz2/headless/components/Switch.kt
@@ -35,7 +35,10 @@ abstract class AbstractSwitch<C : HTMLElement>(
         attr(Aria.checked, enabled.asString())
         attr(Aria.invalid, "true".whenever(value.hasError))
         attr("tabindex", "0")
-        value.handler?.invoke(this, clicks.map { !value.data.first() })
+        value.handler?.invoke(this, clicks {
+            stopImmediatePropagation()
+            preventDefault()
+        }.map { !value.data.first() })
         value.handler?.invoke(
             this,
             keydownsIf {


### PR DESCRIPTION
The `click`-event is now correctly handled by stop propagating it and `preventDefault` as the headless component will do all the work.

This could have led to bugs when using the component with explicit `DataBinging`, where the `handler`-lambda would be used to intercept the update call.